### PR TITLE
Fix USD value labels on homepage

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
@@ -32,16 +32,16 @@
           <div>
             <div class="graph__squares graph__squares--price"></div>
             <%= gettext "Price" %> </br>
-            $<%= format_exchange_rate(@exchange_rate) %> <%= gettext "USD" %>
+            <%= format_exchange_rate(@exchange_rate) %>
           </div>
           <div class="mx-2">
             <div class="graph__squares graph__squares--mcap"></div>
             <%= gettext "Market Cap" %> </br>
-            $<%= format_market_cap(@exchange_rate) %> <%= gettext "USD" %>
+            <%= format_market_cap(@exchange_rate) %>
           </div>
           <div>
             <%= gettext "24h Volume" %> </br>
-            $<%= format_volume_24h(@exchange_rate) %> <%= gettext "USD" %>
+            <%= format_volume_24h(@exchange_rate) %>
           </div>
         </div>
       </div>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -421,9 +421,6 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:35
-#: lib/explorer_web/templates/chain/show.html.eex:40
-#: lib/explorer_web/templates/chain/show.html.eex:44
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -433,9 +433,6 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:35
-#: lib/explorer_web/templates/chain/show.html.eex:40
-#: lib/explorer_web/templates/chain/show.html.eex:44
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""


### PR DESCRIPTION
Fixes: #214 

`$$ 1,234.00 USD USD` -> `$ 1,234.00 USD`

# Changelog

# Bug Fixes
- Remove extra `$` and extra `USD` from USD values on homepage