### PR TITLE
Internal transactions on address #15

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -442,7 +442,9 @@ defmodule Explorer.Chain do
 
     InternalTransaction
     |> where_address_fields_match(address_fields, id)
-    |> join(:inner, [inner_transaction], transaction in assoc(inner_transaction, :transaction))
+    |> join(:inner, [internal_transaction], transaction in assoc(internal_transaction, :transaction))
+    |> join(:left, [internal_transaction, transaction], block in assoc(transaction, :block))
+    |> order_by([it, transaction, block], desc: block.number, desc: transaction.transaction_index, desc: it.index)
     |> preload(transaction: :block)
     |> join_associations(necessity_by_association)
     |> Repo.all()

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain do
   The chain context.
   """
 
-  import Ecto.Query, only: [from: 2, or_where: 3, order_by: 2, preload: 2, where: 2, where: 3]
+  import Ecto.Query, only: [from: 2, join: 4, or_where: 3, order_by: 2, preload: 2, where: 2, where: 3]
 
   alias Explorer.Chain.{
     Address,
@@ -415,12 +415,35 @@ defmodule Explorer.Chain do
     |> Repo.aggregate(:count, :id)
   end
 
+  @doc """
+  `t:Explorer.Chain.InternalTransaction/0`s from `address`.
+
+  ## Options
+
+  * `:direction` - if specified, will filter internal transactions by address type. If `:to` is specified, only internal
+  transactions where the "to" address matches will be returned. Likewise, if `:from` is specified, only internal
+  transactions where the "from" address matches will be returned. If :direction is omitted, internal transactions either
+  to or from the address will be returned.
+  * `:necessity_by_association` - use to load `t:association/0` as `:required` or `:optional`. If an association is
+  `:required`, and the `t:Explorer.Chain.InternalTransaction.t/0` has no associated record for that association, then
+  the `t:Explorer.Chain.InternalTransaction.t/0` will not be included in the page `entries`.
+  * `:pagination` - pagination params to pass to scrivener.
+
+  """
   def address_to_internal_transactions(%Address{id: id}, options \\ []) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    address_fields = [:to_address_id, :from_address_id]
+
+    address_fields =
+      case Keyword.get(options, :direction) do
+        :to -> [:to_address_id]
+        :from -> [:from_address_id]
+        nil -> [:to_address_id, :from_address_id]
+      end
 
     InternalTransaction
     |> where_address_fields_match(address_fields, id)
+    |> join(:inner, [inner_transaction], transaction in assoc(inner_transaction, :transaction))
+    |> preload(transaction: :block)
     |> join_associations(necessity_by_association)
     |> Repo.all()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -415,6 +415,16 @@ defmodule Explorer.Chain do
     |> Repo.aggregate(:count, :id)
   end
 
+  def address_to_internal_transactions(%Address{id: id}, options \\ []) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+    address_fields = [:to_address_id, :from_address_id]
+
+    InternalTransaction
+    |> where_address_fields_match(address_fields, id)
+    |> join_associations(necessity_by_association)
+    |> Repo.all()
+  end
+
   @doc """
   `t:Explorer.Chain.InternalTransaction/0`s in `t:Explorer.Chain.Transaction.t/0` with `hash`
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -609,7 +609,7 @@ defmodule Explorer.ChainTest do
                %InternalTransaction{
                  from_address: %Ecto.Association.NotLoaded{},
                  to_address: %Ecto.Association.NotLoaded{},
-                 transaction: %Ecto.Association.NotLoaded{}
+                 transaction: %Transaction{}
                }
              ] = Chain.address_to_internal_transactions(address)
 

--- a/apps/explorer/test/support/factories/chain/transaction_factory.ex
+++ b/apps/explorer/test/support/factories/chain/transaction_factory.ex
@@ -23,14 +23,19 @@ defmodule Explorer.Chain.TransactionFactory do
         }
       end
 
+      def list_with_block(transactions, block \\ nil) do
+        Enum.map(transactions, fn transaction -> with_block(transaction, block) end)
+      end
+
       def with_block(transaction, block \\ nil) do
         block = block || insert(:block)
-        insert(:block_transaction, %{block_id: block.id, transaction_id: transaction.id})
+        insert(:block_transaction, block_id: block.id, transaction_id: transaction.id)
         transaction
       end
 
-      def list_with_block(transactions, block \\ nil) do
-        Enum.map(transactions, fn transaction -> with_block(transaction, block) end)
+      def with_receipt(transaction) do
+        insert(:receipt, transaction_id: transaction.id)
+        transaction
       end
     end
   end

--- a/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
@@ -1,0 +1,45 @@
+defmodule ExplorerWeb.AddressInternalTransactionController do
+  @moduledoc """
+    Display all the Transactions that terminate at this Address.
+  """
+
+  use ExplorerWeb, :controller
+
+  alias Explorer.Chain
+
+  def index(conn, %{"address_id" => address_hash}) do
+    case Chain.hash_to_address(address_hash) do
+      {:ok, address} ->
+        # options = [
+        #   necessity_by_association: %{
+        #     block: :required,
+        #     from_address: :optional,
+        #     to_address: :optional,
+        #     receipt: :required
+        #   },
+        #   pagination: params
+        # ]
+
+        # page =
+        #   Chain.address_to_transactions(
+        #     address,
+        #     Keyword.merge(options, current_filter(params))
+        #   )
+
+        render(conn, "index.html", address: address)
+
+      {:error, :not_found} ->
+        not_found(conn)
+    end
+  end
+
+  # defp current_filter(params) do
+  #   params
+  #   |> Map.get("filter")
+  #   |> case do
+  #     "to" -> [direction: :to]
+  #     "from" -> [direction: :from]
+  #     _ -> []
+  #   end
+  # end
+end

--- a/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
@@ -1,45 +1,43 @@
 defmodule ExplorerWeb.AddressInternalTransactionController do
   @moduledoc """
-    Display all the Transactions that terminate at this Address.
+    Manages the displaying of information about internal transactions as they relate to addresses
   """
 
   use ExplorerWeb, :controller
 
   alias Explorer.Chain
 
-  def index(conn, %{"address_id" => address_hash}) do
+  def index(conn, %{"address_id" => address_hash} = params) do
     case Chain.hash_to_address(address_hash) do
       {:ok, address} ->
-        # options = [
-        #   necessity_by_association: %{
-        #     block: :required,
-        #     from_address: :optional,
-        #     to_address: :optional,
-        #     receipt: :required
-        #   },
-        #   pagination: params
-        # ]
+        options = [
+          necessity_by_association: %{
+            from_address: :optional,
+            to_address: :optional
+          },
+          pagination: params
+        ]
 
-        # page =
-        #   Chain.address_to_transactions(
-        #     address,
-        #     Keyword.merge(options, current_filter(params))
-        #   )
+        page =
+          Chain.address_to_internal_transactions(
+            address,
+            Keyword.merge(options, current_filter(params))
+          )
 
-        render(conn, "index.html", address: address)
+        render(conn, "index.html", address: address, filter: params["filter"], page: page)
 
       {:error, :not_found} ->
         not_found(conn)
     end
   end
 
-  # defp current_filter(params) do
-  #   params
-  #   |> Map.get("filter")
-  #   |> case do
-  #     "to" -> [direction: :to]
-  #     "from" -> [direction: :from]
-  #     _ -> []
-  #   end
-  # end
+  defp current_filter(params) do
+    params
+    |> Map.get("filter")
+    |> case do
+      "to" -> [direction: :to]
+      "from" -> [direction: :from]
+      _ -> []
+    end
+  end
 end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -40,8 +40,7 @@ defmodule ExplorerWeb.Router do
   end
 
   pipeline :jasmine do
-    if Mix.env() != :prod,
-      do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
+    if Mix.env() != :prod, do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
   end
 
   pipeline :api do

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -40,7 +40,8 @@ defmodule ExplorerWeb.Router do
   end
 
   pipeline :jasmine do
-    if Mix.env() != :prod, do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
+    if Mix.env() != :prod,
+      do: plug(Jasmine, js_files: ["js/test.js"], css_files: ["css/test.css"])
   end
 
   pipeline :api do
@@ -76,11 +77,13 @@ defmodule ExplorerWeb.Router do
     end
 
     resources "/addresses", AddressController, only: [:show] do
+      resources("/transactions", AddressTransactionController, only: [:index], as: :transaction)
+
       resources(
-        "/transactions",
-        AddressTransactionController,
+        "/internal_transactions",
+        AddressInternalTransactionController,
         only: [:index],
-        as: :transaction
+        as: :internal_transaction
       )
     end
 

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -1,0 +1,16 @@
+<div class="address__header">
+  <h1 class="address__heading"><%= gettext "Address" %></h1>
+  <h3 class="address__subheading"><%= @address.hash %></h3>
+</div>
+<div class="address__container">
+  <div class="address__attributes">
+    <dl>
+      <div class="address__item">
+        <dt class="address__item-key"><%= gettext "Balance" %></dt>
+        <dd class="address__item-value address__balance" title="<%= @address.hash %>">
+          <%= balance(@address) %> <%= gettext "Ether" %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -7,7 +7,7 @@
     <dl>
       <div class="address__item">
         <dt class="address__item-key"><%= gettext "Balance" %></dt>
-        <dd class="address__item-value address__balance" title="<%= @address.hash %>">
+        <dd class="address__item-value address__balance" title="<%= @address.hash %>" data-test="address_balance">
           <%= balance(@address) %> <%= gettext "Ether" %>
         </dd>
       </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -18,87 +18,101 @@
         ) %>
       </h2>
     </div>
-  </div>
-  <div class="dropdown u-float-right u-push-sm-right u-push-sm-bottom">
-    <button data-test="filter_dropdown" class="button button--secondary dropdown-toggle" type="button"
-      id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Filter: <%= format_current_filter(@filter) %>
-    </button>
-    <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
-      <%= link(
-        gettext("All"),
-        to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
-        class: "address__link address__link--active dropdown-item",
-        "data-test": "filter_option"
-      ) %>
-      <%= link(
-        gettext("To"),
-        to: address_internal_transaction_path(
-          @conn,
-          :index,
-          @conn.assigns.locale,
-          @conn.params["address_id"],
-          filter: "to"
-        ),
-        class: "address__link address__link--active dropdown-item",
-        "data-test": "filter_option"
-      ) %>
-      <%= link(
-        gettext("From"),
-        to: address_internal_transaction_path(
-          @conn,
-          :index,
-          @conn.assigns.locale,
-          @conn.params["address_id"],
-          filter: "from"
-        ),
-        class: "address__link address__link--active dropdown-item",
-        "data-test": "filter_option"
-      ) %>
+    <div class="dropdown u-float-right u-push-sm-right u-push-sm-bottom">
+      <button data-test="filter_dropdown" class="button button--secondary button--xsmall dropdown-toggle" type="button"
+        id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Filter: <%= format_current_filter(@filter) %>
+      </button>
+      <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
+        <%= link(
+          gettext("All"),
+          to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+          class: "address__link address__link--active dropdown-item",
+          "data-test": "filter_option"
+        ) %>
+        <%= link(
+          gettext("To"),
+          to: address_internal_transaction_path(
+            @conn,
+            :index,
+            @conn.assigns.locale,
+            @conn.params["address_id"],
+            filter: "to"
+          ),
+          class: "address__link address__link--active dropdown-item",
+          "data-test": "filter_option"
+        ) %>
+        <%= link(
+          gettext("From"),
+          to: address_internal_transaction_path(
+            @conn,
+            :index,
+            @conn.assigns.locale,
+            @conn.params["address_id"],
+            filter: "from"
+          ),
+          class: "address__link address__link--active dropdown-item",
+          "data-test": "filter_option"
+        ) %>
+      </div>
+    </div>
+    <div class="internal-transaction__container">
+      <%= if length(@page.entries) > 0 do %>
+        <table class="internal-transaction__table">
+          <thead>
+            <th class="internal-transaction__column-header"><%= gettext "Parent Tx Hash" %></th>
+            <th class="internal-transaction__column-header"><%= gettext "Block" %></th>
+            <th class="internal-transaction__column-header"><%= gettext "Age" %></th>
+            <th class="internal-transaction__column-header"><%= gettext "From" %></th>
+            <th class="internal-transaction__column-header"><%= gettext "To" %></th>
+            <th class="internal-transaction__column-header"><%= gettext "Value" %></th>
+          </thead>
+          <%= for internal_transaction <- @page do %>
+            <tgroup>
+              <tr data-test="internal_transaction">
+                <td>
+                  <%= link(internal_transaction.transaction.hash,
+                    to: transaction_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.hash),
+                    class: "transaction-log__link") %>
+                </td>
+                <td>
+                  <%= link(internal_transaction.transaction.block.number,
+                    to: block_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.block.number),
+                    class: "transaction-log__link") %>
+                </td>
+                <td class="internal-transaction__to-address"><%= ExplorerWeb.BlockView.age(internal_transaction.transaction.block) %></td>
+                <td class="internal-transaction__from-address">
+                  <%= link(internal_transaction.from_address.hash,
+                    to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.from_address.hash),
+                    class: "transaction-log__link") %>
+                </td>
+                <td class="internal-transaction__to-address">
+                  <%= link(internal_transaction.to_address.hash,
+                    to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.to_address.hash),
+                    class: "transaction-log__link") %>
+                </td>
+                <td class="internal-transaction__to-address"><%= ExplorerWeb.TransactionView.value(internal_transaction) %></td>
+              </tr>
+            </tgroup>
+          <% end %>
+        </table>
+      <% else %>
+        <p><%= gettext "There are no Internal Transactions" %></p>
+      <% end %>
     </div>
   </div>
-  <div class="internal-transaction__container">
-    <%= if length(@page) > 0 do %>
-      <table class="internal-transaction__table">
-        <thead>
-          <th class="internal-transaction__column-header"><%= gettext "Parent Tx Hash" %></th>
-          <th class="internal-transaction__column-header"><%= gettext "Block" %></th>
-          <th class="internal-transaction__column-header"><%= gettext "Age" %></th>
-          <th class="internal-transaction__column-header"><%= gettext "From" %></th>
-          <th class="internal-transaction__column-header"><%= gettext "To" %></th>
-          <th class="internal-transaction__column-header"><%= gettext "Value" %></th>
-        </thead>
-        <%= for internal_transaction <- @page do %>
-          <tgroup>
-            <tr data-test="internal_transaction">
-              <td>
-                <%= link(internal_transaction.transaction.hash,
-                  to: transaction_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.hash),
-                  class: "transaction-log__link") %>
-              </td>
-              <td>
-                <%= link(internal_transaction.transaction.block.number,
-                  to: block_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.block.number),
-                  class: "transaction-log__link") %>
-              </td>
-              <td class="internal-transaction__to-address"><%= ExplorerWeb.BlockView.age(internal_transaction.transaction.block) %></td>
-              <td class="internal-transaction__from-address">
-                <%= link(internal_transaction.from_address.hash,
-                  to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.from_address.hash),
-                  class: "transaction-log__link") %>
-              </td>
-              <td class="internal-transaction__to-address">
-                <%= link(internal_transaction.to_address.hash,
-                  to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.to_address.hash),
-                  class: "transaction-log__link") %>
-              </td>
-              <td class="internal-transaction__to-address"><%= ExplorerWeb.TransactionView.value(internal_transaction) %></td>
-            </tr>
-          </tgroup>
-        <% end %>
-      </table>
-    <% else %>
-      <p><%= gettext "There are no Internal Transactions" %></p>
-    <% end %>
+  <div class="address__pagination">
+    <%= pagination_links(
+      @conn,
+      @page,
+      ["en", @conn.params["address_id"]],
+      distance: 1,
+      filter: @conn.params["filter"],
+      first: true,
+      next: Phoenix.HTML.raw("&rsaquo;"),
+      path: &address_internal_transaction_path/5,
+      previous: Phoenix.HTML.raw("&lsaquo;"),
+      view_style: :bulma
+    ) %>
   </div>
 </section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -27,30 +27,33 @@
     <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
       <%= link(
         gettext("All"),
+        to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
         class: "address__link address__link--active dropdown-item",
-        to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+        "data-test": "filter_option"
       ) %>
       <%= link(
         gettext("To"),
-        class: "address__link address__link--active dropdown-item",
         to: address_internal_transaction_path(
           @conn,
           :index,
           @conn.assigns.locale,
           @conn.params["address_id"],
           filter: "to"
-        )
+        ),
+        class: "address__link address__link--active dropdown-item",
+        "data-test": "filter_option"
       ) %>
       <%= link(
         gettext("From"),
-        class: "address__link address__link--active dropdown-item",
         to: address_internal_transaction_path(
           @conn,
           :index,
           @conn.assigns.locale,
           @conn.params["address_id"],
           filter: "from"
-        )
+        ),
+        class: "address__link address__link--active dropdown-item",
+        "data-test": "filter_option"
       ) %>
     </div>
   </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -5,18 +5,97 @@
     <div class="address__tabs">
       <h2 class="address__tab address__tab">
         <%= link(
-              gettext("Transactions"),
-              class: "address__link address__link",
-              to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
-            ) %>
+          gettext("Transactions"),
+          class: "address__link address__link",
+          to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+        ) %>
       </h2>
       <h2 class="address__tab address__tab--active">
         <%= link(
-              gettext("Internal Transactions"),
-              class: "address__link address__link--active",
-              to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
-            ) %>
+          gettext("Internal Transactions"),
+          class: "address__link address__link--active",
+          to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+        ) %>
       </h2>
     </div>
+  </div>
+  <div class="dropdown u-float-right u-push-sm-right u-push-sm-bottom">
+    <button data-test="filter_dropdown" class="button button--secondary dropdown-toggle" type="button"
+      id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Filter: <%= format_current_filter(@filter) %>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
+      <%= link(
+        gettext("All"),
+        class: "address__link address__link--active dropdown-item",
+        to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+      ) %>
+      <%= link(
+        gettext("To"),
+        class: "address__link address__link--active dropdown-item",
+        to: address_internal_transaction_path(
+          @conn,
+          :index,
+          @conn.assigns.locale,
+          @conn.params["address_id"],
+          filter: "to"
+        )
+      ) %>
+      <%= link(
+        gettext("From"),
+        class: "address__link address__link--active dropdown-item",
+        to: address_internal_transaction_path(
+          @conn,
+          :index,
+          @conn.assigns.locale,
+          @conn.params["address_id"],
+          filter: "from"
+        )
+      ) %>
+    </div>
+  </div>
+  <div class="internal-transaction__container">
+    <%= if length(@page) > 0 do %>
+      <table class="internal-transaction__table">
+        <thead>
+          <th class="internal-transaction__column-header"><%= gettext "Parent Tx Hash" %></th>
+          <th class="internal-transaction__column-header"><%= gettext "Block" %></th>
+          <th class="internal-transaction__column-header"><%= gettext "Age" %></th>
+          <th class="internal-transaction__column-header"><%= gettext "From" %></th>
+          <th class="internal-transaction__column-header"><%= gettext "To" %></th>
+          <th class="internal-transaction__column-header"><%= gettext "Value" %></th>
+        </thead>
+        <%= for internal_transaction <- @page do %>
+          <tgroup>
+            <tr data-test="internal_transaction">
+              <td>
+                <%= link(internal_transaction.transaction.hash,
+                  to: transaction_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.hash),
+                  class: "transaction-log__link") %>
+              </td>
+              <td>
+                <%= link(internal_transaction.transaction.block.number,
+                  to: block_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.block.number),
+                  class: "transaction-log__link") %>
+              </td>
+              <td class="internal-transaction__to-address"><%= ExplorerWeb.BlockView.age(internal_transaction.transaction.block) %></td>
+              <td class="internal-transaction__from-address">
+                <%= link(internal_transaction.from_address.hash,
+                  to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.from_address.hash),
+                  class: "transaction-log__link") %>
+              </td>
+              <td class="internal-transaction__to-address">
+                <%= link(internal_transaction.to_address.hash,
+                  to: address_path(@conn, :show, @conn.assigns.locale, internal_transaction.to_address.hash),
+                  class: "transaction-log__link") %>
+              </td>
+              <td class="internal-transaction__to-address"><%= ExplorerWeb.TransactionView.value(internal_transaction) %></td>
+            </tr>
+          </tgroup>
+        <% end %>
+      </table>
+    <% else %>
+      <p><%= gettext "There are no Internal Transactions" %></p>
+    <% end %>
   </div>
 </section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -1,0 +1,22 @@
+<section class="container__section block">
+  <%= render ExplorerWeb.AddressView, "overview.html", assigns %>
+
+  <div class="address__container">
+    <div class="address__tabs">
+      <h2 class="address__tab address__tab">
+        <%= link(
+              gettext("Transactions"),
+              class: "address__link address__link",
+              to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab address__tab--active">
+        <%= link(
+              gettext("Internal Transactions"),
+              class: "address__link address__link--active",
+              to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+    </div>
+  </div>
+</section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -1,20 +1,5 @@
 <section class="container__section block">
-  <div class="address__header">
-    <h1 class="address__heading"><%= gettext "Address" %></h1>
-    <h3 class="address__subheading"><%= @address.hash %></h3>
-  </div>
-  <div class="address__container">
-    <div class="address__attributes">
-      <dl>
-        <div class="address__item">
-          <dt class="address__item-key"><%= gettext "Balance" %></dt>
-          <dd class="address__item-value address__balance" title="<%= @address.hash %>">
-            <%= balance(@address) %> <%= gettext "Ether" %>
-          </dd>
-        </div>
-      </dl>
-    </div>
-  </div>
+  <%= render ExplorerWeb.AddressView, "overview.html", assigns %>
 
   <div class="address__container">
     <div class="address__tabs">
@@ -23,6 +8,14 @@
               gettext("Transactions"),
               class: "address__link address__link--active",
               to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+            ) %>
+      </h2>
+      <h2 class="address__tab address__tab">
+        <%= link(
+              gettext("Internal Transactions"),
+              class: "address__link address__link",
+              "data-test": "internal_transactions_tab_link",
+              to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
             ) %>
       </h2>
     </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -27,30 +27,33 @@
       <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
         <%= link(
               gettext("All"),
+              to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
               class: "address__link address__link--active dropdown-item",
-              to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+              "data-test": "filter_option"
             ) %>
         <%= link(
               gettext("To"),
-              class: "address__link address__link--active dropdown-item",
               to: address_transaction_path(
                 @conn,
                 :index,
                 @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "to"
-              )
+              ),
+              class: "address__link address__link--active dropdown-item",
+              "data-test": "filter_option"
             ) %>
         <%= link(
               gettext("From"),
-              class: "address__link address__link--active dropdown-item",
               to: address_transaction_path(
                 @conn,
                 :index,
                 @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "from"
-              )
+              ),
+              class: "address__link address__link--active dropdown-item",
+              "data-test": "filter_option"
             ) %>
       </div>
     </div>
@@ -80,8 +83,9 @@
                 <div class="transactions__hash">
                   <%= link(
                         transaction.hash,
+                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash),
                         class: "transactions__link transactions__link--truncated transactions__link--long-hash",
-                        to: transaction_path(@conn, :show, @conn.assigns.locale, transaction.hash)
+                        "data-test": "transaction_hash"
                       ) %>
                 </div>
               </td>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -20,7 +20,7 @@
       </h2>
     </div>
     <div class="dropdown u-float-right u-push-sm-right u-push-sm-bottom">
-      <button data-test="filter_dropdown" class="button button--secondary dropdown-toggle" type="button"
+      <button data-test="filter_dropdown" class="button button--secondary button--xsmall dropdown-toggle" type="button"
               id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Filter: <%= format_current_filter(@filter) %>
       </button>

--- a/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
@@ -1,0 +1,3 @@
+defmodule ExplorerWeb.AddressInternalTransactionView do
+  use ExplorerWeb, :view
+end

--- a/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
@@ -1,3 +1,11 @@
 defmodule ExplorerWeb.AddressInternalTransactionView do
   use ExplorerWeb, :view
+
+  def format_current_filter(filter) do
+    case filter do
+      "to" -> gettext("To")
+      "from" -> gettext("From")
+      _ -> gettext("All")
+    end
+  end
 end

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -1,9 +1,8 @@
 defmodule ExplorerWeb.AddressTransactionView do
   use ExplorerWeb, :view
 
-  alias ExplorerWeb.{AddressView, TransactionView}
+  alias ExplorerWeb.TransactionView
 
-  defdelegate balance(address), to: AddressView
   defdelegate fee(transaction), to: TransactionView
 
   def format_current_filter(filter) do

--- a/apps/explorer_web/mix.exs
+++ b/apps/explorer_web/mix.exs
@@ -41,7 +41,7 @@ defmodule ExplorerWeb.Mixfile do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["test/support" | elixirc_paths()]
+  defp elixirc_paths(:test), do: ["test/support", "test/explorer_web/features/pages"] ++ elixirc_paths()
   defp elixirc_paths(_), do: elixirc_paths()
   defp elixirc_paths, do: ["lib"]
 

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,4 +1,5 @@
-#: lib/explorer_web/templates/address_transaction/index.html.eex:73
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:65
+#: lib/explorer_web/templates/address_transaction/index.html.eex:69
 #: lib/explorer_web/templates/block/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:99
 #: lib/explorer_web/templates/chain/show.html.eex:71
@@ -8,7 +9,8 @@
 msgid "Age"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:72
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:64
+#: lib/explorer_web/templates/address_transaction/index.html.eex:68
 #: lib/explorer_web/templates/block_transaction/index.html.eex:98
 #: lib/explorer_web/templates/chain/show.html.eex:28
 #: lib/explorer_web/templates/chain/show.html.eex:109
@@ -31,7 +33,7 @@ msgstr ""
 msgid "Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:71
+#: lib/explorer_web/templates/address_transaction/index.html.eex:67
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
 #: lib/explorer_web/templates/block_transaction/index.html.eex:97
 #: lib/explorer_web/templates/chain/show.html.eex:108
@@ -49,7 +51,8 @@ msgstr ""
 msgid "POA Network Explorer"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:23
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:8
+#: lib/explorer_web/templates/address_transaction/index.html.eex:8
 #: lib/explorer_web/templates/block/index.html.eex:31
 #: lib/explorer_web/templates/block_transaction/index.html.eex:16
 #: lib/explorer_web/templates/block_transaction/index.html.eex:84
@@ -62,7 +65,8 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:76
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:68
+#: lib/explorer_web/templates/address_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:102
 #: lib/explorer_web/templates/chain/show.html.eex:111
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -152,19 +156,22 @@ msgstr ""
 msgid "%{count} transactions in this block"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:3
+#: lib/explorer_web/templates/address/overview.html.eex:2
 #: lib/explorer_web/templates/transaction_log/index.html.eex:26
 msgid "Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_transaction/index.html.eex:74
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:46
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_transaction/index.html.eex:70
 #: lib/explorer_web/templates/block_transaction/index.html.eex:100
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
 #: lib/explorer_web/templates/transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/overview.html.eex:47
 #: lib/explorer_web/templates/transaction/show.html.eex:26
-#: lib/explorer_web/views/address_transaction_view.ex:12
+#: lib/explorer_web/views/address_internal_transaction_view.ex:7
+#: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr ""
 
@@ -177,14 +184,17 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:41
-#: lib/explorer_web/templates/address_transaction/index.html.eex:75
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:34
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/explorer_web/templates/address_transaction/index.html.eex:35
+#: lib/explorer_web/templates/address_transaction/index.html.eex:71
 #: lib/explorer_web/templates/block_transaction/index.html.eex:101
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/overview.html.eex:61
 #: lib/explorer_web/templates/transaction/show.html.eex:27
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_internal_transaction_view.ex:6
+#: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr ""
 
@@ -197,7 +207,7 @@ msgstr ""
 msgid "Transaction Status"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:10
+#: lib/explorer_web/templates/address/overview.html.eex:9
 msgid "Balance"
 msgstr ""
 
@@ -304,7 +314,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:69
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
 #: lib/explorer_web/templates/block_transaction/index.html.eex:95
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:31
 #: lib/explorer_web/templates/transaction/index.html.eex:31
@@ -319,9 +329,9 @@ msgstr ""
 msgid "Showing #%{number}"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:12
+#: lib/explorer_web/templates/address/overview.html.eex:11
+#: lib/explorer_web/templates/address_transaction/index.html.eex:121
 #: lib/explorer_web/templates/address_transaction/index.html.eex:124
-#: lib/explorer_web/templates/address_transaction/index.html.eex:127
 #: lib/explorer_web/templates/block_transaction/index.html.eex:146
 #: lib/explorer_web/templates/chain/show.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:80
@@ -335,6 +345,8 @@ msgstr ""
 msgid "Gwei"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:15
+#: lib/explorer_web/templates/address_transaction/index.html.eex:15
 #: lib/explorer_web/templates/transaction/show.html.eex:8
 #: lib/explorer_web/templates/transaction_log/index.html.eex:8
 msgid "Internal Transactions"
@@ -344,6 +356,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:100
 #: lib/explorer_web/templates/transaction/show.html.eex:52
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -373,12 +386,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:36
-#: lib/explorer_web/views/address_transaction_view.ex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:28
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
+#: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:77
+#: lib/explorer_web/templates/address_transaction/index.html.eex:73
 msgid "Fee"
 msgstr ""
 
@@ -388,4 +403,8 @@ msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
+msgstr ""
+
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:63
+msgid "Parent Tx Hash"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,7 +10,8 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:73
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:65
+#: lib/explorer_web/templates/address_transaction/index.html.eex:69
 #: lib/explorer_web/templates/block/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:99
 #: lib/explorer_web/templates/chain/show.html.eex:71
@@ -20,7 +21,8 @@ msgstr ""
 msgid "Age"
 msgstr "Age"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:72
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:64
+#: lib/explorer_web/templates/address_transaction/index.html.eex:68
 #: lib/explorer_web/templates/block_transaction/index.html.eex:98
 #: lib/explorer_web/templates/chain/show.html.eex:28
 #: lib/explorer_web/templates/chain/show.html.eex:109
@@ -43,7 +45,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 msgid "Gas Used"
 msgstr "Gas Used"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:71
+#: lib/explorer_web/templates/address_transaction/index.html.eex:67
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
 #: lib/explorer_web/templates/block_transaction/index.html.eex:97
 #: lib/explorer_web/templates/chain/show.html.eex:108
@@ -61,7 +63,8 @@ msgstr "Height"
 msgid "POA Network Explorer"
 msgstr "POA Network Explorer"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:23
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:8
+#: lib/explorer_web/templates/address_transaction/index.html.eex:8
 #: lib/explorer_web/templates/block/index.html.eex:31
 #: lib/explorer_web/templates/block_transaction/index.html.eex:16
 #: lib/explorer_web/templates/block_transaction/index.html.eex:84
@@ -74,7 +77,8 @@ msgstr "POA Network Explorer"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:76
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:68
+#: lib/explorer_web/templates/address_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:102
 #: lib/explorer_web/templates/chain/show.html.eex:111
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -164,19 +168,22 @@ msgstr "%{confirmations} block confirmations"
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:3
+#: lib/explorer_web/templates/address/overview.html.eex:2
 #: lib/explorer_web/templates/transaction_log/index.html.eex:26
 msgid "Address"
 msgstr "Address"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_transaction/index.html.eex:74
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:46
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_transaction/index.html.eex:70
 #: lib/explorer_web/templates/block_transaction/index.html.eex:100
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
 #: lib/explorer_web/templates/transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/overview.html.eex:47
 #: lib/explorer_web/templates/transaction/show.html.eex:26
-#: lib/explorer_web/views/address_transaction_view.ex:12
+#: lib/explorer_web/views/address_internal_transaction_view.ex:7
+#: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr "From"
 
@@ -189,14 +196,17 @@ msgstr "Overview"
 msgid "Success"
 msgstr "Success"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:41
-#: lib/explorer_web/templates/address_transaction/index.html.eex:75
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:34
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/explorer_web/templates/address_transaction/index.html.eex:35
+#: lib/explorer_web/templates/address_transaction/index.html.eex:71
 #: lib/explorer_web/templates/block_transaction/index.html.eex:101
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/overview.html.eex:61
 #: lib/explorer_web/templates/transaction/show.html.eex:27
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_internal_transaction_view.ex:6
+#: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr "To"
 
@@ -209,7 +219,7 @@ msgstr "Transaction Hash"
 msgid "Transaction Status"
 msgstr "Transaction Status"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:10
+#: lib/explorer_web/templates/address/overview.html.eex:9
 msgid "Balance"
 msgstr "Balance"
 
@@ -316,7 +326,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:69
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
 #: lib/explorer_web/templates/block_transaction/index.html.eex:95
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:31
 #: lib/explorer_web/templates/transaction/index.html.eex:31
@@ -331,9 +341,9 @@ msgstr ""
 msgid "Showing #%{number}"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:12
+#: lib/explorer_web/templates/address/overview.html.eex:11
+#: lib/explorer_web/templates/address_transaction/index.html.eex:121
 #: lib/explorer_web/templates/address_transaction/index.html.eex:124
-#: lib/explorer_web/templates/address_transaction/index.html.eex:127
 #: lib/explorer_web/templates/block_transaction/index.html.eex:146
 #: lib/explorer_web/templates/chain/show.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:80
@@ -347,6 +357,8 @@ msgstr "POA"
 msgid "Gwei"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:15
+#: lib/explorer_web/templates/address_transaction/index.html.eex:15
 #: lib/explorer_web/templates/transaction/show.html.eex:8
 #: lib/explorer_web/templates/transaction_log/index.html.eex:8
 msgid "Internal Transactions"
@@ -356,6 +368,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:100
 #: lib/explorer_web/templates/transaction/show.html.eex:52
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -385,12 +398,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:36
-#: lib/explorer_web/views/address_transaction_view.ex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:28
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
+#: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:77
+#: lib/explorer_web/templates/address_transaction/index.html.eex:73
 msgid "Fee"
 msgstr ""
 
@@ -400,4 +415,8 @@ msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
+msgstr ""
+
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:63
+msgid "Parent Tx Hash"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
@@ -23,6 +23,7 @@ defmodule ExplorerWeb.AddressInternalTransactionControllerTest do
 
       to_internal_transaction =
         insert(:internal_transaction, transaction_id: transaction.id, to_address_id: address.id, index: 2)
+
       path = address_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, address.hash)
 
       conn = get(conn, path)

--- a/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
@@ -19,9 +19,10 @@ defmodule ExplorerWeb.AddressInternalTransactionControllerTest do
       insert(:block_transaction, block_id: block.id, transaction_id: transaction.id)
 
       from_internal_transaction =
-        insert(:internal_transaction, transaction_id: transaction.id, from_address_id: address.id)
+        insert(:internal_transaction, transaction_id: transaction.id, from_address_id: address.id, index: 1)
 
-      to_internal_transaction = insert(:internal_transaction, transaction_id: transaction.id, to_address_id: address.id)
+      to_internal_transaction =
+        insert(:internal_transaction, transaction_id: transaction.id, to_address_id: address.id, index: 2)
       path = address_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, address.hash)
 
       conn = get(conn, path)

--- a/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule ExplorerWeb.AddressInternalTransactionControllerTest do
+  use ExplorerWeb.ConnCase
+
+  import ExplorerWeb.Router.Helpers, only: [address_internal_transaction_path: 4]
+
+  describe "GET index/3" do
+    test "without address", %{conn: conn} do
+      conn =
+        conn
+        |> get(address_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, "0xcafe"))
+
+      assert html_response(conn, 404)
+    end
+
+    test "returns internal transactions for the address", %{conn: conn} do
+      address = insert(:address)
+      block = insert(:block)
+      transaction = insert(:transaction)
+      insert(:block_transaction, block_id: block.id, transaction_id: transaction.id)
+
+      from_internal_transaction =
+        insert(:internal_transaction, transaction_id: transaction.id, from_address_id: address.id)
+
+      to_internal_transaction = insert(:internal_transaction, transaction_id: transaction.id, to_address_id: address.id)
+      path = address_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, address.hash)
+
+      conn = get(conn, path)
+
+      actual_transaction_ids =
+        conn.assigns.page
+        |> Enum.map(fn internal_transaction -> internal_transaction.id end)
+
+      assert Enum.member?(actual_transaction_ids, from_internal_transaction.id)
+      assert Enum.member?(actual_transaction_ids, to_internal_transaction.id)
+    end
+  end
+end

--- a/apps/explorer_web/test/explorer_web/features/address_page_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_page_test.exs
@@ -4,6 +4,7 @@ defmodule ExplorerWeb.AddressPageTest do
   import Wallaby.Query, only: [css: 2]
 
   alias Explorer.Chain.{Credit, Debit}
+  alias ExplorerWeb.AddressPage
 
   setup do
     block =
@@ -60,22 +61,28 @@ defmodule ExplorerWeb.AddressPageTest do
     {:ok, %{internal: internal}}
   end
 
-  test "see's all addresses transactions by default", %{session: session} do
+  def assert_true(session, assertion) do
+    assert assertion.(session)
     session
-    |> visit("/en/addresses/0xlincoln")
-    |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
-    |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
   end
 
-  # test "can see internal transactions for an address", %{
-  #   session: session,
-  #   internal: internal
-  # } do
-  #   session
-  #   |> visit("/en/transactions/0xSk8")
-  #   |> click(link("Internal Transactions"))
-  #   |> assert_has(css(".internal-transaction__table", text: internal.call_type))
-  # end
+  test "sees all addresses transactions by default", %{session: session} do
+    session
+    |> AddressPage.visit_page("0xlincoln")
+    |> assert_has(AddressPage.transaction("0xSk8"))
+    |> assert_has(AddressPage.transaction("0xrazerscooter"))
+  end
+
+  test "can see internal transactions for an address", %{
+    session: session
+    # internal: internal
+  } do
+
+    session
+    |> AddressPage.visit_page("0xlincoln")
+    |> AddressPage.click_internal_transactions()
+    |> assert_has(AddressPage.internal_transactions(count: 1))
+  end
 
   test "can filter to only see transactions to an address", %{session: session} do
     session

--- a/apps/explorer_web/test/explorer_web/features/address_page_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_page_test.exs
@@ -1,0 +1,106 @@
+defmodule ExplorerWeb.AddressPageTest do
+  use ExplorerWeb.FeatureCase, async: true
+
+  import Wallaby.Query, only: [css: 2]
+
+  alias Explorer.Chain.{Credit, Debit}
+
+  setup do
+    block =
+      insert(:block, %{
+            number: 555,
+            timestamp: Timex.now() |> Timex.shift(hours: -2),
+            gas_used: 123_987
+             })
+
+    for _ <- 0..3, do: insert(:transaction) |> with_block(block)
+    insert(:transaction, hash: "0xC001", gas: 5891) |> with_block
+
+    lincoln = insert(:address, hash: "0xlincoln")
+    taft = insert(:address, hash: "0xhowardtaft")
+
+    transaction =
+      insert(
+        :transaction,
+        hash: "0xSk8",
+        value: Explorer.Chain.Wei.from(Decimal.new(5656), :ether),
+        gas: Decimal.new(1_230_000_000_000_123_123),
+        gas_price: Decimal.new(7_890_000_000_898_912_300_045),
+        input: "0x00012",
+        nonce: 99045,
+        inserted_at: Timex.parse!("1970-01-01T00:00:18-00:00", "{ISO:Extended}"),
+        updated_at: Timex.parse!("1980-01-01T00:00:18-00:00", "{ISO:Extended}"),
+        from_address_id: taft.id,
+        to_address_id: lincoln.id
+      )
+
+    insert(:block_transaction, block: block, transaction: transaction)
+
+    receipt = insert(:receipt, transaction: transaction, status: 1)
+    insert(:log, address_id: lincoln.id, receipt: receipt)
+
+    # From Lincoln to Taft.
+    txn_from_lincoln =
+      insert(
+        :transaction,
+        hash: "0xrazerscooter",
+        from_address_id: lincoln.id,
+        to_address_id: taft.id
+      )
+
+    insert(:block_transaction, block: block, transaction: txn_from_lincoln)
+
+    insert(:receipt, transaction: txn_from_lincoln)
+
+    internal = insert(:internal_transaction, transaction_id: transaction.id)
+
+    Credit.refresh()
+    Debit.refresh()
+
+    {:ok, %{internal: internal}}
+  end
+
+  test "see's all addresses transactions by default", %{session: session} do
+    session
+    |> visit("/en/addresses/0xlincoln")
+    |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
+    |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
+  end
+
+  # test "can see internal transactions for an address", %{
+  #   session: session,
+  #   internal: internal
+  # } do
+  #   session
+  #   |> visit("/en/transactions/0xSk8")
+  #   |> click(link("Internal Transactions"))
+  #   |> assert_has(css(".internal-transaction__table", text: internal.call_type))
+  # end
+
+  test "can filter to only see transactions to an address", %{session: session} do
+    session
+    |> visit("/en/addresses/0xlincoln")
+    |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
+    |> click(css(".address__link", text: "To"))
+    |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
+    |> refute_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
+  end
+
+  test "can filter to only see transactions from an address", %{session: session} do
+    session
+    |> visit("/en/addresses/0xlincoln")
+    |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
+    |> click(css(".address__link", text: "From"))
+    |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
+    |> refute_has(css(".transactions__link--long-hash", text: "0xSk8"))
+  end
+
+  test "views addresses", %{session: session} do
+    insert(:address, hash: "0xthinmints", balance: 500)
+
+    session
+    |> visit("/en/addresses/0xthinmints")
+    |> assert_has(css(".address__balance", text: "0.000,000,000,000,000,500 POA"))
+  end
+
+end

--- a/apps/explorer_web/test/explorer_web/features/address_page_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_page_test.exs
@@ -1,109 +1,90 @@
 defmodule ExplorerWeb.AddressPageTest do
   use ExplorerWeb.FeatureCase, async: true
 
-  import Wallaby.Query, only: [css: 2]
-
-  alias Explorer.Chain.{Credit, Debit}
   alias ExplorerWeb.AddressPage
 
   setup do
-    block =
-      insert(:block, %{
-        number: 555,
-        timestamp: Timex.now() |> Timex.shift(hours: -2),
-        gas_used: 123_987
-      })
+    block = insert(:block)
 
-    for _ <- 0..3, do: insert(:transaction) |> with_block(block)
-    insert(:transaction, hash: "0xC001", gas: 5891) |> with_block
+    lincoln = insert(:address)
+    taft = insert(:address)
 
-    lincoln = insert(:address, hash: "0xlincoln")
-    taft = insert(:address, hash: "0xhowardtaft")
+    from_taft =
+      :transaction
+      |> insert(from_address_id: taft.id, to_address_id: lincoln.id)
+      |> with_block(block)
+      |> with_receipt()
 
-    transaction =
-      insert(
-        :transaction,
-        hash: "0xSk8",
-        value: Explorer.Chain.Wei.from(Decimal.new(5656), :ether),
-        gas: Decimal.new(1_230_000_000_000_123_123),
-        gas_price: Decimal.new(7_890_000_000_898_912_300_045),
-        input: "0x00012",
-        nonce: 99045,
-        inserted_at: Timex.parse!("1970-01-01T00:00:18-00:00", "{ISO:Extended}"),
-        updated_at: Timex.parse!("1980-01-01T00:00:18-00:00", "{ISO:Extended}"),
-        from_address_id: taft.id,
-        to_address_id: lincoln.id
-      )
+    from_lincoln =
+      :transaction
+      |> insert(from_address_id: lincoln.id, to_address_id: taft.id)
+      |> with_block(block)
+      |> with_receipt()
 
-    insert(:block_transaction, block: block, transaction: transaction)
-
-    receipt = insert(:receipt, transaction: transaction, status: 1)
-    insert(:log, address_id: lincoln.id, receipt: receipt)
-
-    # From Lincoln to Taft.
-    txn_from_lincoln =
-      insert(
-        :transaction,
-        hash: "0xrazerscooter",
-        from_address_id: lincoln.id,
-        to_address_id: taft.id
-      )
-
-    insert(:block_transaction, block: block, transaction: txn_from_lincoln)
-
-    insert(:receipt, transaction: txn_from_lincoln)
-
-    Credit.refresh()
-    Debit.refresh()
-
-    {:ok, %{address: lincoln, transaction: transaction}}
+    {:ok,
+     %{
+       transactions: %{from_lincoln: from_lincoln, from_taft: from_taft},
+       addresses: %{lincoln: lincoln, taft: taft}
+     }}
   end
 
   test "viewing address overview information", %{session: session} do
-    insert(:address, hash: "0xthinmints", balance: 500)
+    address = insert(:address, balance: 500)
 
     session
-    |> visit("/en/addresses/0xthinmints")
-    |> assert_has(css(".address__balance", text: "0.000,000,000,000,000,500 POA"))
+    |> AddressPage.visit_page(address)
+    |> assert_text(AddressPage.balance(), "0.000,000,000,000,000,500 POA")
   end
 
   describe "viewing transactions" do
-    test "sees all addresses transactions by default", %{address: address, session: session} do
+    test "sees all addresses transactions by default", %{
+      addresses: addresses,
+      session: session,
+      transactions: transactions
+    } do
       session
-      |> AddressPage.visit_page(address.hash)
-      |> assert_has(AddressPage.transaction("0xSk8"))
-      |> assert_has(AddressPage.transaction("0xrazerscooter"))
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> assert_has(AddressPage.transaction(transactions.from_taft))
+      |> assert_has(AddressPage.transaction(transactions.from_lincoln))
     end
 
-    test "can filter to only see transactions to an address", %{address: address, session: session} do
+    test "can filter to only see transactions from an address", %{
+      addresses: addresses,
+      session: session,
+      transactions: transactions
+    } do
       session
-      |> visit("/en/addresses/#{address.hash}")
-      |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
-      |> click(css(".address__link", text: "To"))
-      |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
-      |> refute_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> AddressPage.apply_filter("From")
+      |> assert_has(AddressPage.transaction(transactions.from_lincoln))
+      |> refute_has(AddressPage.transaction(transactions.from_taft))
     end
 
-    test "can filter to only see transactions from an address", %{address: address, session: session} do
+    test "can filter to only see transactions to an address", %{
+      addresses: addresses,
+      session: session,
+      transactions: transactions
+    } do
       session
-      |> visit("/en/addresses/#{address.hash}")
-      |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
-      |> click(css(".address__link", text: "From"))
-      |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
-      |> refute_has(css(".transactions__link--long-hash", text: "0xSk8"))
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> AddressPage.apply_filter("To")
+      |> refute_has(AddressPage.transaction(transactions.from_lincoln))
+      |> assert_has(AddressPage.transaction(transactions.from_taft))
     end
   end
 
   describe "viewing internal transactions" do
-    setup %{address: address, transaction: transaction} do
-      insert(:internal_transaction, transaction_id: transaction.id, to_address_id: address.id)
-      insert(:internal_transaction, transaction_id: transaction.id, from_address_id: address.id)
+    setup %{addresses: addresses, transactions: transactions} do
+      address_id = addresses.lincoln.id
+      transaction_id = transactions.from_lincoln.id
+      insert(:internal_transaction, transaction_id: transaction_id, to_address_id: address_id, index: 0)
+      insert(:internal_transaction, transaction_id: transaction_id, from_address_id: address_id, index: 1)
       :ok
     end
 
-    test "can see internal transactions for an address", %{address: address, session: session} do
+    test "can see internal transactions for an address", %{addresses: addresses, session: session} do
       session
-      |> AddressPage.visit_page(address.hash)
+      |> AddressPage.visit_page(addresses.lincoln)
       |> AddressPage.click_internal_transactions()
       |> assert_has(AddressPage.internal_transactions(count: 2))
     end
@@ -118,7 +99,7 @@ defmodule ExplorerWeb.AddressPageTest do
 
     test "can filter to only see internal transactions to an address", %{addresses: addresses, session: session} do
       session
-      |> AddressPage.visit_page(address.hash)
+      |> AddressPage.visit_page(addresses.lincoln)
       |> AddressPage.click_internal_transactions()
       |> AddressPage.apply_filter("To")
       |> assert_has(AddressPage.internal_transactions(count: 1))

--- a/apps/explorer_web/test/explorer_web/features/contributor_browsing_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/contributor_browsing_test.exs
@@ -223,38 +223,5 @@ defmodule ExplorerWeb.UserListTest do
       |> click(css(".transaction-log__link", text: "0xlincoln"))
       |> assert_has(css(".address__subheading", text: "0xlincoln"))
     end
-
-    test "see's all addresses transactions by default", %{session: session} do
-      session
-      |> visit("/en/addresses/0xlincoln")
-      |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
-      |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
-    end
-
-    test "can filter to only see transactions to an address", %{session: session} do
-      session
-      |> visit("/en/addresses/0xlincoln")
-      |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
-      |> click(css(".address__link", text: "To"))
-      |> assert_has(css(".transactions__link--long-hash", text: "0xSk8"))
-      |> refute_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
-    end
-
-    test "can filter to only see transactions from an address", %{session: session} do
-      session
-      |> visit("/en/addresses/0xlincoln")
-      |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
-      |> click(css(".address__link", text: "From"))
-      |> assert_has(css(".transactions__link--long-hash", text: "0xrazerscooter"))
-      |> refute_has(css(".transactions__link--long-hash", text: "0xSk8"))
-    end
-  end
-
-  test "views addresses", %{session: session} do
-    insert(:address, hash: "0xthinmints", balance: 500)
-
-    session
-    |> visit("/en/addresses/0xthinmints")
-    |> assert_has(css(".address__balance", text: "0.000,000,000,000,000,500 POA"))
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -22,4 +22,10 @@ defmodule ExplorerWeb.AddressPage do
   def internal_transactions(count: count) do
     css(@internal_transactions_selector, count: count)
   end
+
+  def apply_filter(session, direction) do
+    session
+    |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
+    |> click(css(".address__link", text: direction))
+  end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -1,0 +1,25 @@
+defmodule ExplorerWeb.AddressPage do
+  @moduledoc false
+
+  use Wallaby.DSL
+  import Wallaby.Query, only: [css: 1, css: 2]
+
+  def visit_page(session, address_hash) do
+    visit(session, "/en/addresses/#{address_hash}")
+  end
+
+  @internal_transactions_link_selector "[data-test='internal_transactions_tab_link']"
+  def click_internal_transactions(session) do
+    click(session, css(@internal_transactions_link_selector))
+  end
+
+  @transaction_selector ".transactions__link--long-hash"
+  def transaction(transaction_hash) do
+    css(@transaction_selector, text: transaction_hash)
+  end
+
+  @internal_transactions_selector "[data-test='internal_transaction']"
+  def internal_transactions(count: count) do
+    css(@internal_transactions_selector, count: count)
+  end
+end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -3,6 +3,9 @@ defmodule ExplorerWeb.AddressPage do
 
   use Wallaby.DSL
   import Wallaby.Query, only: [css: 1, css: 2]
+  alias Explorer.Chain.{Address, Transaction}
+
+  def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
 
   def visit_page(session, address_hash) do
     visit(session, "/en/addresses/#{address_hash}")
@@ -13,7 +16,9 @@ defmodule ExplorerWeb.AddressPage do
     click(session, css(@internal_transactions_link_selector))
   end
 
-  @transaction_selector ".transactions__link--long-hash"
+  @transaction_selector "[data-test='transaction_hash']"
+  def transaction(%Transaction{hash: transaction_hash}), do: transaction(transaction_hash)
+
   def transaction(transaction_hash) do
     css(@transaction_selector, text: transaction_hash)
   end
@@ -26,6 +31,10 @@ defmodule ExplorerWeb.AddressPage do
   def apply_filter(session, direction) do
     session
     |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
-    |> click(css(".address__link", text: direction))
+    |> click(css("[data-test='filter_option']", text: direction))
+  end
+
+  def balance do
+    css("[data-test='address_balance']")
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -5,29 +5,6 @@ defmodule ExplorerWeb.AddressPage do
   import Wallaby.Query, only: [css: 1, css: 2]
   alias Explorer.Chain.{Address, Transaction}
 
-  def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
-
-  def visit_page(session, address_hash) do
-    visit(session, "/en/addresses/#{address_hash}")
-  end
-
-  @internal_transactions_link_selector "[data-test='internal_transactions_tab_link']"
-  def click_internal_transactions(session) do
-    click(session, css(@internal_transactions_link_selector))
-  end
-
-  @transaction_selector "[data-test='transaction_hash']"
-  def transaction(%Transaction{hash: transaction_hash}), do: transaction(transaction_hash)
-
-  def transaction(transaction_hash) do
-    css(@transaction_selector, text: transaction_hash)
-  end
-
-  @internal_transactions_selector "[data-test='internal_transaction']"
-  def internal_transactions(count: count) do
-    css(@internal_transactions_selector, count: count)
-  end
-
   def apply_filter(session, direction) do
     session
     |> click(css("[data-test='filter_dropdown']", text: "Filter: All"))
@@ -36,5 +13,25 @@ defmodule ExplorerWeb.AddressPage do
 
   def balance do
     css("[data-test='address_balance']")
+  end
+
+  def click_internal_transactions(session) do
+    click(session, css("[data-test='internal_transactions_tab_link']"))
+  end
+
+  def internal_transactions(count: count) do
+    css("[data-test='internal_transaction']", count: count)
+  end
+
+  def transaction(%Transaction{hash: transaction_hash}), do: transaction(transaction_hash)
+
+  def transaction(transaction_hash) do
+    css("[data-test='transaction_hash']", text: transaction_hash)
+  end
+
+  def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
+
+  def visit_page(session, address_hash) do
+    visit(session, "/en/addresses/#{address_hash}")
   end
 end

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 84
+    "minimum_coverage": 85
   },
   "terminal_options": {
     "file_column_width": 120


### PR DESCRIPTION
Resolves #15

# Changelog
## Enhancements
* Adds internal transaction tab to address page, newest first
* Adds `address_to_internal_transactions` function to Chain context
* Refactor address page tests into separate module utilizing the page module test pattern