### PR TITLE
Require index to be passed as an argument for internal transaction factory

### DIFF
--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -615,7 +615,7 @@ defmodule Explorer.ChainTest do
       address = insert(:address)
       block = insert(:block)
       transaction = insert(:transaction, block_hash: block.hash, index: 0, to_address_hash: address.hash)
-      insert(:internal_transaction, transaction_hash: transaction.hash, to_address_hash: address.hash)
+      insert(:internal_transaction, index: 0, to_address_hash: address.hash, transaction_hash: transaction.hash)
 
       assert %{entries: []} = Chain.address_to_internal_transactions(address)
     end
@@ -686,7 +686,7 @@ defmodule Explorer.ChainTest do
     test "excludes internal transaction with no siblings in the transaction" do
       block = insert(:block)
       %Transaction{hash: hash} = insert(:transaction, block_hash: block.hash, index: 0)
-      insert(:internal_transaction, transaction_hash: hash)
+      insert(:internal_transaction, transaction_hash: hash, index: 0)
 
       result =
         hash

--- a/apps/explorer/test/explorer/indexer/block_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/block_fetcher_test.exs
@@ -52,7 +52,7 @@ defmodule Explorer.Indexer.BlockFetcherTest do
         transaction = insert(:transaction, block_hash: block.hash, index: index)
         receipt = insert(:receipt, transaction_hash: transaction.hash, transaction_index: transaction.index)
         insert(:log, transaction_hash: receipt.transaction_hash)
-        insert(:internal_transaction, transaction_hash: transaction.hash)
+        insert(:internal_transaction, transaction_hash: transaction.hash, index: 0)
       end)
 
       :ok

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -178,7 +178,6 @@ defmodule Explorer.Factory do
       from_address_hash: insert(:address).hash,
       gas: gas,
       gas_used: gas_used,
-      index: 0,
       # caller MUST suppy `index`
       init: data(:internal_transaction_init),
       trace_address: [],

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -52,7 +52,7 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     internal_receipt =
       insert(:receipt, transaction_hash: txn_from_lincoln.hash, transaction_index: txn_from_lincoln.index)
 
-    internal = insert(:internal_transaction, transaction_hash: internal_receipt.transaction_hash)
+    internal = insert(:internal_transaction, index: 0, transaction_hash: internal_receipt.transaction_hash)
 
     Credit.refresh()
     Debit.refresh()


### PR DESCRIPTION
Fixes #171 

## Changelog

### Bugfixes

* Fix intermittent test failures from autogenerated duplicate `index` values by requiring the index to be passed in as an argument