### PR TITLE
Format missed files

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -20,7 +20,7 @@
         #
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
-      #
+        #
         included: ["lib/", "src/", "web/", "apps/*/lib/**/*.{ex,exs}"],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
@@ -74,7 +74,6 @@
         #
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
-
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
@@ -92,7 +91,6 @@
         {Credo.Check.Readability.VariableNames},
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SpaceAfterCommas},
-
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.CyclomaticComplexity},
@@ -104,7 +102,6 @@
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.PipeChainStart},
         {Credo.Check.Refactor.UnlessWithElse},
-
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
         {Credo.Check.Warning.IExPry},
@@ -128,7 +125,7 @@
         {Credo.Check.Refactor.AppendSingleItem},
         {Credo.Check.Refactor.VariableRebinding},
         {Credo.Check.Warning.MapGetUnsafePass},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,10 @@
 [
   inputs: [
-    "mix.exs", "{config,lib,test}/**/*.{ex,exs}"
+    ".credo.exs",
+    ".formatter.exs",
+    "apps/*/mix.exs",
+    "apps/*/{config,lib,test}/**/*.{ex,exs}",
+    "mix.exs",
+    "{config}/**/*.{ex,exs}"
   ]
 ]

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -31,7 +31,7 @@ defmodule Explorer.Application do
     import Supervisor.Spec
 
     [
-      supervisor(Explorer.Repo, []),
+      supervisor(Explorer.Repo, [])
     ]
   end
 end

--- a/apps/explorer_web/config/config.exs
+++ b/apps/explorer_web/config/config.exs
@@ -7,8 +7,8 @@ use Mix.Config
 
 # General application configuration
 config :explorer_web,
-       namespace: ExplorerWeb,
-       ecto_repos: [Explorer.Repo]
+  namespace: ExplorerWeb,
+  ecto_repos: [Explorer.Repo]
 
 # Configures gettext
 config :explorer_web, ExplorerWeb.Gettext, locales: ~w(en), default_locale: "en"

--- a/apps/explorer_web/lib/explorer_web/application.ex
+++ b/apps/explorer_web/lib/explorer_web/application.ex
@@ -13,7 +13,7 @@ defmodule ExplorerWeb.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
-      supervisor(Endpoint, []),
+      supervisor(Endpoint, [])
       # Start your own worker by calling: PoaexpWeb.Worker.start_link(arg1, arg2, arg3)
       # worker(PoaexpWeb.Worker, [arg1, arg2, arg3]),
     ]

--- a/apps/explorer_web/test/explorer_web/forms/transaction_form_test.exs
+++ b/apps/explorer_web/test/explorer_web/forms/transaction_form_test.exs
@@ -31,7 +31,8 @@ defmodule Explorer.TransactionFormTest do
       insert(:receipt, status: 1, transaction: transaction)
 
       form =
-        transaction |> Repo.preload([:block, :to_address, :from_address, :receipt])
+        transaction
+        |> Repo.preload([:block, :to_address, :from_address, :receipt])
         |> TransactionForm.build()
 
       formatted_timestamp = block.timestamp |> Timex.format!("%b-%d-%Y %H:%M:%S %p %Z", :strftime)
@@ -82,7 +83,8 @@ defmodule Explorer.TransactionFormTest do
       insert(:receipt, status: 0, gas_used: 100, transaction: transaction)
 
       form =
-        transaction |> Repo.preload([:block, :to_address, :from_address, :receipt])
+        transaction
+        |> Repo.preload([:block, :to_address, :from_address, :receipt])
         |> TransactionForm.build()
 
       formatted_timestamp = block.timestamp |> Timex.format!("%b-%d-%Y %H:%M:%S %p %Z", :strftime)
@@ -133,7 +135,8 @@ defmodule Explorer.TransactionFormTest do
       insert(:receipt, status: 0, gas_used: 555, transaction: transaction)
 
       form =
-        transaction |> Repo.preload([:block, :to_address, :from_address, :receipt])
+        transaction
+        |> Repo.preload([:block, :to_address, :from_address, :receipt])
         |> TransactionForm.build()
 
       formatted_timestamp = block.timestamp |> Timex.format!("%b-%d-%Y %H:%M:%S %p %Z", :strftime)
@@ -293,7 +296,8 @@ defmodule Explorer.TransactionFormTest do
       insert(:receipt, status: 0, gas_used: 555, transaction: transaction)
 
       form =
-        transaction |> Repo.preload([:block, :to_address, :from_address, :receipt])
+        transaction
+        |> Repo.preload([:block, :to_address, :from_address, :receipt])
         |> TransactionForm.build_and_merge()
 
       assert form.hash == "0xkittenpower"


### PR DESCRIPTION
Fixes #92

# Changelog
## Bug Fixes
* Extend formatter inputs to all .ex and .exs files
  * Add root configuration files like `.credo.exs` and `.formatter.exs`.
  * Add `apps` files that were missed in #86.
  *  Format previously missed files