### PR TITLE
(Feature) Add transaction menu link to main layout. Fixes #12

### DIFF
--- a/lib/explorer_web/templates/layout/_header.html.eex
+++ b/lib/explorer_web/templates/layout/_header.html.eex
@@ -17,6 +17,10 @@
           <img class="header__link-image" src="<%= static_path(@conn, "/images/block.svg") %>" />
           <div class="header__link-name  header__link-name--blocks"><%= gettext("Blocks") %></div>
         </a>
+        <a href="<%= transaction_path(@conn, :index, Gettext.get_locale) %>" class="header__link">
+          <img class="header__link-image" src="<%= static_path(@conn, "/images/transaction.svg") %>" />
+          <div class="header__link-name  header__link-name--transactions"><%= gettext("Transactions") %></div>
+        </a>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
The transactions link was removed from the main navigation during the production release before EthDenver. I've now added it back in.