### PR TITLE
Use configuration to conditionally start processes

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -16,6 +16,14 @@ config :explorer,
 
 config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: 2_000
 
+config :explorer, Explorer.Chain.Statistics.Server, enabled: true
+
+config :explorer, Explorer.ExchangeRates, enabled: true
+
+config :explorer, Explorer.Indexer.Supervisor, enabled: true
+
+config :explorer, Explorer.Market.History.Cataloger, enabled: true
+
 config :explorer, Explorer.Repo, migration_timestamps: [type: :utc_datetime]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -7,3 +7,11 @@ config :explorer, Explorer.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   ownership_timeout: 60_000
+
+config :explorer, Explorer.Chain.Statistics.Server, enabled: false
+
+config :explorer, Explorer.ExchangeRates, enabled: false
+
+config :explorer, Explorer.Indexer.Supervisor, enabled: false
+
+config :explorer, Explorer.Market.History.Cataloger, enabled: false

--- a/apps/explorer/coveralls.json
+++ b/apps/explorer/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "skip_files": [
+    "lib/explorer/application.ex"
+  ]
+}


### PR DESCRIPTION
Removes usage of `Mix.env/0` in application startup since it isn't available at runtime for a distillery release.

# Changelog

## Fixes
* Application startup uses Mix configuration to conditionally start children instead of relying on `Mix.env`