### PR TITLE
Fix flaky tests

### DIFF
--- a/apps/explorer/test/explorer/chain/statistics/server_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics/server_test.exs
@@ -14,13 +14,13 @@ defmodule Explorer.Chain.Statistics.ServerTest do
     test "returns a new chain when not told to refresh" do
       {:ok, statistics} = Server.init(refresh: false)
 
-      assert statistics.number == Statistics.fetch().number
+      assert statistics == %Statistics{}
     end
 
     test "returns a new chain when told to refresh" do
       {:ok, statistics} = Server.init(refresh: true)
 
-      assert statistics == Statistics.fetch()
+      assert statistics == %Statistics{}
     end
 
     test "refreshes when told to refresh" do


### PR DESCRIPTION
Fixes #94

# Changelog
## Bug Fixes
* Don't match against `Statistics.fetch()` since the `%Statistics{}` from `Server.init` was previously changed to be empty to prevent `Statistics.fetch` from timing out `init` and killing the whole supervision tree and then VM.