### PR TITLE
Add missing fields for rates

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/rate.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/rate.ex
@@ -6,19 +6,23 @@ defmodule Explorer.ExchangeRates.Rate do
   @typedoc """
   Represents an exchange rate for a given currency.
 
+  * `:btc_value` - The Bitcoin value of the currency
   * `:id` - ID of a currency
   * `:last_updated` - Timestamp of when the value was last updated
+  * `:market_cap_usd` - Market capitalization of the currency
   * `:name` - Human-readable name of a ticker
   * `:symbol` - Trading symbol used to represent a currency
   * `:usd_value` - The USD value of the currency
   """
   @type t :: %__MODULE__{
+          btc_value: String.t(),
           id: String.t(),
           last_updated: DateTime.t(),
+          market_cap_usd: String.t(),
           name: String.t(),
           symbol: String.t(),
           usd_value: String.t()
         }
 
-  defstruct ~w(id last_updated name symbol usd_value)a
+  defstruct ~w(btc_value id last_updated market_cap_usd name symbol usd_value)a
 end

--- a/apps/explorer/lib/explorer/exchange_rates/rate.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/rate.ex
@@ -15,13 +15,13 @@ defmodule Explorer.ExchangeRates.Rate do
   * `:usd_value` - The USD value of the currency
   """
   @type t :: %__MODULE__{
-          btc_value: String.t(),
+          btc_value: Decimal.t(),
           id: String.t(),
           last_updated: DateTime.t(),
-          market_cap_usd: String.t(),
+          market_cap_usd: Decimal.t(),
           name: String.t(),
           symbol: String.t(),
-          usd_value: String.t()
+          usd_value: Decimal.t()
         }
 
   defstruct ~w(btc_value id last_updated market_cap_usd name symbol usd_value)a

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -35,13 +35,13 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     last_updated = DateTime.from_unix!(last_updated_as_unix)
 
     %Rate{
-      btc_value: json["price_btc"],
+      btc_value: Decimal.new(json["price_btc"]),
       id: json["id"],
       last_updated: last_updated,
-      market_cap_usd: json["market_cap_usd"],
+      market_cap_usd: Decimal.new(json["market_cap_usd"]),
       name: json["name"],
       symbol: json["symbol"],
-      usd_value: json["price_usd"]
+      usd_value: Decimal.new(json["price_usd"])
     }
   end
 

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -35,8 +35,10 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     last_updated = DateTime.from_unix!(last_updated_as_unix)
 
     %Rate{
+      btc_value: json["price_btc"],
       id: json["id"],
       last_updated: last_updated,
+      market_cap_usd: json["market_cap_usd"],
       name: json["name"],
       symbol: json["symbol"],
       usd_value: json["price_usd"]

--- a/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
@@ -52,8 +52,10 @@ defmodule Explorer.ExchangeRatesTest do
 
     test "with successful fetch" do
       expected_rate = %Rate{
+        btc_value: "1.000",
         id: "test",
         last_updated: DateTime.utc_now(),
+        market_cap_usd: "123456789.0000000",
         name: "test",
         symbol: "test",
         usd_value: "9000.000001"

--- a/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
@@ -40,13 +40,13 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCapTest do
       expected_date = ~N[2018-04-11 19:00:00] |> DateTime.from_naive!("Etc/UTC")
 
       expected = %Rate{
-        btc_value: "0.00007032",
+        btc_value: Decimal.new("0.00007032"),
         id: "poa-network",
         last_updated: expected_date,
-        market_cap_usd: "98941986.0",
+        market_cap_usd: Decimal.new("98941986.0"),
         name: "POA Network",
         symbol: "POA",
-        usd_value: "0.485053"
+        usd_value: Decimal.new("0.485053")
       }
 
       assert {:ok, ^expected} = CoinMarketCap.fetch_exchange_rate("poa-network")
@@ -69,13 +69,13 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCapTest do
     expected_date = ~N[2018-04-11 19:00:00] |> DateTime.from_naive!("Etc/UTC")
 
     expected = %Rate{
-      btc_value: "0.00007032",
+      btc_value: Decimal.new("0.00007032"),
       id: "poa-network",
       last_updated: expected_date,
-      market_cap_usd: "98941986.0",
+      market_cap_usd: Decimal.new("98941986.0"),
       name: "POA Network",
       symbol: "POA",
-      usd_value: "0.485053"
+      usd_value: Decimal.new("0.485053")
     }
 
     assert expected == CoinMarketCap.format_data(@json)

--- a/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
@@ -40,8 +40,10 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCapTest do
       expected_date = ~N[2018-04-11 19:00:00] |> DateTime.from_naive!("Etc/UTC")
 
       expected = %Rate{
+        btc_value: "0.00007032",
         id: "poa-network",
         last_updated: expected_date,
+        market_cap_usd: "98941986.0",
         name: "POA Network",
         symbol: "POA",
         usd_value: "0.485053"
@@ -67,8 +69,10 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCapTest do
     expected_date = ~N[2018-04-11 19:00:00] |> DateTime.from_naive!("Etc/UTC")
 
     expected = %Rate{
+      btc_value: "0.00007032",
       id: "poa-network",
       last_updated: expected_date,
+      market_cap_usd: "98941986.0",
       name: "POA Network",
       symbol: "POA",
       usd_value: "0.485053"


### PR DESCRIPTION
For #18, I accidentially missed two values that should have been added. This adds that values to the `Rate` struct.