### PR TITLE
Exclude internal transactions with no siblings in parent transaction #151

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -453,6 +453,7 @@ defmodule Explorer.Chain do
         it.id
       )
     )
+    |> order_by(:index)
     |> Repo.all()
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -674,6 +674,19 @@ defmodule Explorer.ChainTest do
       refute Enum.member?(result, excluded_id)
       assert Enum.member?(result, third_id)
     end
+
+    test "returns the internal transactions in index order" do
+      %Transaction{id: id, hash: hash} = :transaction |> insert() |> with_block()
+      %InternalTransaction{id: first_id} = insert(:internal_transaction, transaction_id: id, index: 0)
+      %InternalTransaction{id: second_id} = insert(:internal_transaction, transaction_id: id, index: 1)
+
+      result =
+        hash
+        |> Chain.transaction_hash_to_internal_transactions()
+        |> Enum.map(fn it -> it.id end)
+
+      assert [first_id, second_id] == result
+    end
   end
 
   describe "transactions_recently_before_id" do

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
@@ -32,14 +32,14 @@
             <tgroup>
               <tr>
                 <td><%= transaction.call_type %></td>
-                <td class="internal-transaction__to-address">
-                  <%= link(transaction.to_address.hash,
-                  to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash),
-                  class: "transaction-log__link") %>
-                </td>
                 <td class="internal-transaction__from-address">
                   <%= link(transaction.from_address.hash,
                   to: address_path(@conn, :show, @conn.assigns.locale, transaction.from_address.hash),
+                  class: "transaction-log__link") %>
+                </td>
+                <td class="internal-transaction__to-address">
+                  <%= link(transaction.to_address.hash,
+                  to: address_path(@conn, :show, @conn.assigns.locale, transaction.to_address.hash),
                   class: "transaction-log__link") %>
                 </td>
                 <td><%= value(transaction) %></td>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/show.html.eex
@@ -19,7 +19,7 @@
       </h2>
     </div>
     <div class="internal-transaction__container">
-      <%= if length(@internal_transactions) > 0 do %>
+      <%= if length(@internal_transactions.entries) > 0 do %>
         <table class="internal-transaction__table">
           <thead>
             <th class="internal-transaction__column-header"><%= gettext "Type" %></th>

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -93,16 +93,19 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
     test "returns internal transactions for the transaction", %{conn: conn} do
       transaction = insert(:transaction)
-      internal_transaction = insert(:internal_transaction, transaction_id: transaction.id)
+      expected_internal_transaction = insert(:internal_transaction, transaction_id: transaction.id, index: 0)
+      insert(:internal_transaction, transaction_id: transaction.id, index: 1)
 
       path = transaction_path(ExplorerWeb.Endpoint, :show, :en, transaction.hash)
 
       conn = get(conn, path)
 
-      first_internal_transaction = List.first(conn.assigns.internal_transactions)
+      actual_internal_transaction_ids =
+        conn.assigns.internal_transactions.entries
+        |> Enum.map(fn it -> it.id end)
 
       assert conn.assigns.transaction.hash == transaction.hash
-      assert first_internal_transaction.id == internal_transaction.id
+      assert Enum.member?(actual_internal_transaction_ids, expected_internal_transaction.id)
     end
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/contributor_browsing_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/contributor_browsing_test.exs
@@ -210,16 +210,6 @@ defmodule ExplorerWeb.UserListTest do
       |> assert_has(css(".transaction__item", text: "38 years ago"))
     end
 
-    test "can see internal transactions for a transaction", %{
-      session: session,
-      internal: internal
-    } do
-      session
-      |> visit("/en/transactions/0xSk8")
-      |> click(link("Internal Transactions"))
-      |> assert_has(css(".internal-transaction__table", text: internal.call_type))
-    end
-
     test "can view a transaction's logs", %{session: session} do
       session
       |> visit("/en/transactions/0xSk8")


### PR DESCRIPTION
Fixes #151

# Changelog
## Enhancements
* Orders internal transactions by index on transaction show page

## Bug Fixes
* This change causes the `transaction_hash_to_internal_transactions` function to exclude an internal transaction from the results if it has no siblings in the parent transaction
* Fixes swapped "From" and "To" address information on the transaction->internal transactions page
* Fixes pagination links