### PR TITLE
Remove transaction hash from detail page

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -54,6 +54,10 @@
             <% end %>
           </dd>
         </div>
+        <div class="transaction__item">
+          <dt class="transaction__item-key"><%= gettext "Nonce" %></dt>
+          <dd class="transaction__item-value"><%= @transaction.nonce %></dd>
+        </div>
       </dl>
     </div>
     <div class="transaction__column">
@@ -77,10 +81,6 @@
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Cumulative Gas Used" %></dt>
           <dd class="transaction__item-value"><%= @transaction.cumulative_gas_used %></dd>
-        </div>
-        <div class="transaction__item">
-          <dt class="transaction__item-key"><%= gettext "Nonce" %></dt>
-          <dd class="transaction__item-value"><%= @transaction.nonce %></dd>
         </div>
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Input" %></dt>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -7,10 +7,6 @@
     <div class="transaction__column">
       <dl>
         <div class="transaction__item">
-          <dt class="transaction__item-key"><%= gettext "Transaction Hash" %></dt>
-          <dd class="transaction__item-value" title="<%= @transaction.hash %>"><%= @transaction.hash %></dd>
-        </div>
-        <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Transaction Status" %></dt>
           <dd class="transaction__item-value transaction__item-value--status">
             <div class="transaction__status">


### PR DESCRIPTION
Resolves #106 

# Changelog
## Enhancements
* Remove duplicate transaction hash from the details page

Before:
![before](https://user-images.githubusercontent.com/966985/38688182-7cd6bf38-3e46-11e8-9281-c6e3e4d89ae0.png)

After:
![after](https://user-images.githubusercontent.com/966985/38700402-ee206c94-3e68-11e8-91a3-e01f04723704.png)
