### PR TITLE
Restore lost change to show ether instead of wei for gas price

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -126,8 +126,8 @@
                 <th scope="row">
                   <%= gettext "Gas Price" %>
                 </th>
-                <td title="<%= gas_price(@transaction, :wei) %>">
-                  <%= gas_price(@transaction, :wei) %>
+                <td title="<%= gas_price(@transaction, :ether) %>">
+                  <%= gas_price(@transaction, :ether) %>
                   (<%= gas_price(@transaction, :gwei) %>)
                 </td>
               </tr>


### PR DESCRIPTION
Fixes #120 

In the shuffle of harmonizing the theme work and the other bugfixes, this change was lost. This restores showing the Gas Price in ether instead of wei.