### PR TITLE
Remove decimal commas

### DIFF
--- a/apps/explorer_web/lib/explorer_web/exchange_rates/usd.ex
+++ b/apps/explorer_web/lib/explorer_web/exchange_rates/usd.ex
@@ -17,6 +17,12 @@ defmodule ExplorerWeb.ExchangeRates.USD do
   alias Explorer.Chain.Wei
   alias Explorer.ExchangeRates.Token
 
+  def from(nil), do: null()
+
+  def from(%Decimal{} = usd_decimal) do
+    %__MODULE__{value: usd_decimal}
+  end
+
   def from(nil, _), do: null()
 
   def from(_, nil), do: null()

--- a/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
@@ -28,16 +28,16 @@
         <div class="u-push-md-left">
           <div class="graph__squares graph__squares--price"></div>
           <%= gettext "Price" %> </br>
-          $<%= format_exchange_rate(@exchange_rate) %> <%= gettext "USD" %>
+          <%= format_exchange_rate(@exchange_rate) %>
         </div>
         <div>
           <div class="graph__squares graph__squares--mcap"></div>
           <%= gettext "Market Cap" %> </br>
-          $<%= format_market_cap(@exchange_rate) %> <%= gettext "USD" %>
+          <%= format_market_cap(@exchange_rate) %>
         </div>
         <div class="u-push-md-right">
           <%= gettext "24h Volume" %> </br>
-          $<%= format_volume_24h(@exchange_rate) %> <%= gettext "USD" %>
+          <%= format_volume_24h(@exchange_rate) %>
         </div>
       </div>
     </div>

--- a/apps/explorer_web/lib/explorer_web/views/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_view.ex
@@ -13,7 +13,7 @@ defmodule ExplorerWeb.AddressView do
   Returns a formatted address balance and includes the unit.
   """
   def balance(%Address{fetched_balance: balance}) do
-    format_wei_value(balance, :ether, fractional_digits: 18)
+    format_wei_value(balance, :ether)
   end
 
   def formatted_usd(%Address{fetched_balance: nil}, _), do: nil

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -14,8 +14,6 @@ defmodule ExplorerWeb.ChainView do
     end
   end
 
-  def format_exchange_rate(%Token{usd_value: nil}), do: nil
-
   def format_exchange_rate(%Token{usd_value: usd_value}) do
     usd_value
     |> USD.from()

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -2,6 +2,7 @@ defmodule ExplorerWeb.ChainView do
   use ExplorerWeb, :view
 
   alias Explorer.ExchangeRates.Token
+  alias ExplorerWeb.ExchangeRates.USD
 
   def encode_market_history_data(market_history_data) do
     market_history_data
@@ -16,17 +17,20 @@ defmodule ExplorerWeb.ChainView do
   def format_exchange_rate(%Token{usd_value: nil}), do: nil
 
   def format_exchange_rate(%Token{usd_value: usd_value}) do
-    Cldr.Number.to_string!(usd_value, fractional_digits: 6)
+    usd_value
+    |> USD.from()
+    |> format_usd_value()
   end
 
   def format_volume_24h(%Token{volume_24h_usd: volume_24h}) do
-    format_number(volume_24h)
+    volume_24h
+    |> USD.from()
+    |> format_usd_value()
   end
 
   def format_market_cap(%Token{market_cap_usd: market_cap}) do
-    format_number(market_cap)
+    market_cap
+    |> USD.from()
+    |> format_usd_value()
   end
-
-  defp format_number(nil), do: nil
-  defp format_number(number), do: Cldr.Number.to_string!(number)
 end

--- a/apps/explorer_web/lib/explorer_web/views/currency_helpers.ex
+++ b/apps/explorer_web/lib/explorer_web/views/currency_helpers.ex
@@ -14,10 +14,10 @@ defmodule ExplorerWeb.CurrencyHelpers do
   ## Examples
 
       iex> format_usd_value(%USD{value: Decimal.new(5)})
-      "$5 USD"
+      "$5.00 USD"
 
       iex> format_usd_value(%USD{value: Decimal.new(5000)})
-      "$5,000 USD"
+      "$5,000.00 USD"
 
       iex> format_usd_value(%USD{value: Decimal.new(0.000005)})
       "$0.000005 USD"
@@ -28,7 +28,7 @@ defmodule ExplorerWeb.CurrencyHelpers do
   def format_usd_value(%USD{value: nil}), do: nil
 
   def format_usd_value(%USD{value: value}) do
-    case Number.to_string(value, format: "#,##0.##################") do
+    case Number.to_string(value, format: "#,##0.00################") do
       {:ok, formatted} -> "$#{formatted} " <> gettext("USD")
       _ -> nil
     end

--- a/apps/explorer_web/lib/explorer_web/views/transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/transaction_view.ex
@@ -34,7 +34,7 @@ defmodule ExplorerWeb.TransactionView do
   end
 
   defp fee_to_currency({fee_type, fee}, denomination: denomination) do
-    {fee_type, format_wei_value(Wei.from(fee, :wei), denomination, fractional_digits: 18)}
+    {fee_type, format_wei_value(Wei.from(fee, :wei), denomination)}
   end
 
   defp fee_to_currency({fee_type, fee}, exchange_rate: %Token{} = exchange_rate) do

--- a/apps/explorer_web/lib/explorer_web/views/wei_helpers.ex
+++ b/apps/explorer_web/lib/explorer_web/views/wei_helpers.ex
@@ -9,7 +9,7 @@ defmodule ExplorerWeb.WeiHelpers do
 
   @valid_units ~w(wei gwei ether)a
 
-  @type format_option :: {:fractional_digits, pos_integer()} | {:include_unit_label, boolean()}
+  @type format_option :: {:include_unit_label, boolean()}
 
   @type format_options :: [format_option()]
 
@@ -22,7 +22,6 @@ defmodule ExplorerWeb.WeiHelpers do
   The third argument allows for keyword options to be passed for formatting the
   converted number.
 
-    * `:fractional_digits` - Integer. Number of fractional digits to include
     * `:include_unit_label` - Boolean (Defaults to `true`). Flag for if the unit
       label should be included in the returned string
 
@@ -40,11 +39,10 @@ defmodule ExplorerWeb.WeiHelpers do
       # With formatting options
 
       iex> format_wei_value(
-      ...>   %Wei{value: Decimal.new(1)},
-      ...>   :wei,
-      ...>   fractional_digits: 3
+      ...>   %Wei{value: Decimal.new(1000500000000000000)},
+      ...>   :ether
       ...> )
-      "1.000 Wei"
+      "1.0005 POA"
 
       iex> format_wei_value(
       ...>   %Wei{value: Decimal.new(10)},
@@ -55,12 +53,10 @@ defmodule ExplorerWeb.WeiHelpers do
   """
   @spec format_wei_value(Wei.t(), Wei.unit(), format_options()) :: String.t()
   def format_wei_value(%Wei{} = wei, unit, options \\ []) when unit in @valid_units do
-    number_format_options = build_number_format_options(options)
-
     converted_value =
       wei
       |> Wei.to(unit)
-      |> Cldr.Number.to_string!(number_format_options)
+      |> Cldr.Number.to_string!(format: "#,##0.##################")
 
     if Keyword.get(options, :include_unit_label, true) do
       display_unit = display_unit(unit)
@@ -70,24 +66,7 @@ defmodule ExplorerWeb.WeiHelpers do
     end
   end
 
-  defp build_number_format_options(options) do
-    Enum.reduce(options, [], fn option, formatted_options ->
-      case parse_number_format_option(option) do
-        nil -> formatted_options
-        {key, value} -> Keyword.put(formatted_options, key, value)
-      end
-    end)
-  end
-
   defp display_unit(:wei), do: gettext("Wei")
   defp display_unit(:gwei), do: gettext("Gwei")
   defp display_unit(:ether), do: gettext("Ether")
-
-  defguardp is_fractional_digit(digits) when is_integer(digits) and digits > 0
-
-  defp parse_number_format_option({:fractional_digits, digits}) when is_fractional_digit(digits) do
-    {:fractional_digits, digits}
-  end
-
-  defp parse_number_format_option(_), do: nil
 end

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -330,12 +330,12 @@ msgstr ""
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:40
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-#: lib/explorer_web/views/wei_helpers.ex:84
+#: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr ""
 
 #: lib/explorer_web/views/block_view.ex:22
-#: lib/explorer_web/views/wei_helpers.ex:83
+#: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "Type"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:145
-#: lib/explorer_web/views/wei_helpers.ex:82
+#: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
@@ -422,9 +422,6 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:31
-#: lib/explorer_web/templates/chain/show.html.eex:36
-#: lib/explorer_web/templates/chain/show.html.eex:40
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -342,12 +342,12 @@ msgstr ""
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:40
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-#: lib/explorer_web/views/wei_helpers.ex:84
+#: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr "POA"
 
 #: lib/explorer_web/views/block_view.ex:22
-#: lib/explorer_web/views/wei_helpers.ex:83
+#: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgid "Type"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:145
-#: lib/explorer_web/views/wei_helpers.ex:82
+#: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
@@ -434,9 +434,6 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:31
-#: lib/explorer_web/templates/chain/show.html.eex:36
-#: lib/explorer_web/templates/chain/show.html.eex:40
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/exchange_rates/usd_test.exs
+++ b/apps/explorer_web/test/explorer_web/exchange_rates/usd_test.exs
@@ -38,5 +38,11 @@ defmodule ExplorerWeb.ExchangeRates.USDTest do
 
       assert %USD{value: Decimal.new(0.000005)} == USD.from(wei, token)
     end
+
+    test "returns USD struct from decimal usd value" do
+      value = Decimal.new(0.000005)
+
+      assert %USD{value: ^value} = USD.from(value)
+    end
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -41,7 +41,7 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     session
     |> AddressPage.visit_page(address)
-    |> assert_text(AddressPage.balance(), "0.000,000,000,000,000,500 POA")
+    |> assert_text(AddressPage.balance(), "0.0000000000000005 POA")
   end
 
   describe "viewing transactions" do

--- a/apps/explorer_web/test/explorer_web/views/chain_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/chain_view_test.exs
@@ -1,3 +1,33 @@
 defmodule ExplorerWeb.ChainViewTest do
   use ExplorerWeb.ConnCase, async: true
+
+  alias Explorer.ExchangeRates.Token
+  alias ExplorerWeb.ChainView
+
+  describe "format_exchange_rate/1" do
+    test "returns a formatted usd value from a `Token`'s usd_value" do
+      token = %Token{usd_value: Decimal.new(5.45)}
+
+      assert "$5.45 USD" == ChainView.format_exchange_rate(token)
+      assert nil == ChainView.format_exchange_rate(%Token{usd_value: nil})
+    end
+  end
+
+  describe "format_volume_24h/1" do
+    test "returns a formatted usd value from a `Token`'s volume_24h_usd" do
+      token = %Token{volume_24h_usd: Decimal.new(5.456)}
+
+      assert "$5.456 USD" == ChainView.format_volume_24h(token)
+      assert nil == ChainView.format_volume_24h(%Token{volume_24h_usd: nil})
+    end
+  end
+
+  describe "format_market_cap/1" do
+    test "returns a formatted usd value from a `Token`'s market_cap_usd" do
+      token = %Token{market_cap_usd: Decimal.new(5.4)}
+
+      assert "$5.40 USD" == ChainView.format_market_cap(token)
+      assert nil == ChainView.format_market_cap(%Token{market_cap_usd: nil})
+    end
+  end
 end

--- a/apps/explorer_web/test/explorer_web/views/transaction_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/transaction_view_test.exs
@@ -20,7 +20,7 @@ defmodule ExplorerWeb.TransactionViewTest do
 
       token = %Token{usd_value: Decimal.new(0.50)}
 
-      expected_value = "<= 0.009,000,000,000,000,000 POA"
+      expected_value = "<= 0.009 POA"
       assert expected_value == TransactionView.formatted_fee(transaction, denomination: :ether)
       assert "<= $0.0045 USD" == TransactionView.formatted_fee(transaction, exchange_rate: token)
     end
@@ -31,7 +31,7 @@ defmodule ExplorerWeb.TransactionViewTest do
       transaction = build(:transaction, gas_price: gas_price, receipt: receipt)
       token = %Token{usd_value: Decimal.new(0.50)}
 
-      expected_value = "0.003,102,702,000,000,000 POA"
+      expected_value = "0.003102702 POA"
       assert expected_value == TransactionView.formatted_fee(transaction, denomination: :ether)
       assert "$0.001551351 USD" == TransactionView.formatted_fee(transaction, exchange_rate: token)
     end


### PR DESCRIPTION
Resolves: #165 

Old:
`1,234.003,102,702,000,000,000`

New:
`1,234.003102702`

# Changelog

## Enhancements
- Use custom format for `Cldr.Number.to_string!` to remove commas in decimal and trailing zeroes
- Always show at least 2 decimal places for USD values

## Additions
- Add function to create USD structs from decimal representations