### PR TITLE
Add transaction count to address page

### DIFF
--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -8,6 +8,22 @@ defmodule Explorer.ChainTest do
 
   doctest Explorer.Chain
 
+  describe "address_to_transaction_count/1" do
+    test "without transactions" do
+      address = insert(:address)
+
+      assert Chain.address_to_transaction_count(address) == 0
+    end
+
+    test "with transactions" do
+      %Transaction{from_address_hash: address_hash} = insert(:transaction)
+      insert(:transaction, to_address_hash: address_hash)
+      address = Repo.get!(Address, address_hash)
+
+      assert Chain.address_to_transaction_count(address) == 2
+    end
+  end
+
   describe "address_to_transactions/2" do
     test "without transactions" do
       address = insert(:address)
@@ -74,7 +90,6 @@ defmodule Explorer.ChainTest do
       %Transaction{hash: to_transaction_hash} = insert(:transaction, to_address_hash: address_hash)
       address = Repo.get!(Address, address_hash)
 
-      # only contains "to" transaction
       assert %Scrivener.Page{
                entries: [
                  %Transaction{hash: ^to_transaction_hash},
@@ -269,7 +284,7 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "block_to_transaction_bound/1" do
+  describe "block_to_transaction_count/1" do
     test "without transactions" do
       block = insert(:block)
 

--- a/apps/explorer_web/lib/explorer_web/controllers/address_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_controller.ex
@@ -1,7 +1,14 @@
 defmodule ExplorerWeb.AddressController do
   use ExplorerWeb, :controller
 
+  alias Explorer.Chain
+  alias Explorer.Chain.Address
+
   def show(conn, %{"id" => id, "locale" => locale}) do
     redirect(conn, to: address_transaction_path(conn, :index, locale, id))
+  end
+
+  def transaction_count(%Address{} = address) do
+    Chain.address_to_transaction_count(address)
   end
 end

--- a/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_internal_transaction_controller.ex
@@ -5,6 +5,8 @@ defmodule ExplorerWeb.AddressInternalTransactionController do
 
   use ExplorerWeb, :controller
 
+  import ExplorerWeb.AddressController, only: [transaction_count: 1]
+
   alias Explorer.Chain
 
   def index(conn, %{"address_id" => address_hash_string} = params) do
@@ -24,7 +26,14 @@ defmodule ExplorerWeb.AddressInternalTransactionController do
           Keyword.merge(options, current_filter(params))
         )
 
-      render(conn, "index.html", address: address, filter: params["filter"], page: page)
+      render(
+        conn,
+        "index.html",
+        address: address,
+        filter: params["filter"],
+        page: page,
+        transaction_count: transaction_count(address)
+      )
     else
       :error ->
         not_found(conn)

--- a/apps/explorer_web/lib/explorer_web/controllers/address_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_transaction_controller.ex
@@ -5,6 +5,8 @@ defmodule ExplorerWeb.AddressTransactionController do
 
   use ExplorerWeb, :controller
 
+  import ExplorerWeb.AddressController, only: [transaction_count: 1]
+
   alias Explorer.Chain
 
   def index(conn, %{"address_id" => address_hash_string} = params) do
@@ -26,7 +28,14 @@ defmodule ExplorerWeb.AddressTransactionController do
           Keyword.merge(options, current_filter(params))
         )
 
-      render(conn, "index.html", address: address, filter: params["filter"], page: page)
+      render(
+        conn,
+        "index.html",
+        address: address,
+        filter: params["filter"],
+        page: page,
+        transaction_count: transaction_count(address)
+      )
     else
       :error ->
         not_found(conn)

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -11,6 +11,12 @@
           <%= balance(@address) %>
         </dd>
       </div>
+      <div class="address__item">
+        <dt class="address__item-key"><%= gettext "Number of Transactions" %></dt>
+        <dd class="address__item-value" data-test="transaction_count">
+          <%= Cldr.Number.to_string!(@transaction_count) %>
+        </dd>
+      </div>
     </dl>
   </div>
 </div>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -422,3 +422,7 @@ msgstr ""
 #: lib/explorer_web/templates/chain/show.html.eex:35
 msgid "USD"
 msgstr ""
+
+#: lib/explorer_web/templates/address/overview.html.eex:15
+msgid "Number of Transactions"
+msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -434,3 +434,7 @@ msgstr ""
 #: lib/explorer_web/templates/chain/show.html.eex:35
 msgid "USD"
 msgstr ""
+
+#: lib/explorer_web/templates/address/overview.html.eex:15
+msgid "Number of Transactions"
+msgstr ""

--- a/apps/explorer_web/test/explorer_web/features/address_page_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_page_test.exs
@@ -104,4 +104,12 @@ defmodule ExplorerWeb.AddressPageTest do
       |> assert_has(AddressPage.internal_transactions(count: 1))
     end
   end
+
+  test "viewing transaction count", %{addresses: addresses, session: session} do
+    insert_list(1000, :transaction, to_address_hash: addresses.lincoln.hash)
+
+    session
+    |> AddressPage.visit_page(addresses.lincoln)
+    |> assert_text(AddressPage.transaction_count(), "1,002")
+  end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -35,6 +35,10 @@ defmodule ExplorerWeb.AddressPage do
     css("[data-test='transaction_hash']", text: transaction_hash)
   end
 
+  def transaction_count do
+    css("[data-test='transaction_count']")
+  end
+
   def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
 
   def visit_page(session, address_hash) do


### PR DESCRIPTION
Resolves #142 

## Changelog

### Enhancements
* Adds transaction count for all transactions to or from an address on the address overview

<img width="703" alt="address transaction count" src="https://user-images.githubusercontent.com/966985/39940198-80e78b1a-5526-11e8-9a1a-330ab58436c6.png">
