### PR TITLE
Standardize tools to 120 columns

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -81,7 +81,7 @@
         {Credo.Check.Design.TagFIXME},
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,5 +6,6 @@
     "apps/*/{config,lib,test}/**/*.{ex,exs}",
     "mix.exs",
     "{config}/**/*.{ex,exs}"
-  ]
+  ],
+  line_length: 120
 ]

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -43,8 +43,7 @@ config :exq,
   queues: [
     {"blocks", String.to_integer(System.get_env("EXQ_BLOCKS_CONCURRENCY") || "1")},
     {"default", String.to_integer(System.get_env("EXQ_CONCURRENCY") || "1")},
-    {"internal_transactions",
-     String.to_integer(System.get_env("EXQ_INTERNAL_TRANSACTIONS_CONCURRENCY") || "1")},
+    {"internal_transactions", String.to_integer(System.get_env("EXQ_INTERNAL_TRANSACTIONS_CONCURRENCY") || "1")},
     {"receipts", String.to_integer(System.get_env("EXQ_RECEIPTS_CONCURRENCY") || "1")},
     {"transactions", String.to_integer(System.get_env("EXQ_TRANSACTIONS_CONCURRENCY") || "1")}
   ]

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -58,8 +58,9 @@ defmodule Explorer.Chain do
   * `:pagination` - pagination params to pass to scrivener.
   """
   @spec block_to_transactions(Block.t()) :: %Scrivener.Page{entries: [Transaction.t()]}
-  @spec block_to_transactions(Block.t(), [necessity_by_association_option | pagination_option]) ::
-          %Scrivener.Page{entries: [Transaction.t()]}
+  @spec block_to_transactions(Block.t(), [necessity_by_association_option | pagination_option]) :: %Scrivener.Page{
+          entries: [Transaction.t()]
+        }
   def block_to_transactions(%Block{id: block_id}, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     pagination = Keyword.get(options, :pagination, %{})
@@ -405,10 +406,9 @@ defmodule Explorer.Chain do
       then the `t:Explorer.Chain.InternalTransaction.t/0` will not be included in the list.
 
   """
-  @spec transactions_recently_before_id(id :: non_neg_integer, [necessity_by_association_option]) ::
-          [
-            Transaction.t()
-          ]
+  @spec transactions_recently_before_id(id :: non_neg_integer, [necessity_by_association_option]) :: [
+          Transaction.t()
+        ]
   def transactions_recently_before_id(id, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 

--- a/apps/explorer/lib/explorer/workers/refresh_balance.ex
+++ b/apps/explorer/lib/explorer/workers/refresh_balance.ex
@@ -22,8 +22,7 @@ defmodule Explorer.Workers.RefreshBalance do
   def refreshing(table) do
     query = "REFRESH MATERIALIZED VIEW CONCURRENTLY #{table}%"
 
-    result =
-      SQL.query!(Repo, "SELECT TRUE FROM pg_stat_activity WHERE query ILIKE '$#{query}'", [])
+    result = SQL.query!(Repo, "SELECT TRUE FROM pg_stat_activity WHERE query ILIKE '$#{query}'", [])
 
     Enum.count(result.rows) > 0
   end

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -46,8 +46,7 @@ defmodule Explorer.Mixfile do
   defp elixirc_paths, do: ["lib"]
 
   # Specifies extra applications to start per environment
-  defp extra_applications(:prod),
-    do: [:phoenix_pubsub_redis, :exq, :exq_ui | extra_applications()]
+  defp extra_applications(:prod), do: [:phoenix_pubsub_redis, :exq, :exq_ui | extra_applications()]
 
   defp extra_applications(:dev), do: [:exq, :exq_ui | extra_applications()]
   defp extra_applications(_), do: extra_applications()

--- a/apps/explorer/test/explorer/chain/block_test.exs
+++ b/apps/explorer/test/explorer/chain/block_test.exs
@@ -19,8 +19,7 @@ defmodule Explorer.Chain.BlockTest do
     test "with duplicate information" do
       insert(:block, hash: "0x0")
 
-      {:error, changeset} =
-        %Block{} |> Block.changeset(params_for(:block, hash: "0x0")) |> Repo.insert()
+      {:error, changeset} = %Block{} |> Block.changeset(params_for(:block, hash: "0x0")) |> Repo.insert()
 
       refute changeset.valid?
       assert changeset.errors == [hash: {"has already been taken", []}]
@@ -29,8 +28,7 @@ defmodule Explorer.Chain.BlockTest do
     test "rejects duplicate blocks with mixed case" do
       insert(:block, hash: "0xa")
 
-      {:error, changeset} =
-        %Block{} |> Block.changeset(params_for(:block, hash: "0xA")) |> Repo.insert()
+      {:error, changeset} = %Block{} |> Block.changeset(params_for(:block, hash: "0xA")) |> Repo.insert()
 
       refute changeset.valid?
       assert changeset.errors == [hash: {"has already been taken", []}]
@@ -48,8 +46,7 @@ defmodule Explorer.Chain.BlockTest do
       insert(:block, number: 1)
       insert(:block, number: 5)
 
-      assert Block |> Block.latest() |> Repo.all() ==
-               Block |> order_by(desc: :number) |> Repo.all()
+      assert Block |> Block.latest() |> Repo.all() == Block |> order_by(desc: :number) |> Repo.all()
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/credit_test.exs
+++ b/apps/explorer/test/explorer/chain/credit_test.exs
@@ -28,8 +28,7 @@ defmodule Explorer.Chain.CreditTest do
       recipient = insert(:address)
       sender = insert(:address)
 
-      transaction =
-        insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
+      transaction = insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
 
       insert(:receipt, transaction: transaction, status: 1)
       address_id = sender.id
@@ -42,8 +41,7 @@ defmodule Explorer.Chain.CreditTest do
       recipient = insert(:address)
       sender = insert(:address)
 
-      transaction =
-        insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
+      transaction = insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
 
       insert(:receipt, transaction: transaction, status: 1)
       address_id = recipient.id

--- a/apps/explorer/test/explorer/chain/debit_test.exs
+++ b/apps/explorer/test/explorer/chain/debit_test.exs
@@ -28,8 +28,7 @@ defmodule Explorer.Chain.DebitTest do
       recipient = insert(:address)
       sender = insert(:address)
 
-      transaction =
-        insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
+      transaction = insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
 
       insert(:receipt, transaction: transaction, status: 1)
       address_id = sender.id
@@ -42,8 +41,7 @@ defmodule Explorer.Chain.DebitTest do
       recipient = insert(:address)
       sender = insert(:address)
 
-      transaction =
-        insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
+      transaction = insert(:transaction, value: 21, to_address_id: recipient.id, from_address_id: sender.id)
 
       insert(:receipt, transaction: transaction, status: 1)
       address_id = recipient.id

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -69,8 +69,7 @@ defmodule Explorer.Chain.StatisticsTest do
       inserted_at = validation_time |> Timex.shift(seconds: 5)
       insert(:block, timestamp: validation_time, inserted_at: inserted_at)
 
-      assert %Statistics{lag: %Duration{seconds: 5, megaseconds: 0, microseconds: 0}} =
-               Statistics.fetch()
+      assert %Statistics{lag: %Duration{seconds: 5, megaseconds: 0, microseconds: 0}} = Statistics.fetch()
     end
 
     test "returns the number of blocks inserted in the last minute" do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -92,8 +92,7 @@ defmodule Explorer.ChainTest do
         insert(:block_transaction, block_id: block_id, transaction_id: transaction_id)
       end)
 
-      [%Transaction{id: first_transaction_id}, %Transaction{id: second_transaction_id}] =
-        transactions
+      [%Transaction{id: first_transaction_id}, %Transaction{id: second_transaction_id}] = transactions
 
       assert %Scrivener.Page{
                entries: [%Transaction{id: ^first_transaction_id}],
@@ -144,8 +143,7 @@ defmodule Explorer.ChainTest do
 
       assert block.number < max_block_number
 
-      assert Chain.confirmations(block, max_block_number: max_block_number) ==
-               max_block_number - block.number
+      assert Chain.confirmations(block, max_block_number: max_block_number) == max_block_number - block.number
     end
   end
 
@@ -188,18 +186,15 @@ defmodule Explorer.ChainTest do
     end
 
     test ":gwei unit" do
-      assert Chain.gas_price(%Transaction{gas_price: Decimal.new(1)}, :gwei) ==
-               Decimal.new("1e-9")
+      assert Chain.gas_price(%Transaction{gas_price: Decimal.new(1)}, :gwei) == Decimal.new("1e-9")
 
       assert Chain.gas_price(%Transaction{gas_price: Decimal.new("1e9")}, :gwei) == Decimal.new(1)
     end
 
     test ":ether unit" do
-      assert Chain.gas_price(%Transaction{gas_price: Decimal.new(1)}, :ether) ==
-               Decimal.new("1e-18")
+      assert Chain.gas_price(%Transaction{gas_price: Decimal.new(1)}, :ether) == Decimal.new("1e-18")
 
-      assert Chain.gas_price(%Transaction{gas_price: Decimal.new("1e18")}, :ether) ==
-               Decimal.new(1)
+      assert Chain.gas_price(%Transaction{gas_price: Decimal.new("1e18")}, :ether) == Decimal.new(1)
     end
   end
 
@@ -230,13 +225,11 @@ defmodule Explorer.ChainTest do
     test "with transactions with receipt required without receipt does not return transaction" do
       address = %Address{id: from_address_id} = insert(:address)
 
-      %Transaction{id: transaction_id_with_receipt} =
-        insert(:transaction, from_address_id: from_address_id)
+      %Transaction{id: transaction_id_with_receipt} = insert(:transaction, from_address_id: from_address_id)
 
       insert(:receipt, transaction_id: transaction_id_with_receipt)
 
-      %Transaction{id: transaction_id_without_receipt} =
-        insert(:transaction, from_address_id: from_address_id)
+      %Transaction{id: transaction_id_without_receipt} = insert(:transaction, from_address_id: from_address_id)
 
       assert %Scrivener.Page{
                entries: [%Transaction{id: ^transaction_id_with_receipt, receipt: %Receipt{}}],
@@ -273,8 +266,7 @@ defmodule Explorer.ChainTest do
       adddress = %Address{id: from_address_id} = insert(:address)
       transactions = insert_list(2, :transaction, from_address_id: from_address_id)
 
-      [%Transaction{id: oldest_transaction_id}, %Transaction{id: newest_transaction_id}] =
-        transactions
+      [%Transaction{id: oldest_transaction_id}, %Transaction{id: newest_transaction_id}] = transactions
 
       assert %Scrivener.Page{
                entries: [%Transaction{id: ^newest_transaction_id}],
@@ -290,8 +282,7 @@ defmodule Explorer.ChainTest do
                page_size: 1,
                total_entries: 2,
                total_pages: 2
-             } =
-               Chain.from_address_to_transactions(adddress, pagination: %{page: 2, page_size: 1})
+             } = Chain.from_address_to_transactions(adddress, pagination: %{page: 2, page_size: 1})
     end
   end
 
@@ -321,8 +312,7 @@ defmodule Explorer.ChainTest do
     end
 
     test "with transaction with receipt required without receipt returns {:error, :not_found}" do
-      %Transaction{hash: hash_with_receipt, id: transaction_id_with_receipt} =
-        insert(:transaction)
+      %Transaction{hash: hash_with_receipt, id: transaction_id_with_receipt} = insert(:transaction)
 
       insert(:receipt, transaction_id: transaction_id_with_receipt)
 
@@ -479,13 +469,11 @@ defmodule Explorer.ChainTest do
     test "with transactions with receipt required without receipt does not return transaction" do
       address = %Address{id: to_address_id} = insert(:address)
 
-      %Transaction{id: transaction_id_with_receipt} =
-        insert(:transaction, to_address_id: to_address_id)
+      %Transaction{id: transaction_id_with_receipt} = insert(:transaction, to_address_id: to_address_id)
 
       insert(:receipt, transaction_id: transaction_id_with_receipt)
 
-      %Transaction{id: transaction_id_without_receipt} =
-        insert(:transaction, to_address_id: to_address_id)
+      %Transaction{id: transaction_id_without_receipt} = insert(:transaction, to_address_id: to_address_id)
 
       assert %Scrivener.Page{
                entries: [%Transaction{id: ^transaction_id_with_receipt, receipt: %Receipt{}}],
@@ -522,8 +510,7 @@ defmodule Explorer.ChainTest do
       adddress = %Address{id: to_address_id} = insert(:address)
       transactions = insert_list(2, :transaction, to_address_id: to_address_id)
 
-      [%Transaction{id: oldest_transaction_id}, %Transaction{id: newest_transaction_id}] =
-        transactions
+      [%Transaction{id: oldest_transaction_id}, %Transaction{id: newest_transaction_id}] = transactions
 
       assert %Scrivener.Page{
                entries: [%Transaction{id: ^newest_transaction_id}],
@@ -643,11 +630,9 @@ defmodule Explorer.ChainTest do
         insert(:receipt, transaction_id: id)
       end)
 
-      assert length(Chain.transactions_recently_before_id(last_transaction_id, pending: true)) ==
-               8
+      assert length(Chain.transactions_recently_before_id(last_transaction_id, pending: true)) == 8
 
-      assert length(Chain.transactions_recently_before_id(last_transaction_id, pending: false)) ==
-               10
+      assert length(Chain.transactions_recently_before_id(last_transaction_id, pending: false)) == 10
 
       assert length(Chain.transactions_recently_before_id(last_transaction_id)) == 10
     end
@@ -761,8 +746,7 @@ defmodule Explorer.ChainTest do
 
       Chain.update_balance(hash, 88)
 
-      assert {:ok, %Address{balance_updated_at: balance_updated_at}} =
-               Chain.hash_to_address("0xtwizzlers")
+      assert {:ok, %Address{balance_updated_at: balance_updated_at}} = Chain.hash_to_address("0xtwizzlers")
 
       refute is_nil(balance_updated_at)
     end
@@ -782,18 +766,15 @@ defmodule Explorer.ChainTest do
     end
 
     test "with InternalTransaction.t with :gwei" do
-      assert Chain.value(%InternalTransaction{value: Decimal.new(1)}, :gwei) ==
-               Decimal.new("1e-9")
+      assert Chain.value(%InternalTransaction{value: Decimal.new(1)}, :gwei) == Decimal.new("1e-9")
 
       assert Chain.value(%InternalTransaction{value: Decimal.new("1e9")}, :gwei) == Decimal.new(1)
     end
 
     test "with InternalTransaction.t with :ether" do
-      assert Chain.value(%InternalTransaction{value: Decimal.new(1)}, :ether) ==
-               Decimal.new("1e-18")
+      assert Chain.value(%InternalTransaction{value: Decimal.new(1)}, :ether) == Decimal.new("1e-18")
 
-      assert Chain.value(%InternalTransaction{value: Decimal.new("1e18")}, :ether) ==
-               Decimal.new(1)
+      assert Chain.value(%InternalTransaction{value: Decimal.new("1e18")}, :ether) == Decimal.new(1)
     end
 
     test "with Transaction.t with :wei" do

--- a/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
@@ -62,8 +62,7 @@ defmodule Explorer.ExchangeRatesTest do
       id = expected_rate.id
       state = %{}
 
-      assert {:noreply, ^state} =
-               ExchangeRates.handle_info({nil, {id, {:ok, expected_rate}}}, state)
+      assert {:noreply, ^state} = ExchangeRates.handle_info({nil, {id, {:ok, expected_rate}}}, state)
 
       assert [{^id, ^expected_rate}] = :ets.lookup(ExchangeRates.table_name(), id)
     end
@@ -75,8 +74,7 @@ defmodule Explorer.ExchangeRatesTest do
       expect(TestSource, :fetch_exchange_rate, fn "failed-ticker" -> {:ok, %Rate{}} end)
       set_mox_global()
 
-      assert {:noreply, ^state} =
-               ExchangeRates.handle_info({nil, {ticker, {:error, "some error"}}}, state)
+      assert {:noreply, ^state} = ExchangeRates.handle_info({nil, {ticker, {:error, "some error"}}}, state)
 
       assert_receive {_, {^ticker, {:ok, _}}}
     end

--- a/apps/explorer/test/explorer/importers/block_importer_test.exs
+++ b/apps/explorer/test/explorer/importers/block_importer_test.exs
@@ -14,8 +14,7 @@ defmodule Explorer.BlockImporterTest do
           BlockImporter.import("0xc4f0d")
           block = Block |> order_by(desc: :inserted_at) |> Repo.one()
 
-          assert block.hash ==
-                   "0x16cb43ccfb7875c14eb3f03bdc098e4af053160544270594fa429d256cbca64e"
+          assert block.hash == "0x16cb43ccfb7875c14eb3f03bdc098e4af053160544270594fa429d256cbca64e"
         end
       end
     end

--- a/apps/explorer/test/explorer/importers/internal_transaction_importer_test.exs
+++ b/apps/explorer/test/explorer/importers/internal_transaction_importer_test.exs
@@ -29,8 +29,7 @@ defmodule Explorer.InternalTransactionImporterTest do
 
         InternalTransactionImporter.import(transaction.hash)
 
-        last_internal_transaction =
-          InternalTransaction |> order_by(desc: :index) |> limit(1) |> Repo.one()
+        last_internal_transaction = InternalTransaction |> order_by(desc: :index) |> limit(1) |> Repo.one()
 
         assert last_internal_transaction.index == 1
       end
@@ -46,8 +45,7 @@ defmodule Explorer.InternalTransactionImporterTest do
 
         InternalTransactionImporter.import(transaction.hash)
 
-        last_internal_transaction =
-          InternalTransaction |> order_by(desc: :index) |> limit(1) |> Repo.one()
+        last_internal_transaction = InternalTransaction |> order_by(desc: :index) |> limit(1) |> Repo.one()
 
         assert last_internal_transaction.call_type == "create"
       end

--- a/apps/explorer/test/explorer/importers/receipt_importer_test.exs
+++ b/apps/explorer/test/explorer/importers/receipt_importer_test.exs
@@ -13,9 +13,7 @@ defmodule Explorer.ReceiptImporterTest do
         )
 
       use_cassette "transaction_importer_import_1_receipt" do
-        ReceiptImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        ReceiptImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         receipt = Receipt |> preload([:transaction]) |> Repo.one()
         assert receipt.transaction == transaction
@@ -29,9 +27,7 @@ defmodule Explorer.ReceiptImporterTest do
       )
 
       use_cassette "transaction_importer_import_1_receipt" do
-        ReceiptImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        ReceiptImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         receipt = Receipt |> preload([:transaction]) |> Repo.one()
         log = Log |> preload(receipt: :transaction) |> Repo.one()
@@ -48,9 +44,7 @@ defmodule Explorer.ReceiptImporterTest do
       address = insert(:address, hash: "0x353fe3ffbf77edef7f9c352c47965a38c07e837c")
 
       use_cassette "transaction_importer_import_1_receipt" do
-        ReceiptImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        ReceiptImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         log = Log |> preload([:address]) |> Repo.one()
         assert log.address == address
@@ -64,9 +58,7 @@ defmodule Explorer.ReceiptImporterTest do
       )
 
       use_cassette "transaction_importer_import_1_failed" do
-        ReceiptImporter.import(
-          "0x2532864dc2e0d0bc2dfabf4685c0c03dbdbe9cf67ebc593fc82d41087ab71435"
-        )
+        ReceiptImporter.import("0x2532864dc2e0d0bc2dfabf4685c0c03dbdbe9cf67ebc593fc82d41087ab71435")
 
         receipt = Repo.one(Receipt)
         assert receipt.status == 0
@@ -80,9 +72,7 @@ defmodule Explorer.ReceiptImporterTest do
       )
 
       use_cassette "transaction_importer_import_1_out_of_gas" do
-        ReceiptImporter.import(
-          "0x702e518267b0a57e4cb44b9db100afe4d7115f2d2650466a8c376f3dbb77eb35"
-        )
+        ReceiptImporter.import("0x702e518267b0a57e4cb44b9db100afe4d7115f2d2650466a8c376f3dbb77eb35")
 
         receipt = Repo.one(Receipt)
         assert receipt.status == 0
@@ -99,9 +89,7 @@ defmodule Explorer.ReceiptImporterTest do
       insert(:receipt, transaction: transaction)
 
       use_cassette "transaction_importer_import_1_receipt" do
-        ReceiptImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        ReceiptImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         assert Repo.all(Receipt) |> Enum.count() == 1
       end
@@ -109,9 +97,7 @@ defmodule Explorer.ReceiptImporterTest do
 
     test "does not import a receipt for a nonexistent transaction" do
       use_cassette "transaction_importer_import_1_receipt" do
-        ReceiptImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        ReceiptImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         assert Repo.all(Receipt) |> Enum.count() == 0
       end
@@ -124,9 +110,7 @@ defmodule Explorer.ReceiptImporterTest do
       )
 
       use_cassette "transaction_importer_import_1_pending" do
-        ReceiptImporter.import(
-          "0xde791cfcde3900d4771e5fcf8c11dc305714118df7aa7e42f84576e64dbf6246"
-        )
+        ReceiptImporter.import("0xde791cfcde3900d4771e5fcf8c11dc305714118df7aa7e42f84576e64dbf6246")
 
         assert Repo.all(Receipt) |> Enum.count() == 0
       end

--- a/apps/explorer/test/explorer/importers/transaction_importer_test.exs
+++ b/apps/explorer/test/explorer/importers/transaction_importer_test.exs
@@ -40,14 +40,11 @@ defmodule Explorer.TransactionImporterTest do
   describe "import/1" do
     test "imports and saves a transaction to the database" do
       use_cassette "transaction_importer_import_saves_the_transaction" do
-        TransactionImporter.import(
-          "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
-        )
+        TransactionImporter.import("0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291")
 
         transaction = Transaction |> order_by(desc: :inserted_at) |> Repo.one()
 
-        assert transaction.hash ==
-                 "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
+        assert transaction.hash == "0xdc3a0dfd0bbffd5eabbe40fb13afbe35ac5f5c030bff148f3e50afe32974b291"
       end
     end
 
@@ -59,9 +56,7 @@ defmodule Explorer.TransactionImporterTest do
           gas: 5
         )
 
-        TransactionImporter.import(
-          "0x170baac4eca26076953370dd603c68eab340c0135b19b585010d3158a5dbbf23"
-        )
+        TransactionImporter.import("0x170baac4eca26076953370dd603c68eab340c0135b19b585010d3158a5dbbf23")
 
         transaction = Transaction |> order_by(desc: :inserted_at) |> Repo.one()
 
@@ -77,15 +72,11 @@ defmodule Explorer.TransactionImporterTest do
             hash: "0xfce13392435a8e7dab44c07d482212efb9dc39a9bea1915a9ead308b55a617f9"
           )
 
-        TransactionImporter.import(
-          "0x64d851139325479c3bb7ccc6e6ab4cde5bc927dce6810190fe5d770a4c1ac333"
-        )
+        TransactionImporter.import("0x64d851139325479c3bb7ccc6e6ab4cde5bc927dce6810190fe5d770a4c1ac333")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0x64d851139325479c3bb7ccc6e6ab4cde5bc927dce6810190fe5d770a4c1ac333"
-          )
+          |> Repo.get_by(hash: "0x64d851139325479c3bb7ccc6e6ab4cde5bc927dce6810190fe5d770a4c1ac333")
 
         block_transaction = BlockTransaction |> Repo.get_by(transaction_id: transaction.id)
 
@@ -95,15 +86,11 @@ defmodule Explorer.TransactionImporterTest do
 
     test "when there is no block it does not save a block transaction" do
       use_cassette "transaction_importer_txn_without_block" do
-        TransactionImporter.import(
-          "0xc6aa189827c14880f012a65292f7add7b5310094f8773a3d85b66303039b9dcf"
-        )
+        TransactionImporter.import("0xc6aa189827c14880f012a65292f7add7b5310094f8773a3d85b66303039b9dcf")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xc6aa189827c14880f012a65292f7add7b5310094f8773a3d85b66303039b9dcf"
-          )
+          |> Repo.get_by(hash: "0xc6aa189827c14880f012a65292f7add7b5310094f8773a3d85b66303039b9dcf")
 
         block_transaction = BlockTransaction |> Repo.get_by(transaction_id: transaction.id)
 
@@ -113,15 +100,11 @@ defmodule Explorer.TransactionImporterTest do
 
     test "creates a from address" do
       use_cassette "transaction_importer_creates_a_from_address" do
-        TransactionImporter.import(
-          "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d"
-        )
+        TransactionImporter.import("0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d"
-          )
+          |> Repo.get_by(hash: "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d")
 
         address = Address |> Repo.get_by(hash: "0xa5b4b372112ab8dbbb48c8d0edd89227e24ec785")
 
@@ -133,15 +116,11 @@ defmodule Explorer.TransactionImporterTest do
       insert(:address, hash: "0xa5b4b372112ab8dbbb48c8d0edd89227e24ec785")
 
       use_cassette "transaction_importer_creates_a_from_address" do
-        TransactionImporter.import(
-          "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d"
-        )
+        TransactionImporter.import("0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d"
-          )
+          |> Repo.get_by(hash: "0xc445f5410912458c480d992dd93355ae3dad64d9f65db25a3cf43a9c609a2e0d")
 
         address = Address |> Repo.get_by(hash: "0xa5b4b372112ab8dbbb48c8d0edd89227e24ec785")
 
@@ -151,15 +130,11 @@ defmodule Explorer.TransactionImporterTest do
 
     test "creates a to address" do
       use_cassette "transaction_importer_creates_a_to_address" do
-        TransactionImporter.import(
-          "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-        )
+        TransactionImporter.import("0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-          )
+          |> Repo.get_by(hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         address = Address |> Repo.get_by(hash: "0x24e5b8528fe83257d5fe3497ef616026713347f8")
 
@@ -171,15 +146,11 @@ defmodule Explorer.TransactionImporterTest do
       insert(:address, hash: "0x24e5b8528fe83257d5fe3497ef616026713347f8")
 
       use_cassette "transaction_importer_creates_a_to_address" do
-        TransactionImporter.import(
-          "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-        )
+        TransactionImporter.import("0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-          )
+          |> Repo.get_by(hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         address = Address |> Repo.get_by(hash: "0x24e5b8528fe83257d5fe3497ef616026713347f8")
 
@@ -189,15 +160,11 @@ defmodule Explorer.TransactionImporterTest do
 
     test "creates a to address using creates when to is nil" do
       use_cassette "transaction_importer_creates_a_to_address_from_creates" do
-        TransactionImporter.import(
-          "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-        )
+        TransactionImporter.import("0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         transaction =
           Transaction
-          |> Repo.get_by(
-            hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-          )
+          |> Repo.get_by(hash: "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
         address = Address |> Repo.get_by(hash: "0x24e5b8528fe83257d5fe3497ef616026713347f8")
 
@@ -208,9 +175,7 @@ defmodule Explorer.TransactionImporterTest do
     test "processes a map of transaction attributes" do
       insert(:block, hash: "0xtakis")
 
-      TransactionImporter.import(
-        Map.merge(@raw_transaction, %{"hash" => "0xmunchos", "blockHash" => "0xtakis"})
-      )
+      TransactionImporter.import(Map.merge(@raw_transaction, %{"hash" => "0xmunchos", "blockHash" => "0xtakis"}))
 
       last_transaction = Transaction |> order_by(desc: :inserted_at) |> limit(1) |> Repo.one()
 
@@ -218,9 +183,7 @@ defmodule Explorer.TransactionImporterTest do
     end
 
     test "gets balances for addresses" do
-      TransactionImporter.import(
-        "0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c"
-      )
+      TransactionImporter.import("0xdc533d4227734a7cacd75a069e8dc57ac571b865ed97bae5ea4cb74b54145f4c")
 
       from_address = Address |> Repo.get_by(hash: "0xb2867180771b196518651c174c9240d5e8bd0ecd")
       to_address = Address |> Repo.get_by(hash: "0x24e5b8528fe83257d5fe3497ef616026713347f8")
@@ -245,9 +208,7 @@ defmodule Explorer.TransactionImporterTest do
     test "downloads a transaction" do
       use_cassette "transaction_importer_download_transaction" do
         raw_transaction =
-          TransactionImporter.download_transaction(
-            "0x170baac4eca26076953370dd603c68eab340c0135b19b585010d3158a5dbbf23"
-          )
+          TransactionImporter.download_transaction("0x170baac4eca26076953370dd603c68eab340c0135b19b585010d3158a5dbbf23")
 
         assert(raw_transaction["from"] == "0xbe96ef1d056c97323e210fd0dd818aa027e57143")
       end

--- a/apps/explorer/test/explorer/workers/import_balance_test.exs
+++ b/apps/explorer/test/explorer/workers/import_balance_test.exs
@@ -32,8 +32,7 @@ defmodule Explorer.Workers.ImportBalanceTest do
 
         expected_balance = Decimal.new(66)
 
-        assert {:ok, %Address{balance: ^expected_balance}} =
-                 Chain.hash_to_address("0xskateboards")
+        assert {:ok, %Address{balance: ^expected_balance}} = Chain.hash_to_address("0xskateboards")
       end
     end
   end

--- a/apps/explorer/test/explorer/workers/import_internal_transaction_test.exs
+++ b/apps/explorer/test/explorer/workers/import_internal_transaction_test.exs
@@ -9,9 +9,7 @@ defmodule Explorer.Workers.ImportInternalTransactionTest do
     test "does not import the internal transactions when no transaction with the hash exists" do
       use_cassette "import_internal_transaction_perform_1" do
         assert_raise Ecto.NoResultsError, fn ->
-          ImportInternalTransaction.perform(
-            "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-          )
+          ImportInternalTransaction.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
         end
       end
     end
@@ -23,9 +21,7 @@ defmodule Explorer.Workers.ImportInternalTransactionTest do
       )
 
       use_cassette "import_internal_transaction_perform_1" do
-        ImportInternalTransaction.perform(
-          "0x051e031f05b3b3a5ff73e1189c36e3e2a41fd1c2d9772b2c75349e22ed4d3f68"
-        )
+        ImportInternalTransaction.perform("0x051e031f05b3b3a5ff73e1189c36e3e2a41fd1c2d9772b2c75349e22ed4d3f68")
 
         internal_transaction_count = InternalTransaction |> Repo.all() |> Enum.count()
         assert internal_transaction_count == 2

--- a/apps/explorer/test/explorer/workers/import_receipt_test.exs
+++ b/apps/explorer/test/explorer/workers/import_receipt_test.exs
@@ -8,9 +8,7 @@ defmodule Explorer.Workers.ImportReceiptTest do
   describe "perform/1" do
     test "does not import a receipt when no transaction with the hash exists" do
       use_cassette "import_receipt_perform_1" do
-        ImportReceipt.perform(
-          "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-        )
+        ImportReceipt.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
 
         assert Repo.one(Receipt) == nil
       end
@@ -23,9 +21,7 @@ defmodule Explorer.Workers.ImportReceiptTest do
       )
 
       use_cassette "import_receipt_perform_1" do
-        ImportReceipt.perform(
-          "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-        )
+        ImportReceipt.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
 
         receipt_count = Receipt |> Repo.all() |> Enum.count()
         assert receipt_count == 1

--- a/apps/explorer/test/explorer/workers/import_transaction_test.exs
+++ b/apps/explorer/test/explorer/workers/import_transaction_test.exs
@@ -12,15 +12,12 @@ defmodule Explorer.Workers.ImportTransactionTest do
     test "imports the requested transaction hash" do
       use_cassette "import_transaction_perform_1" do
         with_mock Exq, enqueue: fn _, _, _, _ -> :ok end do
-          ImportTransaction.perform(
-            "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-          )
+          ImportTransaction.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
         end
 
         transaction = Transaction |> Repo.one()
 
-        assert transaction.hash ==
-                 "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
+        assert transaction.hash == "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
       end
     end
 
@@ -32,9 +29,7 @@ defmodule Explorer.Workers.ImportTransactionTest do
 
       use_cassette "import_transaction_perform_1" do
         with_mock Exq, enqueue: fn _, _, _, _ -> :ok end do
-          ImportTransaction.perform(
-            "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-          )
+          ImportTransaction.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
         end
 
         transaction_count = Transaction |> Repo.all() |> Enum.count()
@@ -52,9 +47,7 @@ defmodule Explorer.Workers.ImportTransactionTest do
       use_cassette "import_transaction_perform_1" do
         with_mock Exq, enqueue: fn _, _, _, _ -> insert(:receipt, transaction: transaction) end do
           with_mock ImportInternalTransaction, perform_later: fn _ -> :ok end do
-            ImportTransaction.perform(
-              "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-            )
+            ImportTransaction.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
 
             receipt = Repo.one(Receipt)
             refute is_nil(receipt)
@@ -98,9 +91,7 @@ defmodule Explorer.Workers.ImportTransactionTest do
         with_mock Exq, enqueue: fn _, _, _, _ -> :ok end do
           with_mock ImportInternalTransaction,
             perform_later: fn _ -> insert(:internal_transaction, transaction: transaction) end do
-            ImportTransaction.perform(
-              "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-            )
+            ImportTransaction.perform("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
 
             internal_transaction = Repo.one(InternalTransaction)
             refute is_nil(internal_transaction)
@@ -145,14 +136,11 @@ defmodule Explorer.Workers.ImportTransactionTest do
               hash: "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
             )
           end do
-          ImportTransaction.perform_later(
-            "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
-          )
+          ImportTransaction.perform_later("0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926")
 
           transaction = Repo.one(Transaction)
 
-          assert transaction.hash ==
-                   "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
+          assert transaction.hash == "0xf9a0959d5ccde33ec5221ddba1c6d7eaf9580a8d3512c7a1a60301362a98f926"
         end
       end
     end

--- a/apps/explorer_web/lib/explorer_web/chain.ex
+++ b/apps/explorer_web/lib/explorer_web/chain.ex
@@ -5,8 +5,7 @@ defmodule ExplorerWeb.Chain do
 
   import Explorer.Chain, only: [hash_to_address: 1, hash_to_transaction: 1, number_to_block: 1]
 
-  @spec from_param(String.t()) ::
-          {:ok, Address.t() | Transaction.t() | Block.t()} | {:error, :not_found}
+  @spec from_param(String.t()) :: {:ok, Address.t() | Transaction.t() | Block.t()} | {:error, :not_found}
   def from_param(param)
 
   def from_param(hash) when byte_size(hash) > 42 do

--- a/apps/explorer_web/lib/explorer_web/controllers/block_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/block_controller.ex
@@ -4,8 +4,7 @@ defmodule ExplorerWeb.BlockController do
   alias Explorer.Chain
 
   def index(conn, params) do
-    blocks =
-      Chain.list_blocks(necessity_by_association: %{transactions: :optional}, pagination: params)
+    blocks = Chain.list_blocks(necessity_by_association: %{transactions: :optional}, pagination: params)
 
     render(conn, "index.html", blocks: blocks)
   end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -40,8 +40,7 @@ defmodule ExplorerWeb.Router do
   end
 
   pipeline :jasmine do
-    if Mix.env() != :prod,
-      do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
+    if Mix.env() != :prod, do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
   end
 
   pipeline :api do

--- a/apps/explorer_web/lib/explorer_web/templates/address/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/show.html.eex
@@ -5,15 +5,31 @@
   </div>
   <div class="address__container">
     <div class="address__tabs">
-      <h2 class="address__tab address__tab--active"><%= link(gettext("Overview"), to: address_path(@conn, :show, @conn.assigns.locale, @address.hash), class: "address__link address__link--active") %></h2>
-      <h2 class="address__tab"><%= link(gettext("Transactions To"), to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @address.hash), class: "address__link") %></h2>
-      <h2 class="address__tab"><%= link(gettext("Transactions From"), to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @address.hash), class: "address__link") %></h2>
+      <h2 class="address__tab address__tab--active">
+        <%= link(
+              gettext("Overview"),
+              to: address_path(@conn, :show, @conn.assigns.locale, @address.hash),
+              class: "address__link address__link--active"
+            ) %>
+      </h2>
+      <h2 class="address__tab">
+        <%= link(gettext("Transactions To"), to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @address.hash), class: "address__link") %>
+      </h2>
+      <h2 class="address__tab">
+        <%= link(
+              gettext("Transactions From"),
+              to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @address.hash),
+              class: "address__link"
+            ) %>
+      </h2>
     </div>
     <div class="address__attributes">
       <dl>
         <div class="address__item">
           <dt class="address__item-key"><%= gettext "Balance" %></dt>
-          <dd class="address__item-value address__balance" title="<%= @address.hash %>"><%= format_balance(@address.balance) %> <%= gettext "Ether" %></dd>
+          <dd class="address__item-value address__balance" title="<%= @address.hash %>">
+            <%= format_balance(@address.balance) %> <%= gettext "Ether" %>
+          </dd>
         </div>
       </dl>
     </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction_from/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction_from/index.html.eex
@@ -2,18 +2,51 @@
   <div class="address__headline">
     <h1 class="address__headline-title"><%= gettext("Address %{number}", number: @conn.params["address_id"]) %></h1>
     <div class="address__pagination"><%= pagination_links @conn, @page, ["en", @conn.params["address_id"]], view_style: :bulma, first: true, distance: 1, previous: Phoenix.HTML.raw("&lsaquo;"), next: Phoenix.HTML.raw("&rsaquo;"), path: &address_transaction_to_path/5 %></div>
+    <div class="address__pagination">
+      <%= pagination_links(
+            @conn,
+            @page,
+            ["en", @conn.params["address_id"]],
+            distance: 1,
+            first: true,
+            next: Phoenix.HTML.raw("&rsaquo;"),
+            path: &address_transaction_to_path/5,
+            previous: Phoenix.HTML.raw("&lsaquo;"),
+            view_style: :bulma
+          ) %>
+    </div>
   </div>
   <div class="address__container">
     <div class="address__tabs">
-      <h2 class="address__tab"><%= link(gettext("Overview"), to: address_path(@conn, :show, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link") %></h2>
-      <h2 class="address__tab"><%= link(gettext("Transactions To"), to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link") %></h2>
-      <h2 class="address__tab address__tab--active"><%= link(gettext("Transactions From"), to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link address__link--active") %></h2>
+      <h2 class="address__tab">
+        <%= link(
+              gettext("Overview"),
+              class: "address__link",
+              to: address_path(@conn, :show, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab">
+        <%= link(
+              gettext("Transactions To"),
+              class: "address__link",
+              to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab address__tab--active">
+        <%= link(
+              gettext("Transactions From"),
+              class: "address__link address__link--active",
+              to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
     </div>
     <div class="transactions__container">
       <table class="transactions__table">
         <thead class="transactions__header">
           <tr>
-            <th class="transactions__column-header transactions__column-header--status"><span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span></th>
+            <th class="transactions__column-header transactions__column-header--status">
+              <span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span>
+            </th>
             <th class="transactions__column-header"><%= gettext "Hash" %></th>
             <th class="transactions__column-header transactions__column-header--optional"><%= gettext "Block" %></th>
             <th class="transactions__column-header"><%= gettext "Age" %></th>
@@ -25,21 +58,45 @@
         <tbody>
           <%= for transaction <- @page.entries do %>
             <tr class="transactions__row">
-              <td class="transactions__column transactions__column--status"><div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div></td>
+              <td class="transactions__column transactions__column--status">
+                <div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div>
+              </td>
               <td class="transactions__column transactions__column--hash">
-                <div class="transactions__hash"><%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--long-hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--long-hash",
+                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                      ) %>
+                </div>
               </td>
               <td class="transactions__column transactions__column--block transactions__column--optional">
-                <%= link(transaction.block.number, to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number), class: "transactions__link") %>
+                <%= link(
+                      transaction.block.number,
+                      class: "transactions__link",
+                      to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number)
+                    ) %>
               </td>
               <td class="transactions__column transactions__column--age">
                 <%= transaction.block.timestamp |> Timex.from_now %>
               </td>
               <td class="transactions__column transactions__column--from transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.from_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.from_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash)
+                      ) %>
+                </div>
               </td>
               <td class="transactions__column transactions__column--to transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.to_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.to_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash)
+                      ) %>
+                </div>
               </td>
               <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
             </tr>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction_to/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction_to/index.html.eex
@@ -1,19 +1,51 @@
 <section class="container__section block">
   <div class="address__headline">
     <h1 class="address__headline-title"><%= gettext("Address %{number}", number: @conn.params["address_id"]) %></h1>
-    <div class="address__pagination"><%= pagination_links @conn, @page, ["en", @conn.params["address_id"]], view_style: :bulma, first: true, distance: 1, previous: Phoenix.HTML.raw("&lsaquo;"), next: Phoenix.HTML.raw("&rsaquo;"), path: &address_transaction_to_path/5 %></div>
+    <div class="address__pagination">
+      <%= pagination_links(
+            @conn,
+            @page,
+            ["en", @conn.params["address_id"]],
+            distance: 1,
+            first: true,
+            next: Phoenix.HTML.raw("&rsaquo;"),
+            path: &address_transaction_to_path/5,
+            previous: Phoenix.HTML.raw("&lsaquo;"),
+            view_style: :bulma
+          ) %>
+    </div>
   </div>
   <div class="address__container">
     <div class="address__tabs">
-      <h2 class="address__tab"><%= link(gettext("Overview"), to: address_path(@conn, :show, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link") %></h2>
-      <h2 class="address__tab address__tab--active"><%= link(gettext("Transactions To"), to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link address__link--active") %></h2>
-      <h2 class="address__tab"><%= link(gettext("Transactions From"), to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]), class: "address__link") %></h2>
+      <h2 class="address__tab">
+        <%= link(
+              gettext("Overview"),
+              class: "address__link",
+              to: address_path(@conn, :show, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab address__tab--active">
+        <%= link(
+              gettext("Transactions To"),
+              class: "address__link address__link--active",
+              to: address_transaction_to_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab">
+        <%= link(
+              gettext("Transactions From"),
+              class: "address__link",
+              to: address_transaction_from_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
     </div>
     <div class="transactions__container">
       <table class="transactions__table">
         <thead class="transactions__header">
           <tr>
-            <th class="transactions__column-header transactions__column-header--status"><span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span></th>
+            <th class="transactions__column-header transactions__column-header--status">
+              <span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span>
+            </th>
             <th class="transactions__column-header"><%= gettext "Hash" %></th>
             <th class="transactions__column-header transactions__column-header--optional"><%= gettext "Block" %></th>
             <th class="transactions__column-header"><%= gettext "Age" %></th>
@@ -25,23 +57,49 @@
         <tbody>
           <%= for transaction <- @page.entries do %>
             <tr class="transactions__row">
-              <td class="transactions__column transactions__column--status"><div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div></td>
+              <td class="transactions__column transactions__column--status">
+                <div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div>
+              </td>
               <td class="transactions__column transactions__column--hash">
-                <div class="transactions__hash"><%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--long-hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--long-hash",
+                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                      ) %>
+                </div>
               </td>
               <td class="transactions__column transactions__column--block transactions__column--optional">
-                <%= link(transaction.block.number, to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number), class: "transactions__link") %>
+                <%= link(
+                      transaction.block.number,
+                      class: "transactions__link",
+                      to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number)
+                    ) %>
               </td>
               <td class="transactions__column transactions__column--age">
                 <%= transaction.block.timestamp |> Timex.from_now %>
               </td>
               <td class="transactions__column transactions__column--from transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.from_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.from_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash)
+                      ) %>
+                </div>
               </td>
               <td class="transactions__column transactions__column--to transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.to_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.to_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash)
+                      ) %>
+                </div>
               </td>
-              <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
+              <td class="transactions__column transactions__column--value">
+                <%= value(transaction) %> <%= gettext "Ether" %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/apps/explorer_web/lib/explorer_web/templates/block/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block/index.html.eex
@@ -1,7 +1,25 @@
 <section class="container__section">
   <div class="blocks__headline">
-    <h1 class="blocks__headline-title"><%= gettext("Showing #%{start_block} to #%{end_block}", start_block: List.first(@blocks.entries).number, end_block: List.last(@blocks.entries).number) %></h1>
-    <div class="blocks__pagination"><%= pagination_links @conn, @blocks, ["en"], view_style: :bulma, first: true, distance: 1, previous: Phoenix.HTML.raw("&lsaquo;"), next: Phoenix.HTML.raw("&rsaquo;"), path: &block_path/4 %></div>
+    <h1 class="blocks__headline-title">
+      <%= gettext(
+            "Showing #%{start_block} to #%{end_block}",
+            start_block: List.first(@blocks.entries).number,
+            end_block: List.last(@blocks.entries).number
+          ) %>
+    </h1>
+    <div class="blocks__pagination">
+      <%= pagination_links(
+            @conn,
+            @blocks,
+            ["en"],
+            distance: 1,
+            first: true,
+            next: Phoenix.HTML.raw("&rsaquo;"),
+            path: &block_path/4,
+            previous: Phoenix.HTML.raw("&lsaquo;"),
+            view_style: :bulma
+          ) %>
+    </div>
   </div>
   <div class="blocks">
     <div class="blocks__container">
@@ -19,12 +37,34 @@
         <tbody>
           <%= for block <- @blocks do %>
             <tr class="blocks__row">
-              <td class="blocks__column blocks__column--height"><%= link(block.number, to: block_path(@conn, :show, @conn.assigns.locale, block.number), class: "blocks__link") %></td>
+              <td class="blocks__column blocks__column--height">
+                <%= link(
+                      block.number,
+                      class: "blocks__link",
+                      to: block_path(@conn, :show, @conn.assigns.locale, block.number)
+                    ) %>
+              </td>
               <td class="transactions__column transactions__column--age"><%= block.timestamp |> Timex.from_now  %></td>
-              <td class="blocks__column blocks__column--transactions-count"><%= gettext("%{count} transactions", count: block.transactions |> Enum.count) %></td>
-              <td class="blocks__column blocks__column--optional blocks__column--gas-used"><%= block.gas_used |> Cldr.Number.to_string! %> (<%= block.gas_used / block.gas_limit |> Cldr.Number.to_string!(format: "#.#%") %>)</td>
-              <td class="blocks__column blocks__column--optional blocks__column--gas-limit"><%= block.gas_limit |> Cldr.Number.to_string! %></td>
-              <td class="blocks__column blocks__column--optional blocks__column--gas-price"><%= block.transactions |> Enum.map(fn(transaction) -> Decimal.to_float(Decimal.div(Decimal.new(transaction.gas_price), Decimal.new(1_000_000_000))) end) |> Math.Enum.mean || 0 |> Cldr.Number.to_string! %> Gwei</td>
+              <td class="blocks__column blocks__column--transactions-count">
+                <%= gettext("%{count} transactions", count: block.transactions |> Enum.count) %>
+              </td>
+              <td class="blocks__column blocks__column--optional blocks__column--gas-used">
+                <%= block.gas_used |> Cldr.Number.to_string! %> (<%=
+                block.gas_used / block.gas_limit |> Cldr.Number.to_string!(format: "#.#%")
+                %>)
+              </td>
+              <td class="blocks__column blocks__column--optional blocks__column--gas-limit">
+                <%= block.gas_limit |> Cldr.Number.to_string! %>
+              </td>
+              <td class="blocks__column blocks__column--optional blocks__column--gas-price">
+                <%= block.transactions
+                    |> Enum.map(fn(transaction) ->
+                         Decimal.to_float(Decimal.div(Decimal.new(transaction.gas_price), Decimal.new(1_000_000_000)))
+                       end)
+                    |> Math.Enum.mean()
+                    |> Kernel.||(0)
+                    |> Cldr.Number.to_string! %> Gwei
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/apps/explorer_web/lib/explorer_web/templates/block/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block/show.html.eex
@@ -4,8 +4,20 @@
   </div>
   <div class="block__container">
     <div class="block__tabs">
-      <h2 class="block__tab block__tab--active"><%= link(gettext("Overview"), to: block_path(@conn, :show, @conn.assigns.locale, @block.number), class: "block__link block__link--active") %></h2>
-      <h2 class="block__tab"><%= link(gettext("Transactions"), to: block_transaction_path(@conn, :index, @conn.assigns.locale, @block.number), class: "block__link") %></h2>
+      <h2 class="block__tab block__tab--active">
+        <%= link(
+              gettext("Overview"),
+              class: "block__link block__link--active",
+              to: block_path(@conn, :show, @conn.assigns.locale, @block.number)
+            ) %>
+      </h2>
+      <h2 class="block__tab">
+        <%= link(
+              gettext("Transactions"),
+              class: "block__link",
+              to: block_transaction_path(@conn, :index, @conn.assigns.locale, @block.number)
+            ) %>
+      </h2>
     </div>
     <div class="block__attributes">
       <div class="block__column">
@@ -20,7 +32,9 @@
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Transactions" %></dt>
-            <dd class="block__item-value"><%= gettext "%{count} transactions in this block", count: @block_transaction_count %></dd>
+            <dd class="block__item-value">
+              <%= gettext "%{count} transactions in this block", count: @block_transaction_count %>
+            </dd>
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Hash" %></dt>
@@ -28,7 +42,12 @@
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Parent Hash" %></dt>
-            <dd class="block__item-value" title="<%= @block.parent_hash %>"><%= link(@block.parent_hash, to: block_path(@conn, :show, @conn.assigns.locale, @block.number - 1), class: "block__link") %>
+            <dd class="block__item-value" title="<%= @block.parent_hash %>">
+              <%= link(
+                    @block.parent_hash,
+                    class: "block__link",
+                    to: block_path(@conn, :show, @conn.assigns.locale, @block.number - 1)
+                  ) %>
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Miner" %></dt>
@@ -36,7 +55,9 @@
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Difficulty" %></dt>
-            <dd class="block__item-value" title="<%= @block.difficulty %>"><%= @block.difficulty |> Cldr.Number.to_string! %></dd>
+            <dd class="block__item-value" title="<%= @block.difficulty %>">
+              <%= @block.difficulty |> Cldr.Number.to_string! %>
+            </dd>
           </div>
         </dl>
       </div>
@@ -44,7 +65,9 @@
         <dl>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Total Difficulty" %></dt>
-            <dd class="block__item-value" title="<%= @block.total_difficulty %>"><%= @block.total_difficulty |> Cldr.Number.to_string! %></dd>
+            <dd class="block__item-value" title="<%= @block.total_difficulty %>">
+              <%= @block.total_difficulty |> Cldr.Number.to_string! %>
+            </dd>
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Size" %></dt>
@@ -52,7 +75,11 @@
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Gas Used" %></dt>
-            <dd class="block__item-value"><%= @block.gas_used |> Cldr.Number.to_string! %> (<%= @block.gas_used / @block.gas_limit |> Cldr.Number.to_string!(format: "#.#%") %>)</dd>
+            <dd class="block__item-value">
+              <%= @block.gas_used
+                  |> Cldr.Number.to_string! %> (<%= (@block.gas_used / @block.gas_limit)
+                                                    |> Cldr.Number.to_string!(format: "#.#%") %>)
+            </dd>
           </div>
           <div class="block__item">
             <dt class="block__item-key"><%= gettext "Gas Limit" %></dt>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -1,18 +1,43 @@
 <section class="container__section block">
   <div class="blocks__headline">
     <h1 class="blocks__headline-title"><%= gettext("Showing #%{number}", number: @conn.params["block_id"]) %></h1>
-    <div class="blocks__pagination"><%= pagination_links @conn, @page, ["en", @conn.params["block_id"]], view_style: :bulma, first: true, distance: 1, previous: Phoenix.HTML.raw("&lsaquo;"), next: Phoenix.HTML.raw("&rsaquo;"), path: &block_transaction_path/5 %></div>
+    <div class="blocks__pagination">
+      <%= pagination_links(
+            @conn,
+            @page,
+            ["en", @conn.params["block_id"]],
+            distance: 1,
+            first: true,
+            next: Phoenix.HTML.raw("&rsaquo;"),
+            path: &block_transaction_path/5,
+            previous: Phoenix.HTML.raw("&lsaquo;"),
+            view_style: :bulma
+          ) %></div>
   </div>
   <div class="block__container">
     <div class="block__tabs">
-      <h2 class="block__tab"><%= link(gettext("Overview"), to: block_path(@conn, :show, @conn.assigns.locale, @conn.params["block_id"]), class: "block__link") %></h2>
-      <h2 class="block__tab block__tab--active"><%= link(gettext("Transactions"), to: block_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["block_id"]), class: "block__link block__link--active") %></h2>
+      <h2 class="block__tab">
+        <%= link(
+              gettext("Overview"),
+              class: "block__link",
+              to: block_path(@conn, :show, @conn.assigns.locale, @conn.params["block_id"])
+            ) %>
+      </h2>
+      <h2 class="block__tab block__tab--active">
+        <%= link(
+              gettext("Transactions"),
+              class: "block__link block__link--active",
+              to: block_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["block_id"])
+            ) %>
+      </h2>
     </div>
     <div class="transactions__container">
       <table class="transactions__table">
         <thead class="transactions__header">
           <tr>
-            <th class="transactions__column-header transactions__column-header--status"><span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span></th>
+            <th class="transactions__column-header transactions__column-header--status">
+              <span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span>
+            </th>
             <th class="transactions__column-header"><%= gettext "Hash" %></th>
             <th class="transactions__column-header transactions__column-header--optional"><%= gettext "Block" %></th>
             <th class="transactions__column-header"><%= gettext "Age" %></th>
@@ -24,23 +49,46 @@
         <tbody>
           <%= for transaction <- @page.entries do %>
             <tr class="transactions__row">
-              <td class="transactions__column transactions__column--status"><div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div></td>
+              <td class="transactions__column transactions__column--status">
+                <div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div>
+              </td>
               <td class="transactions__column transactions__column--hash">
-                <div class="transactions__hash"><%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--long-hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--long-hash",
+                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                      ) %></div>
               </td>
               <td class="transactions__column transactions__column--block transactions__column--optional">
-                <%= link(transaction.block.number, to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number), class: "transactions__link") %>
+                <%= link(
+                      transaction.block.number,
+                      class: "transactions__link",
+                      to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number)
+                    ) %>
               </td>
               <td class="transactions__column transactions__column--age">
                 <%= transaction.block.timestamp |> Timex.from_now %>
               </td>
               <td class="transactions__column transactions__column--from transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.from_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.from_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash)
+                      ) %></div>
               </td>
               <td class="transactions__column transactions__column--to transactions__column--optional">
-                <div class="transactions__hash"><%= link(transaction.to_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                <div class="transactions__hash">
+                  <%= link(
+                        transaction.to_address.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash)
+                      ) %></div>
               </td>
-              <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
+              <td class="transactions__column transactions__column--value">
+                <%= value(transaction) %> <%= gettext "Ether" %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
@@ -36,12 +36,16 @@
       <div class="chain__container chain__container--secondary">
         <img class="chain__image" src="<%= static_path(@conn, "/images/average_time.svg") %>" />
         <div class="chain__title"><%= gettext("Average Block Time") %></div>
-        <div class="chain__title chain__title--data"><%= @chain.average_time |> Timex.format_duration(:humanized) %></div>
+        <div class="chain__title chain__title--data">
+          <%= @chain.average_time |> Timex.format_duration(:humanized) %>
+        </div>
       </div>
       <div class="chain__container">
         <img class="chain__image" src="<%= static_path(@conn, "/images/transactions.svg") %>" />
         <div class="chain__title"><%= gettext("Transactions") %></div>
-        <div class="chain__title chain__title--data"><%= gettext("%{count} per day", count: Cldr.Number.to_string!(@chain.transaction_count)) %></div>
+        <div class="chain__title chain__title--data">
+          <%= gettext("%{count} per day", count: Cldr.Number.to_string!(@chain.transaction_count)) %>
+        </div>
       </div>
     </div>
   </section>
@@ -66,9 +70,17 @@
           <tbody>
             <%= for block <- @chain.blocks do %>
               <tr class="blocks__row">
-                <td class="blocks__column blocks__column--height"><%= link(block.number, to: block_path(@conn, :show, @conn.assigns.locale, block.number), class: "blocks__link") %></td>
+                <td class="blocks__column blocks__column--height">
+                  <%= link(
+                        block.number,
+                        class: "blocks__link",
+                        to: block_path(@conn, :show, @conn.assigns.locale, block.number)
+                      ) %>
+                </td>
                 <td class="blocks__column blocks__column--age"><%= block.timestamp |> Timex.from_now %></td>
-                <td class="blocks__column blocks__column--transactions-count"><%= block.transactions |> Enum.count %></td>
+                <td class="blocks__column blocks__column--transactions-count">
+                  <%= block.transactions |> Enum.count %>
+                </td>
                 <td class="blocks__column blocks__column--gas-used"><%= block.gas_used |> Cldr.Number.to_string! %></td>
               </tr>
             <% end %>
@@ -95,12 +107,26 @@
               <tr class="transactions__row">
                 <td class="transactions__column transactions__column--hash">
                   <div class="transactions__hash-container" title="<%= transaction.hash %>">
-                    <%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %>
+                    <%= link(
+                          transaction.hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--hash",
+                          to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                        ) %>
                   </div>
                 </td>
-                <td class="transactions__column transactions__column--block"><%= link(transaction.block.number, to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number), class: "transactions__link") %></td>
-                <td class="transactions__column transactions__column--age transactions__column--optional"><%= transaction.block.timestamp |> Timex.from_now() %></td>
-                <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
+                <td class="transactions__column transactions__column--block">
+                  <%= link(
+                        transaction.block.number,
+                        class: "transactions__link",
+                        to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number)
+                      ) %>
+                </td>
+                <td class="transactions__column transactions__column--age transactions__column--optional">
+                  <%= transaction.block.timestamp |> Timex.from_now() %>
+                </td>
+                <td class="transactions__column transactions__column--value">
+                  <%= value(transaction) %> <%= gettext "Ether" %>
+                </td>
               </tr>
             <% end %>
           </tbody>

--- a/apps/explorer_web/lib/explorer_web/templates/layout/_header.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/layout/_header.html.eex
@@ -7,10 +7,19 @@
         </a>
       </td>
       <td class="header__cell header__cell--search">
-        <%= form_for @conn, chain_path(@conn, :search, Gettext.get_locale), [class: "header__cell--search-form", method: :get, enforce_utf8: false], fn f -> %>
+        <%= form_for(
+              @conn,
+              chain_path(@conn, :search, Gettext.get_locale),
+              [class: "header__cell--search-form", method: :get, enforce_utf8: false],
+              fn f -> %>
           <%= img_tag :svg, src: static_path(@conn, "/images/mgi.svg"), class: "header__cell--search-glass" %>
-          <%= search_input f, :q, class: 'header__cell--search-input', placeholder: gettext "Search by address, transaction hash, or block number" %>
-        <% end %>
+          <%= search_input(
+                f,
+                :q,
+                class: 'header__cell--search-input',
+                placeholder: gettext("Search by address, transaction hash, or block number")
+              ) %>
+        <% end) %>
       </td>
       <td class="header__cell header__cell--links" align="right">
         <a href="<%= block_path(@conn, :index, Gettext.get_locale) %>" class="header__link">

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -1,18 +1,36 @@
 <section class="container__section">
   <section class="container__subsection">
     <div class="transactions__headline">
-      <h1 class="transactions__headline-title"><%= gettext("Showing %{count} Pending Transactions", count: @transaction_count) %></h1>
+      <h1 class="transactions__headline-title">
+        <%= gettext("Showing %{count} Pending Transactions", count: @transaction_count) %>
+      </h1>
     </div>
     <div class="transactions">
       <div class="transactions__tabs">
-        <h2 class="transactions__tab"><%= link(gettext("Transactions"), to: transaction_path(@conn, :index, @conn.assigns.locale), class: "transactions__tab-link") %></h2>
-        <h2 class="transactions__tab transactions__tab--active"><%= link(gettext("Pending"), to: pending_transaction_path(@conn, :index, @conn.assigns.locale), class: "transactions__tab-link transactions__tab-link--active") %></h2>
+        <h2 class="transactions__tab">
+          <%= link(
+                gettext("Transactions"),
+                class: "transactions__tab-link",
+                to: transaction_path(@conn, :index, @conn.assigns.locale)
+              ) %>
+        </h2>
+        <h2 class="transactions__tab transactions__tab--active">
+          <%= link(
+                gettext("Pending"),
+                class: "transactions__tab-link transactions__tab-link--active",
+                to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+              ) %>
+        </h2>
       </div>
       <div class="transactions__container">
         <table class="transactions__table">
           <thead class="transactions__header">
             <tr>
-              <th class="transactions__column-header transactions__column-header--status"><span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span></th>
+              <th class="transactions__column-header transactions__column-header--status">
+                <span class="transactions__column-title transactions__column-title--status">
+                  <%= gettext "Status" %>
+                </span>
+              </th>
               <th class="transactions__column-header"><%= gettext "Hash" %></th>
               <th class="transactions__column-header"><%= gettext "Last Seen" %></th>
               <th class="transactions__column-header transactions__column-header--optional"><%= gettext "From" %></th>
@@ -23,15 +41,25 @@
           <tbody>
             <%= for transaction <- @transactions do %>
               <tr class="transactions__row">
-                <td class="transactions__column transactions__column--status"><div class="transactions__dot transactions__dot--pending"></div></td>
+                <td class="transactions__column transactions__column--status">
+                  <div class="transactions__dot transactions__dot--pending"></div>
+                </td>
                 <td class="transactions__column transactions__column--hash">
-                  <%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--long-hash") %>
+                  <%= link(
+                        transaction.hash,
+                        class: "transactions__link transactions__link--truncated transactions__link--long-hash",
+                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                      ) %>
                 </td>
                 <td class="transactions__column transactions__column--last-seen"><%= last_seen(transaction) %></td>
                 <td class="transactions__column transactions__column--optional transactions__column--from-address">
                   <% to_address_hash = to_address_hash(transaction) %>
                   <%= if to_address_hash do %>
-                    <%= link(to_address_hash, to: address_path(@conn, :show, @conn.assigns.locale, to_address_hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %>
+                    <%= link(
+                          to_address_hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--hash",
+                          to: address_path(@conn, :show, @conn.assigns.locale, to_address_hash)
+                        ) %>
                   <% else %>
                     <%= gettext "Pending" %>
                   <% end %>
@@ -39,17 +67,32 @@
                 <td class="transactions__column transactions__column--optional transactions__column--to-address">
                   <% from_address_hash = from_address_hash(transaction) %>
                   <%= if from_address_hash do %>
-                    <%= link(from_address_hash, to: address_path(@conn, :show, @conn.assigns.locale, from_address_hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %>
+                    <%= link(
+                          from_address_hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--hash",
+                          to: address_path(@conn, :show, @conn.assigns.locale, from_address_hash)
+                        ) %>
                   <% else %>
                     <%= gettext "Pending" %>
                   <% end %>
                 </td>
-                <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
+                <td class="transactions__column transactions__column--value">
+                  <%= value(transaction) %> <%= gettext "Ether" %>
+                </td>
               </tr>
             <% end %>
           </tbody>
         </table>
-        <%= link(gettext("Next Page"), to: pending_transaction_path(@conn, :index, @conn.assigns.locale, %{"last_seen" => @last_seen_transaction_id}), class: "transactions__link transactions__link--next-page") %>
+        <%= link(
+              gettext("Next Page"),
+              class: "transactions__link transactions__link--next-page",
+              to: pending_transaction_path(
+                @conn,
+                :index,
+                @conn.assigns.locale,
+                %{"last_seen" => @last_seen_transaction_id}
+              )
+            ) %>
       </div>
     </div>
   </section>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -1,18 +1,36 @@
 <section class="container__section">
   <section class="container__subsection">
     <div class="transactions__headline">
-      <h1 class="transactions__headline-title"><%= gettext("Showing %{count} Transactions", count: @transactions.total_entries) %></h1>
+      <h1 class="transactions__headline-title">
+        <%= gettext("Showing %{count} Transactions", count: @transactions.total_entries) %>
+      </h1>
     </div>
     <div class="transactions">
       <div class="transactions__tabs">
-        <h2 class="transactions__tab transactions__tab--active"><%= link(gettext("Transactions"), to: transaction_path(@conn, :index, @conn.assigns.locale), class: "transactions__tab-link transactions__tab-link--active") %></h2>
-        <h2 class="transactions__tab"><%= link(gettext("Pending"), to: pending_transaction_path(@conn, :index, @conn.assigns.locale), class: "transactions__tab-link") %></h2>
+        <h2 class="transactions__tab transactions__tab--active">
+          <%= link(
+                gettext("Transactions"),
+                class: "transactions__tab-link transactions__tab-link--active",
+                to: transaction_path(@conn, :index, @conn.assigns.locale)
+              ) %>
+        </h2>
+        <h2 class="transactions__tab">
+          <%= link(
+                gettext("Pending"),
+                class: "transactions__tab-link",
+                to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+              ) %>
+        </h2>
       </div>
       <div class="transactions__container">
         <table class="transactions__table">
           <thead class="transactions__header">
             <tr>
-              <th class="transactions__column-header transactions__column-header--status"><span class="transactions__column-title transactions__column-title--status"><%= gettext "Status" %></span></th>
+              <th class="transactions__column-header transactions__column-header--status">
+                <span class="transactions__column-title transactions__column-title--status">
+                  <%= gettext "Status" %>
+                </span>
+              </th>
               <th class="transactions__column-header"><%= gettext "Hash" %></th>
               <th class="transactions__column-header transactions__column-header--optional"><%= gettext "Block" %></th>
               <th class="transactions__column-header"><%= gettext "Age" %></th>
@@ -24,28 +42,56 @@
           <tbody>
             <%= for transaction <- @transactions.entries do %>
               <tr class="transactions__row">
-                <td class="transactions__column transactions__column--status"><div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div></td>
+                <td class="transactions__column transactions__column--status">
+                  <div class="transactions__dot transactions__dot--<%= status(transaction) %>"></div>
+                </td>
                 <td class="transactions__column transactions__column--hash">
-                  <div class="transactions__hash"><%= link(transaction.hash, to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash), class: "transactions__link transactions__link--truncated transactions__link--long-hash") %></div>
+                  <div class="transactions__hash">
+                    <%= link(
+                          transaction.hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--long-hash",
+                          to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                        ) %>
+                   </div>
                 </td>
                 <td class="transactions__column transactions__column--block transactions__column--optional">
-                  <%= link(transaction.block.number, to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number), class: "transactions__link") %>
+                  <%= link(
+                        transaction.block.number,
+                        class: "transactions__link",
+                        to: block_path(@conn, :show, @conn.assigns.locale, transaction.block.number)
+                      ) %>
                 </td>
                 <td class="transactions__column transactions__column--age">
                   <%= transaction.block.timestamp |> Timex.from_now %>
                 </td>
                 <td class="transactions__column transactions__column--from transactions__column--optional">
-                  <div class="transactions__hash"><%= link(transaction.from_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                  <div class="transactions__hash">
+                    <%= link(
+                          transaction.from_address.hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--hash",
+                          to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash)
+                        ) %></div>
                 </td>
                 <td class="transactions__column transactions__column--to transactions__column--optional">
-                  <div class="transactions__hash"><%= link(transaction.to_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash), class: "transactions__link transactions__link--truncated transactions__link--hash") %></div>
+                  <div class="transactions__hash">
+                    <%= link(
+                          transaction.to_address.hash,
+                          class: "transactions__link transactions__link--truncated transactions__link--hash",
+                          to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash)
+                        ) %></div>
                 </td>
-                <td class="transactions__column transactions__column--value"><%= value(transaction) %> <%= gettext "Ether" %></td>
+                <td class="transactions__column transactions__column--value">
+                  <%= value(transaction) %> <%= gettext "Ether" %>
+                </td>
               </tr>
             <% end %>
           </tbody>
         </table>
-        <%= link(gettext("Next Page"), to: transaction_path(@conn, :index, @conn.assigns.locale, %{"last_seen" => @transactions.last_seen}), class: "transactions__link transactions__link--next-page") %>
+        <%= link(
+              gettext("Next Page"),
+              class: "transactions__link transactions__link--next-page",
+              to: transaction_path(@conn, :index, @conn.assigns.locale, %{"last_seen" => @transactions.last_seen})
+            ) %>
       </div>
     </div>
   </section>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -21,7 +21,11 @@
             <span class="transaction__item--primary">
               <% block = @transaction.block %>
               <%= if block do %>
-                <%= link(block.number, to: block_path(@conn, :show, @conn.assigns.locale, block.number), class: "transaction__link") %>
+                <%= link(
+                      block.number,
+                      class: "transaction__link",
+                      to: block_path(@conn, :show, @conn.assigns.locale, block.number)
+                    ) %>
               <% end %>
             </span>
             <span class="transaction__item--secondary">
@@ -31,7 +35,9 @@
         </div>
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Age" %></dt>
-          <dd class="transaction__item-value" title="<%= formatted_timestamp(@transaction) %>"><%= formatted_age(@transaction) %></dd>
+          <dd class="transaction__item-value" title="<%= formatted_timestamp(@transaction) %>">
+            <%= formatted_age(@transaction) %>
+          </dd>
         </div>
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Value" %></dt>
@@ -41,7 +47,11 @@
           <dt class="transaction__item-key"><%= gettext "From" %></dt>
           <dd class="transaction__item-value">
             <%= if @transaction.from_address do %>
-              <%= link(@transaction.from_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, @transaction.from_address.hash), class: "transaction__link") %>
+              <%= link(
+                    @transaction.from_address.hash,
+                    class: "transaction__link",
+                    to: address_path(@conn, :show, @conn.assigns.locale, @transaction.from_address.hash)
+                  ) %>
             <% else %>
               <%= gettext "Pending" %>
             <% end %>
@@ -51,7 +61,11 @@
           <dt class="transaction__item-key"><%= gettext "To" %></dt>
           <dd class="transaction__item-value">
             <%= if @transaction.to_address do %>
-              <%= link(@transaction.to_address.hash, to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address.hash), class: "transaction__link") %>
+              <%= link(
+                    @transaction.to_address.hash,
+                    class: "transaction__link",
+                    to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address.hash)
+                  ) %>
             <% else %>
               <%= gettext "Pending" %>
             <% end %>
@@ -81,7 +95,10 @@
         </div>
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Gas Price" %></dt>
-          <dd class="transaction__item-value"><%= gas_price(@transaction, :wei) %> <%= gettext("Wei") %> (<%= gas_price(@transaction, :gwei) %> <%= gettext "Gwei" %>)</dd>
+          <dd class="transaction__item-value">
+            <%= gas_price(@transaction, :wei) %> <%= gettext("Wei") %>
+              (<%= gas_price(@transaction, :gwei) %> <%= gettext "Gwei" %>)
+          </dd>
         </div>
         <div class="transaction__item">
           <dt class="transaction__item-key"><%= gettext "Cumulative Gas Used" %></dt>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
@@ -3,8 +3,20 @@
 
   <div class="transaction__container">
     <div class="transaction__tabs">
-      <h2 class="transaction__tab transaction__tab--active"><%= link(gettext("Internal Transactions"), to: transaction_path(@conn, :show, @conn.assigns.locale, @transaction.hash), class: "transaction__link transaction__link--active") %></h2>
-      <h2 class="transaction__tab"><%= link(gettext("Logs"), to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction.hash), class: "transaction__link") %></h2>
+      <h2 class="transaction__tab transaction__tab--active">
+        <%= link(
+              gettext("Internal Transactions"),
+              class: "transaction__link transaction__link--active",
+              to: transaction_path(@conn, :show, @conn.assigns.locale, @transaction.hash)
+            ) %>
+      </h2>
+      <h2 class="transaction__tab">
+        <%= link(
+              gettext("Logs"),
+              class: "transaction__link",
+              to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction.hash)
+            ) %>
+      </h2>
     </div>
     <div class="internal-transaction__container">
       <%= if length(@internal_transactions) > 0 do %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_log/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_log/index.html.eex
@@ -3,8 +3,20 @@
 
   <div class="transaction-log">
     <div class="transaction-log__tabs">
-      <h2 class="transaction__tab"><%= link(gettext("Internal Transactions"), to: transaction_path(@conn, :show, @conn.assigns.locale, @transaction.hash), class: "transaction__link") %></h2>
-      <h2 class="transaction__tab transaction__tab--active"><%= link(gettext("Logs"), to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction.hash), class: "transaction__link transaction__link--active") %></h2>
+      <h2 class="transaction__tab">
+        <%= link(
+              gettext("Internal Transactions"),
+              class: "transaction__link",
+              to: transaction_path(@conn, :show, @conn.assigns.locale, @transaction.hash)
+            ) %>
+      </h2>
+      <h2 class="transaction__tab transaction__tab--active">
+        <%= link(
+              gettext("Logs"),
+              class: "transaction__link transaction__link--active",
+              to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction.hash)
+            ) %>
+      </h2>
     </div>
 
     <div class="transaction-log__container">
@@ -17,7 +29,13 @@
           <%= for log <- @logs.entries do %>
             <tgroup>
               <tr>
-                <td><%= link(log.address.hash, to: address_path(@conn, :show, @conn.assigns.locale, log.address.hash), class: "transaction-log__link") %></td>
+                <td>
+                  <%= link(
+                        log.address.hash,
+                        class: "transaction-log__link",
+                        to: address_path(@conn, :show, @conn.assigns.locale, log.address.hash)
+                      ) %>
+                </td>
                 <td><%= log.first_topic %></td>
               </tr>
               <% unless is_nil(log.second_topic) do %>

--- a/apps/explorer_web/mix.exs
+++ b/apps/explorer_web/mix.exs
@@ -46,8 +46,7 @@ defmodule ExplorerWeb.Mixfile do
   defp elixirc_paths, do: ["lib"]
 
   # Specifies extra applications to start per environment
-  defp extra_applications(:prod),
-    do: [:phoenix_pubsub_redis, :exq, :exq_ui | extra_applications()]
+  defp extra_applications(:prod), do: [:phoenix_pubsub_redis, :exq, :exq_ui | extra_applications()]
 
   defp extra_applications(:dev), do: [:exq, :exq_ui | extra_applications()]
   defp extra_applications(_), do: extra_applications()

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,25 +1,25 @@
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:19
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:19
-#: lib/explorer_web/templates/block/index.html.eex:12
-#: lib/explorer_web/templates/block_transaction/index.html.eex:18
-#: lib/explorer_web/templates/chain/show.html.eex:61
-#: lib/explorer_web/templates/chain/show.html.eex:89
-#: lib/explorer_web/templates/transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:52
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:51
+#: lib/explorer_web/templates/block/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:43
+#: lib/explorer_web/templates/chain/show.html.eex:65
+#: lib/explorer_web/templates/chain/show.html.eex:101
+#: lib/explorer_web/templates/transaction/index.html.eex:36
+#: lib/explorer_web/templates/transaction/overview.html.eex:37
 msgid "Age"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:18
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:18
-#: lib/explorer_web/templates/block_transaction/index.html.eex:17
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:51
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:50
+#: lib/explorer_web/templates/block_transaction/index.html.eex:42
 #: lib/explorer_web/templates/chain/show.html.eex:28
-#: lib/explorer_web/templates/chain/show.html.eex:88
-#: lib/explorer_web/templates/transaction/index.html.eex:17
+#: lib/explorer_web/templates/chain/show.html.eex:100
+#: lib/explorer_web/templates/transaction/index.html.eex:35
 msgid "Block"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:54
-#: lib/explorer_web/templates/layout/_header.html.eex:18
+#: lib/explorer_web/templates/chain/show.html.eex:58
+#: lib/explorer_web/templates/layout/_header.html.eex:27
 msgid "Blocks"
 msgstr ""
 
@@ -27,24 +27,24 @@ msgstr ""
 msgid "Copyright %{year} POA"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:14
-#: lib/explorer_web/templates/block/show.html.eex:54
-#: lib/explorer_web/templates/chain/show.html.eex:63
+#: lib/explorer_web/templates/block/index.html.eex:32
+#: lib/explorer_web/templates/block/show.html.eex:77
+#: lib/explorer_web/templates/chain/show.html.eex:67
 msgid "Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:17
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:17
-#: lib/explorer_web/templates/block/show.html.eex:26
-#: lib/explorer_web/templates/block_transaction/index.html.eex:16
-#: lib/explorer_web/templates/chain/show.html.eex:87
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:16
-#: lib/explorer_web/templates/transaction/index.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:50
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:49
+#: lib/explorer_web/templates/block/show.html.eex:40
+#: lib/explorer_web/templates/block_transaction/index.html.eex:41
+#: lib/explorer_web/templates/chain/show.html.eex:99
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:34
+#: lib/explorer_web/templates/transaction/index.html.eex:34
 msgid "Hash"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:11
-#: lib/explorer_web/templates/chain/show.html.eex:60
+#: lib/explorer_web/templates/block/index.html.eex:29
+#: lib/explorer_web/templates/chain/show.html.eex:64
 msgid "Height"
 msgstr ""
 
@@ -53,26 +53,26 @@ msgstr ""
 msgid "POA Network Explorer"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:13
-#: lib/explorer_web/templates/block/show.html.eex:8
-#: lib/explorer_web/templates/block/show.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:9
-#: lib/explorer_web/templates/chain/show.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:62
-#: lib/explorer_web/templates/chain/show.html.eex:81
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:8
-#: lib/explorer_web/templates/transaction/index.html.eex:8
+#: lib/explorer_web/templates/block/index.html.eex:31
+#: lib/explorer_web/templates/block/show.html.eex:16
+#: lib/explorer_web/templates/block/show.html.eex:34
+#: lib/explorer_web/templates/block_transaction/index.html.eex:28
+#: lib/explorer_web/templates/chain/show.html.eex:45
+#: lib/explorer_web/templates/chain/show.html.eex:66
+#: lib/explorer_web/templates/chain/show.html.eex:93
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:12
+#: lib/explorer_web/templates/transaction/index.html.eex:12
 msgid "Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:22
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:21
-#: lib/explorer_web/templates/chain/show.html.eex:90
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:20
-#: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:37
-#: lib/explorer_web/templates/transaction/show.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:55
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:54
+#: lib/explorer_web/templates/block_transaction/index.html.eex:46
+#: lib/explorer_web/templates/chain/show.html.eex:102
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:38
+#: lib/explorer_web/templates/transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/overview.html.eex:43
+#: lib/explorer_web/templates/transaction/show.html.eex:28
 msgid "Value"
 msgstr ""
 
@@ -80,43 +80,43 @@ msgstr ""
 msgid "Block #%{number} Details"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:38
+#: lib/explorer_web/templates/block/show.html.eex:57
 msgid "Difficulty"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:15
-#: lib/explorer_web/templates/block/show.html.eex:58
-#: lib/explorer_web/templates/transaction/overview.html.eex:79
-#: lib/explorer_web/templates/transaction/show.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:33
+#: lib/explorer_web/templates/block/show.html.eex:85
+#: lib/explorer_web/templates/transaction/overview.html.eex:93
+#: lib/explorer_web/templates/transaction/show.html.eex:29
 msgid "Gas Limit"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:34
+#: lib/explorer_web/templates/block/show.html.eex:53
 msgid "Miner"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:62
-#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/block/show.html.eex:89
+#: lib/explorer_web/templates/transaction/overview.html.eex:75
 msgid "Nonce"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:14
+#: lib/explorer_web/templates/block/show.html.eex:26
 msgid "Number"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:30
+#: lib/explorer_web/templates/block/show.html.eex:44
 msgid "Parent Hash"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:50
+#: lib/explorer_web/templates/block/show.html.eex:73
 msgid "Size"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:18
+#: lib/explorer_web/templates/block/show.html.eex:30
 msgid "Timestamp"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:46
+#: lib/explorer_web/templates/block/show.html.eex:67
 msgid "Total Difficulty"
 msgstr ""
 
@@ -128,54 +128,54 @@ msgstr ""
 msgid "Transaction Details"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:87
+#: lib/explorer_web/templates/transaction/overview.html.eex:104
 msgid "Cumulative Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:14
-#: lib/explorer_web/templates/block/index.html.eex:15
-#: lib/explorer_web/templates/transaction/overview.html.eex:80
-#: lib/explorer_web/templates/transaction/show.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:32
+#: lib/explorer_web/templates/block/index.html.eex:33
+#: lib/explorer_web/templates/transaction/overview.html.eex:94
+#: lib/explorer_web/templates/transaction/show.html.eex:29
 msgid "Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:16
-#: lib/explorer_web/templates/transaction/overview.html.eex:83
+#: lib/explorer_web/templates/block/index.html.eex:34
+#: lib/explorer_web/templates/transaction/overview.html.eex:97
 msgid "Gas Price"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:91
+#: lib/explorer_web/templates/transaction/overview.html.eex:108
 msgid "Input"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:28
+#: lib/explorer_web/templates/transaction/overview.html.eex:32
 msgid "%{confirmations} block confirmations"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:23
+#: lib/explorer_web/templates/block/show.html.eex:36
 msgid "%{count} transactions in this block"
 msgstr ""
 
 #: lib/explorer_web/templates/address/show.html.eex:3
-#: lib/explorer_web/templates/transaction_log/index.html.eex:14
+#: lib/explorer_web/templates/transaction_log/index.html.eex:26
 msgid "Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:20
-#: lib/explorer_web/templates/block_transaction/index.html.eex:19
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction/index.html.eex:19
-#: lib/explorer_web/templates/transaction/overview.html.eex:41
-#: lib/explorer_web/templates/transaction/show.html.eex:14
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:53
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:52
+#: lib/explorer_web/templates/block_transaction/index.html.eex:44
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:36
+#: lib/explorer_web/templates/transaction/index.html.eex:37
+#: lib/explorer_web/templates/transaction/overview.html.eex:47
+#: lib/explorer_web/templates/transaction/show.html.eex:26
 msgid "From"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:8
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:8
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:8
-#: lib/explorer_web/templates/block/show.html.eex:7
-#: lib/explorer_web/templates/block_transaction/index.html.eex:8
+#: lib/explorer_web/templates/address/show.html.eex:10
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:23
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:22
+#: lib/explorer_web/templates/block/show.html.eex:9
+#: lib/explorer_web/templates/block_transaction/index.html.eex:21
 msgid "Overview"
 msgstr ""
 
@@ -183,13 +183,13 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:21
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:21
-#: lib/explorer_web/templates/block_transaction/index.html.eex:20
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:19
-#: lib/explorer_web/templates/transaction/index.html.eex:20
-#: lib/explorer_web/templates/transaction/overview.html.eex:51
-#: lib/explorer_web/templates/transaction/show.html.eex:15
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:54
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:53
+#: lib/explorer_web/templates/block_transaction/index.html.eex:45
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:37
+#: lib/explorer_web/templates/transaction/index.html.eex:38
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/show.html.eex:27
 msgid "To"
 msgstr ""
 
@@ -202,7 +202,7 @@ msgstr ""
 msgid "Transaction Status"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:15
+#: lib/explorer_web/templates/address/show.html.eex:29
 msgid "Balance"
 msgstr ""
 
@@ -216,24 +216,24 @@ msgstr ""
 msgid "POA"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:24
+#: lib/explorer_web/templates/block/index.html.eex:49
 msgid "%{count} transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:3
+#: lib/explorer_web/templates/block/index.html.eex:4
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:4
+#: lib/explorer_web/templates/transaction/index.html.eex:5
 msgid "Showing %{count} Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:9
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
-#: lib/explorer_web/templates/transaction/index.html.eex:9
-#: lib/explorer_web/templates/transaction/overview.html.eex:46
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:19
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:64
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:76
+#: lib/explorer_web/templates/transaction/index.html.eex:19
 #: lib/explorer_web/templates/transaction/overview.html.eex:56
+#: lib/explorer_web/templates/transaction/overview.html.eex:70
 #: lib/explorer_web/views/transaction_view.ex:20
 #: lib/explorer_web/views/transaction_view.ex:35
 #: lib/explorer_web/views/transaction_view.ex:42
@@ -241,25 +241,25 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction/overview.html.eex:83
 msgid "First Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:17
-#: lib/explorer_web/templates/transaction/overview.html.eex:74
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:35
+#: lib/explorer_web/templates/transaction/overview.html.eex:88
 msgid "Last Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:7
-#: lib/explorer_web/templates/transaction_log/index.html.eex:7
+#: lib/explorer_web/templates/transaction/show.html.eex:15
+#: lib/explorer_web/templates/transaction_log/index.html.eex:15
 msgid "Logs"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:4
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:5
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:15
+#: lib/explorer_web/templates/transaction_log/index.html.eex:27
 msgid "Topic"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Transaction Logs"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:44
+#: lib/explorer_web/templates/chain/show.html.eex:47
 msgid "%{count} per day"
 msgstr ""
 
@@ -295,8 +295,8 @@ msgstr ""
 msgid "TPM"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:52
-#: lib/explorer_web/templates/transaction/index.html.eex:48
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:87
+#: lib/explorer_web/templates/transaction/index.html.eex:91
 msgid "Next Page"
 msgstr ""
 
@@ -308,11 +308,11 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:16
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:16
-#: lib/explorer_web/templates/block_transaction/index.html.eex:15
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:15
-#: lib/explorer_web/templates/transaction/index.html.eex:15
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:47
+#: lib/explorer_web/templates/block_transaction/index.html.eex:39
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:31
+#: lib/explorer_web/templates/transaction/index.html.eex:31
 msgid "Status"
 msgstr ""
 
@@ -325,56 +325,56 @@ msgstr ""
 msgid "Showing #%{number}"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:16
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:44
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:44
-#: lib/explorer_web/templates/block_transaction/index.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:103
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
-#: lib/explorer_web/templates/transaction/index.html.eex:43
-#: lib/explorer_web/templates/transaction/overview.html.eex:38
-#: lib/explorer_web/templates/transaction/show.html.eex:16
+#: lib/explorer_web/templates/address/show.html.eex:31
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:101
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:101
+#: lib/explorer_web/templates/block_transaction/index.html.eex:90
+#: lib/explorer_web/templates/chain/show.html.eex:128
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:80
+#: lib/explorer_web/templates/transaction/index.html.eex:84
+#: lib/explorer_web/templates/transaction/overview.html.eex:44
+#: lib/explorer_web/templates/transaction/show.html.eex:28
 msgid "Ether"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:84
+#: lib/explorer_web/templates/transaction/overview.html.eex:100
 msgid "Gwei"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:6
-#: lib/explorer_web/templates/transaction_log/index.html.eex:6
+#: lib/explorer_web/templates/transaction/show.html.eex:8
+#: lib/explorer_web/templates/transaction_log/index.html.eex:8
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_header.html.eex:12
+#: lib/explorer_web/templates/layout/_header.html.eex:20
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:40
+#: lib/explorer_web/templates/transaction/show.html.eex:52
 msgid "There are no Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:45
+#: lib/explorer_web/templates/transaction_log/index.html.eex:63
 msgid "There are no logs currently."
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:10
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:10
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:10
+#: lib/explorer_web/templates/address/show.html.eex:20
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:37
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:36
 msgid "Transactions From"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:9
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:9
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:9
+#: lib/explorer_web/templates/address/show.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:30
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:29
 msgid "Transactions To"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:13
+#: lib/explorer_web/templates/transaction/show.html.eex:25
 msgid "Type"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:84
-#: lib/explorer_web/templates/transaction/overview.html.eex:88
+#: lib/explorer_web/templates/transaction/overview.html.eex:99
+#: lib/explorer_web/templates/transaction/overview.html.eex:105
 msgid "Wei"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,28 +10,28 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:19
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:19
-#: lib/explorer_web/templates/block/index.html.eex:12
-#: lib/explorer_web/templates/block_transaction/index.html.eex:18
-#: lib/explorer_web/templates/chain/show.html.eex:61
-#: lib/explorer_web/templates/chain/show.html.eex:89
-#: lib/explorer_web/templates/transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:52
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:51
+#: lib/explorer_web/templates/block/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:43
+#: lib/explorer_web/templates/chain/show.html.eex:65
+#: lib/explorer_web/templates/chain/show.html.eex:101
+#: lib/explorer_web/templates/transaction/index.html.eex:36
+#: lib/explorer_web/templates/transaction/overview.html.eex:37
 msgid "Age"
 msgstr "Age"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:18
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:18
-#: lib/explorer_web/templates/block_transaction/index.html.eex:17
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:51
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:50
+#: lib/explorer_web/templates/block_transaction/index.html.eex:42
 #: lib/explorer_web/templates/chain/show.html.eex:28
-#: lib/explorer_web/templates/chain/show.html.eex:88
-#: lib/explorer_web/templates/transaction/index.html.eex:17
+#: lib/explorer_web/templates/chain/show.html.eex:100
+#: lib/explorer_web/templates/transaction/index.html.eex:35
 msgid "Block"
 msgstr "Block"
 
-#: lib/explorer_web/templates/chain/show.html.eex:54
-#: lib/explorer_web/templates/layout/_header.html.eex:18
+#: lib/explorer_web/templates/chain/show.html.eex:58
+#: lib/explorer_web/templates/layout/_header.html.eex:27
 msgid "Blocks"
 msgstr "Blocks"
 
@@ -39,24 +39,24 @@ msgstr "Blocks"
 msgid "Copyright %{year} POA"
 msgstr "%{year} POA Network Ltd. All rights reserved"
 
-#: lib/explorer_web/templates/block/index.html.eex:14
-#: lib/explorer_web/templates/block/show.html.eex:54
-#: lib/explorer_web/templates/chain/show.html.eex:63
+#: lib/explorer_web/templates/block/index.html.eex:32
+#: lib/explorer_web/templates/block/show.html.eex:77
+#: lib/explorer_web/templates/chain/show.html.eex:67
 msgid "Gas Used"
 msgstr "Gas Used"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:17
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:17
-#: lib/explorer_web/templates/block/show.html.eex:26
-#: lib/explorer_web/templates/block_transaction/index.html.eex:16
-#: lib/explorer_web/templates/chain/show.html.eex:87
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:16
-#: lib/explorer_web/templates/transaction/index.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:50
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:49
+#: lib/explorer_web/templates/block/show.html.eex:40
+#: lib/explorer_web/templates/block_transaction/index.html.eex:41
+#: lib/explorer_web/templates/chain/show.html.eex:99
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:34
+#: lib/explorer_web/templates/transaction/index.html.eex:34
 msgid "Hash"
 msgstr "Hash"
 
-#: lib/explorer_web/templates/block/index.html.eex:11
-#: lib/explorer_web/templates/chain/show.html.eex:60
+#: lib/explorer_web/templates/block/index.html.eex:29
+#: lib/explorer_web/templates/chain/show.html.eex:64
 msgid "Height"
 msgstr "Height"
 
@@ -65,26 +65,26 @@ msgstr "Height"
 msgid "POA Network Explorer"
 msgstr "POA Network Explorer"
 
-#: lib/explorer_web/templates/block/index.html.eex:13
-#: lib/explorer_web/templates/block/show.html.eex:8
-#: lib/explorer_web/templates/block/show.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:9
-#: lib/explorer_web/templates/chain/show.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:62
-#: lib/explorer_web/templates/chain/show.html.eex:81
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:8
-#: lib/explorer_web/templates/transaction/index.html.eex:8
+#: lib/explorer_web/templates/block/index.html.eex:31
+#: lib/explorer_web/templates/block/show.html.eex:16
+#: lib/explorer_web/templates/block/show.html.eex:34
+#: lib/explorer_web/templates/block_transaction/index.html.eex:28
+#: lib/explorer_web/templates/chain/show.html.eex:45
+#: lib/explorer_web/templates/chain/show.html.eex:66
+#: lib/explorer_web/templates/chain/show.html.eex:93
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:12
+#: lib/explorer_web/templates/transaction/index.html.eex:12
 msgid "Transactions"
 msgstr "Transactions"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:22
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:21
-#: lib/explorer_web/templates/chain/show.html.eex:90
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:20
-#: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:37
-#: lib/explorer_web/templates/transaction/show.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:55
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:54
+#: lib/explorer_web/templates/block_transaction/index.html.eex:46
+#: lib/explorer_web/templates/chain/show.html.eex:102
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:38
+#: lib/explorer_web/templates/transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/overview.html.eex:43
+#: lib/explorer_web/templates/transaction/show.html.eex:28
 msgid "Value"
 msgstr "Value"
 
@@ -92,43 +92,43 @@ msgstr "Value"
 msgid "Block #%{number} Details"
 msgstr "Block #%{number} Details"
 
-#: lib/explorer_web/templates/block/show.html.eex:38
+#: lib/explorer_web/templates/block/show.html.eex:57
 msgid "Difficulty"
 msgstr "Difficulty"
 
-#: lib/explorer_web/templates/block/index.html.eex:15
-#: lib/explorer_web/templates/block/show.html.eex:58
-#: lib/explorer_web/templates/transaction/overview.html.eex:79
-#: lib/explorer_web/templates/transaction/show.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:33
+#: lib/explorer_web/templates/block/show.html.eex:85
+#: lib/explorer_web/templates/transaction/overview.html.eex:93
+#: lib/explorer_web/templates/transaction/show.html.eex:29
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
-#: lib/explorer_web/templates/block/show.html.eex:34
+#: lib/explorer_web/templates/block/show.html.eex:53
 msgid "Miner"
 msgstr "Validator"
 
-#: lib/explorer_web/templates/block/show.html.eex:62
-#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/block/show.html.eex:89
+#: lib/explorer_web/templates/transaction/overview.html.eex:75
 msgid "Nonce"
 msgstr "Nonce"
 
-#: lib/explorer_web/templates/block/show.html.eex:14
+#: lib/explorer_web/templates/block/show.html.eex:26
 msgid "Number"
 msgstr "Height"
 
-#: lib/explorer_web/templates/block/show.html.eex:30
+#: lib/explorer_web/templates/block/show.html.eex:44
 msgid "Parent Hash"
 msgstr "Parent Hash"
 
-#: lib/explorer_web/templates/block/show.html.eex:50
+#: lib/explorer_web/templates/block/show.html.eex:73
 msgid "Size"
 msgstr "Size"
 
-#: lib/explorer_web/templates/block/show.html.eex:18
+#: lib/explorer_web/templates/block/show.html.eex:30
 msgid "Timestamp"
 msgstr "Timestamp"
 
-#: lib/explorer_web/templates/block/show.html.eex:46
+#: lib/explorer_web/templates/block/show.html.eex:67
 msgid "Total Difficulty"
 msgstr "Total Difficulty"
 
@@ -140,54 +140,54 @@ msgstr "Block Height"
 msgid "Transaction Details"
 msgstr "Transaction Details"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:87
+#: lib/explorer_web/templates/transaction/overview.html.eex:104
 msgid "Cumulative Gas Used"
 msgstr "Cumulative Gas Used"
 
-#: lib/explorer_web/templates/block/index.html.eex:14
-#: lib/explorer_web/templates/block/index.html.eex:15
-#: lib/explorer_web/templates/transaction/overview.html.eex:80
-#: lib/explorer_web/templates/transaction/show.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:32
+#: lib/explorer_web/templates/block/index.html.eex:33
+#: lib/explorer_web/templates/transaction/overview.html.eex:94
+#: lib/explorer_web/templates/transaction/show.html.eex:29
 msgid "Gas"
 msgstr "Gas"
 
-#: lib/explorer_web/templates/block/index.html.eex:16
-#: lib/explorer_web/templates/transaction/overview.html.eex:83
+#: lib/explorer_web/templates/block/index.html.eex:34
+#: lib/explorer_web/templates/transaction/overview.html.eex:97
 msgid "Gas Price"
 msgstr "Gas Price"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:91
+#: lib/explorer_web/templates/transaction/overview.html.eex:108
 msgid "Input"
 msgstr "Input"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:28
+#: lib/explorer_web/templates/transaction/overview.html.eex:32
 msgid "%{confirmations} block confirmations"
 msgstr "%{confirmations} block confirmations"
 
-#: lib/explorer_web/templates/block/show.html.eex:23
+#: lib/explorer_web/templates/block/show.html.eex:36
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
 #: lib/explorer_web/templates/address/show.html.eex:3
-#: lib/explorer_web/templates/transaction_log/index.html.eex:14
+#: lib/explorer_web/templates/transaction_log/index.html.eex:26
 msgid "Address"
 msgstr "Address"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:20
-#: lib/explorer_web/templates/block_transaction/index.html.eex:19
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction/index.html.eex:19
-#: lib/explorer_web/templates/transaction/overview.html.eex:41
-#: lib/explorer_web/templates/transaction/show.html.eex:14
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:53
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:52
+#: lib/explorer_web/templates/block_transaction/index.html.eex:44
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:36
+#: lib/explorer_web/templates/transaction/index.html.eex:37
+#: lib/explorer_web/templates/transaction/overview.html.eex:47
+#: lib/explorer_web/templates/transaction/show.html.eex:26
 msgid "From"
 msgstr "From"
 
-#: lib/explorer_web/templates/address/show.html.eex:8
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:8
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:8
-#: lib/explorer_web/templates/block/show.html.eex:7
-#: lib/explorer_web/templates/block_transaction/index.html.eex:8
+#: lib/explorer_web/templates/address/show.html.eex:10
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:23
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:22
+#: lib/explorer_web/templates/block/show.html.eex:9
+#: lib/explorer_web/templates/block_transaction/index.html.eex:21
 msgid "Overview"
 msgstr "Overview"
 
@@ -195,13 +195,13 @@ msgstr "Overview"
 msgid "Success"
 msgstr "Success"
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:21
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:21
-#: lib/explorer_web/templates/block_transaction/index.html.eex:20
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:19
-#: lib/explorer_web/templates/transaction/index.html.eex:20
-#: lib/explorer_web/templates/transaction/overview.html.eex:51
-#: lib/explorer_web/templates/transaction/show.html.eex:15
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:54
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:53
+#: lib/explorer_web/templates/block_transaction/index.html.eex:45
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:37
+#: lib/explorer_web/templates/transaction/index.html.eex:38
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/show.html.eex:27
 msgid "To"
 msgstr "To"
 
@@ -214,7 +214,7 @@ msgstr "Transaction Hash"
 msgid "Transaction Status"
 msgstr "Transaction Status"
 
-#: lib/explorer_web/templates/address/show.html.eex:15
+#: lib/explorer_web/templates/address/show.html.eex:29
 msgid "Balance"
 msgstr "Balance"
 
@@ -228,24 +228,24 @@ msgstr "Balance"
 msgid "POA"
 msgstr "POA"
 
-#: lib/explorer_web/templates/block/index.html.eex:24
+#: lib/explorer_web/templates/block/index.html.eex:49
 msgid "%{count} transactions"
 msgstr "%{count} transactions"
 
-#: lib/explorer_web/templates/block/index.html.eex:3
+#: lib/explorer_web/templates/block/index.html.eex:4
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr "Showing #%{start_block} to #%{end_block}"
 
-#: lib/explorer_web/templates/transaction/index.html.eex:4
+#: lib/explorer_web/templates/transaction/index.html.eex:5
 msgid "Showing %{count} Transactions"
 msgstr "Showing %{count} Transactions"
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:9
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
-#: lib/explorer_web/templates/transaction/index.html.eex:9
-#: lib/explorer_web/templates/transaction/overview.html.eex:46
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:19
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:64
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:76
+#: lib/explorer_web/templates/transaction/index.html.eex:19
 #: lib/explorer_web/templates/transaction/overview.html.eex:56
+#: lib/explorer_web/templates/transaction/overview.html.eex:70
 #: lib/explorer_web/views/transaction_view.ex:20
 #: lib/explorer_web/views/transaction_view.ex:35
 #: lib/explorer_web/views/transaction_view.ex:42
@@ -253,25 +253,25 @@ msgstr "Showing %{count} Transactions"
 msgid "Pending"
 msgstr "Pending"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction/overview.html.eex:83
 msgid "First Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:17
-#: lib/explorer_web/templates/transaction/overview.html.eex:74
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:35
+#: lib/explorer_web/templates/transaction/overview.html.eex:88
 msgid "Last Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:7
-#: lib/explorer_web/templates/transaction_log/index.html.eex:7
+#: lib/explorer_web/templates/transaction/show.html.eex:15
+#: lib/explorer_web/templates/transaction_log/index.html.eex:15
 msgid "Logs"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:4
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:5
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:15
+#: lib/explorer_web/templates/transaction_log/index.html.eex:27
 msgid "Topic"
 msgstr ""
 
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Transaction Logs"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:44
+#: lib/explorer_web/templates/chain/show.html.eex:47
 msgid "%{count} per day"
 msgstr ""
 
@@ -307,8 +307,8 @@ msgstr ""
 msgid "TPM"
 msgstr ""
 
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:52
-#: lib/explorer_web/templates/transaction/index.html.eex:48
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:87
+#: lib/explorer_web/templates/transaction/index.html.eex:91
 msgid "Next Page"
 msgstr ""
 
@@ -320,11 +320,11 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:16
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:16
-#: lib/explorer_web/templates/block_transaction/index.html.eex:15
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:15
-#: lib/explorer_web/templates/transaction/index.html.eex:15
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:47
+#: lib/explorer_web/templates/block_transaction/index.html.eex:39
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:31
+#: lib/explorer_web/templates/transaction/index.html.eex:31
 msgid "Status"
 msgstr ""
 
@@ -337,56 +337,56 @@ msgstr ""
 msgid "Showing #%{number}"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:16
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:44
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:44
-#: lib/explorer_web/templates/block_transaction/index.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:103
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
-#: lib/explorer_web/templates/transaction/index.html.eex:43
-#: lib/explorer_web/templates/transaction/overview.html.eex:38
-#: lib/explorer_web/templates/transaction/show.html.eex:16
+#: lib/explorer_web/templates/address/show.html.eex:31
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:101
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:101
+#: lib/explorer_web/templates/block_transaction/index.html.eex:90
+#: lib/explorer_web/templates/chain/show.html.eex:128
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:80
+#: lib/explorer_web/templates/transaction/index.html.eex:84
+#: lib/explorer_web/templates/transaction/overview.html.eex:44
+#: lib/explorer_web/templates/transaction/show.html.eex:28
 msgid "Ether"
 msgstr "POA"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:84
+#: lib/explorer_web/templates/transaction/overview.html.eex:100
 msgid "Gwei"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:6
-#: lib/explorer_web/templates/transaction_log/index.html.eex:6
+#: lib/explorer_web/templates/transaction/show.html.eex:8
+#: lib/explorer_web/templates/transaction_log/index.html.eex:8
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_header.html.eex:12
+#: lib/explorer_web/templates/layout/_header.html.eex:20
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:40
+#: lib/explorer_web/templates/transaction/show.html.eex:52
 msgid "There are no Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:45
+#: lib/explorer_web/templates/transaction_log/index.html.eex:63
 msgid "There are no logs currently."
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:10
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:10
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:10
+#: lib/explorer_web/templates/address/show.html.eex:20
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:37
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:36
 msgid "Transactions From"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:9
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:9
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:9
+#: lib/explorer_web/templates/address/show.html.eex:16
+#: lib/explorer_web/templates/address_transaction_from/index.html.eex:30
+#: lib/explorer_web/templates/address_transaction_to/index.html.eex:29
 msgid "Transactions To"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/show.html.eex:13
+#: lib/explorer_web/templates/transaction/show.html.eex:25
 msgid "Type"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:84
-#: lib/explorer_web/templates/transaction/overview.html.eex:88
+#: lib/explorer_web/templates/transaction/overview.html.eex:99
+#: lib/explorer_web/templates/transaction/overview.html.eex:105
 msgid "Wei"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_transaction_from_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_transaction_from_controller_test.exs
@@ -18,13 +18,11 @@ defmodule ExplorerWeb.AddressTransactionFromControllerTest do
       block = insert(:block)
       insert(:block_transaction, transaction: transaction, block: block)
 
-      conn =
-        get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
 
-      transaction_hash_divs =
-        Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
+      transaction_hash_divs = Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
 
       assert length(transaction_hash_divs) == 1
 
@@ -43,8 +41,7 @@ defmodule ExplorerWeb.AddressTransactionFromControllerTest do
       insert(:to_address, transaction: transaction, address: address)
       insert(:from_address, transaction: transaction, address: other_address)
 
-      conn =
-        get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -58,8 +55,7 @@ defmodule ExplorerWeb.AddressTransactionFromControllerTest do
       insert(:to_address, transaction: transaction, address: address)
       insert(:from_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -73,8 +69,7 @@ defmodule ExplorerWeb.AddressTransactionFromControllerTest do
       address = insert(:address)
       insert(:to_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -88,8 +83,7 @@ defmodule ExplorerWeb.AddressTransactionFromControllerTest do
       address = insert(:address)
       insert(:from_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_from_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0

--- a/apps/explorer_web/test/explorer_web/controllers/address_transaction_to_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_transaction_to_controller_test.exs
@@ -18,14 +18,12 @@ defmodule ExplorerWeb.AddressTransactionToControllerTest do
       block = insert(:block)
       insert(:block_transaction, transaction: transaction, block: block)
 
-      conn =
-        get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 1
 
-      transaction_hash_divs =
-        Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
+      transaction_hash_divs = Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
 
       assert length(transaction_hash_divs) == 1
 
@@ -44,8 +42,7 @@ defmodule ExplorerWeb.AddressTransactionToControllerTest do
       insert(:to_address, transaction: transaction, address: other_address)
       insert(:from_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -59,8 +56,7 @@ defmodule ExplorerWeb.AddressTransactionToControllerTest do
       insert(:to_address, transaction: transaction, address: address)
       insert(:from_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -74,8 +70,7 @@ defmodule ExplorerWeb.AddressTransactionToControllerTest do
       address = insert(:address)
       insert(:to_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0
@@ -89,8 +84,7 @@ defmodule ExplorerWeb.AddressTransactionToControllerTest do
       address = insert(:address)
       insert(:from_address, transaction: transaction, address: address)
 
-      conn =
-        get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_to_path(ExplorerWeb.Endpoint, :index, :en, address.hash))
 
       assert html = html_response(conn, 200)
       assert html |> Floki.find("tbody tr") |> length == 0

--- a/apps/explorer_web/test/explorer_web/controllers/block_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/block_controller_test.exs
@@ -17,8 +17,7 @@ defmodule ExplorerWeb.BlockControllerTest do
 
   describe "GET index/2" do
     test "returns all blocks", %{conn: conn} do
-      block_ids =
-        insert_list(4, :block) |> Enum.map(fn block -> block.number end) |> Enum.reverse()
+      block_ids = insert_list(4, :block) |> Enum.map(fn block -> block.number end) |> Enum.reverse()
 
       conn = get(conn, "/en/blocks")
       assert conn.assigns.blocks |> Enum.map(fn block -> block.number end) == block_ids

--- a/apps/explorer_web/test/explorer_web/controllers/block_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/block_transaction_controller_test.exs
@@ -30,8 +30,7 @@ defmodule ExplorerWeb.BlockTransactionControllerTest do
 
       assert html = html_response(conn, 200)
 
-      transaction_hash_divs =
-        Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
+      transaction_hash_divs = Floki.find(html, "td.transactions__column--hash div.transactions__hash a")
 
       assert length(transaction_hash_divs) == 1
 

--- a/apps/explorer_web/test/explorer_web/controllers/chain_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/chain_controller_test.exs
@@ -1,8 +1,7 @@
 defmodule ExplorerWeb.ChainControllerTest do
   use ExplorerWeb.ConnCase
 
-  import ExplorerWeb.Router.Helpers,
-    only: [chain_path: 3, block_path: 4, transaction_path: 4, address_path: 4]
+  import ExplorerWeb.Router.Helpers, only: [chain_path: 3, block_path: 4, transaction_path: 4, address_path: 4]
 
   describe "GET index/2 without a locale" do
     test "redirects to the en locale", %{conn: conn} do

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -77,8 +77,7 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
       assert html |> Floki.find("div.transaction__header h3") |> Floki.text() == transaction.hash
 
-      assert html |> Floki.find("span.transaction__item--primary a") |> Floki.text() ==
-               to_string(block.number)
+      assert html |> Floki.find("span.transaction__item--primary a") |> Floki.text() == to_string(block.number)
     end
 
     test "returns a transaction without associated block data", %{conn: conn} do


### PR DESCRIPTION
Fixes #129 

# Changelog
## Enhancements
* Reformat `.ex` and `.exs` files to 120 columns using `mix credo`
* Reformat `.html.eex` files manually to 120 columns.

## Bug Fixes
* Harmonize `mix format`, `mix credo`, and `mix coveralls` to 120 columns