### PR TITLE
Only hide "call" type internal transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1855,15 +1855,18 @@ defmodule Explorer.Chain do
   end
 
   defp where_transaction_has_multiple_internal_transactions(query) do
-    query
-    |> where(
-      [it, transaction],
-      fragment(
-        "(? != ? OR (SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1)",
-        it.type,
-        "call",
-        transaction.hash
-      )
+    where(
+      query,
+      [internal_transaction, transaction],
+      internal_transaction.type != ^:call or
+        fragment(
+          """
+          (SELECT COUNT(sibling.id)
+          FROM internal_transactions AS sibling
+          WHERE sibling.transaction_hash = ?)
+          """,
+          transaction.hash
+        ) > 1
     )
   end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1859,9 +1859,9 @@ defmodule Explorer.Chain do
     |> where(
       [it, transaction],
       fragment(
-        "(? = ? OR (SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1)",
+        "(? != ? OR (SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1)",
         it.type,
-        "create",
+        "call",
         transaction.hash
       )
     )

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1855,9 +1855,10 @@ defmodule Explorer.Chain do
   end
 
   defp where_transaction_has_multiple_internal_transactions(query) do
-    where(
-      query,
-      [_it, transaction],
+    query
+    |> where([it], it.type == ^:create)
+    |> or_where(
+      [it, transaction],
       fragment(
         "(SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1",
         transaction.hash

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1856,11 +1856,12 @@ defmodule Explorer.Chain do
 
   defp where_transaction_has_multiple_internal_transactions(query) do
     query
-    |> where([it], it.type == ^:create)
-    |> or_where(
+    |> where(
       [it, transaction],
       fragment(
-        "(SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1",
+        "(? = ? OR (SELECT COUNT(sibling.id) FROM internal_transactions as sibling WHERE sibling.transaction_hash = ?) > 1)",
+        it.type,
+        "create",
         transaction.hash
       )
     )

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -671,8 +671,7 @@ defmodule Explorer.ChainTest do
 
     test "with transaction with internal transactions loads associations with in necessity_by_association" do
       %Transaction{hash: hash} = insert(:transaction)
-      insert(:internal_transaction, transaction_hash: hash, index: 0)
-      insert(:internal_transaction, transaction_hash: hash, index: 1)
+      insert(:internal_transaction_create, transaction_hash: hash, index: 0)
 
       assert [
                %InternalTransaction{
@@ -680,7 +679,6 @@ defmodule Explorer.ChainTest do
                  to_address: %Ecto.Association.NotLoaded{},
                  transaction: %Ecto.Association.NotLoaded{}
                }
-               | _
              ] = Chain.transaction_hash_to_internal_transactions(hash).entries
 
       assert [
@@ -689,7 +687,6 @@ defmodule Explorer.ChainTest do
                  to_address: nil,
                  transaction: %Transaction{}
                }
-               | _
              ] =
                Chain.transaction_hash_to_internal_transactions(
                  hash,

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -483,7 +483,7 @@ defmodule Explorer.ChainTest do
       %InternalTransaction{id: second_id} =
         insert(:internal_transaction, index: 1, transaction_hash: transaction.hash, to_address_hash: address.hash)
 
-      result = address |> Chain.address_to_internal_transactions() |> Enum.map(&(&1.id))
+      result = address |> Chain.address_to_internal_transactions() |> Enum.map(& &1.id)
       assert Enum.member?(result, first_id)
       assert Enum.member?(result, second_id)
     end
@@ -606,7 +606,7 @@ defmodule Explorer.ChainTest do
         address
         |> Chain.address_to_internal_transactions()
         |> Map.get(:entries, [])
-        |> Enum.map(&(&1.id))
+        |> Enum.map(& &1.id)
 
       assert [second_pending, first_pending, sixth, fifth, fourth, third, second, first] == result
     end
@@ -624,7 +624,14 @@ defmodule Explorer.ChainTest do
       address = insert(:address)
       block = insert(:block)
       transaction = insert(:transaction, block_hash: block.hash, index: 0, to_address_hash: address.hash)
-      expected = insert(:internal_transaction_create, index: 0, from_address_hash: address.hash, transaction_hash: transaction.hash)
+
+      expected =
+        insert(
+          :internal_transaction_create,
+          index: 0,
+          from_address_hash: address.hash,
+          transaction_hash: transaction.hash
+        )
 
       actual = Enum.at(Chain.address_to_internal_transactions(address), 0)
 
@@ -655,7 +662,7 @@ defmodule Explorer.ChainTest do
         transaction.hash
         |> Chain.transaction_hash_to_internal_transactions()
         |> Map.get(:entries, [])
-        |> Enum.map(&(&1.id))
+        |> Enum.map(& &1.id)
 
       assert 2 == length(results)
       assert Enum.member?(results, first.id)
@@ -723,7 +730,7 @@ defmodule Explorer.ChainTest do
       result =
         hash
         |> Chain.transaction_hash_to_internal_transactions()
-        |> Enum.map(&(&1.id))
+        |> Enum.map(& &1.id)
 
       assert [first_id, second_id] == result
     end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -80,9 +80,9 @@ defmodule Explorer.Factory do
     internal_transaction_factory(:call)
   end
 
-  # TODO add call, reward, and suicide
+  # TODO add reward and suicide
   def internal_transaction_type do
-    Enum.random(~w(create)a)
+    Enum.random(~w(call create)a)
   end
 
   def log_factory do

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -72,6 +72,14 @@ defmodule Explorer.Factory do
     internal_transaction_factory(type)
   end
 
+  def internal_transaction_create_factory do
+    internal_transaction_factory(:create)
+  end
+
+  def internal_transaction_call_factory do
+    internal_transaction_factory(:call)
+  end
+
   # TODO add call, reward, and suicide
   def internal_transaction_type do
     Enum.random(~w(create)a)
@@ -162,6 +170,29 @@ defmodule Explorer.Factory do
     insert(:receipt, transaction_hash: hash, transaction_index: index)
 
     Repo.preload(block_transaction, [:block, :receipt])
+  end
+
+  defp internal_transaction_factory(:call = type) do
+    gas = Enum.random(21_000..100_000)
+    gas_used = Enum.random(0..gas)
+
+    block = insert(:block)
+    transaction = insert(:transaction, block_hash: block.hash, index: 0)
+    receipt = insert(:receipt, transaction_hash: transaction.hash, transaction_index: transaction.index)
+
+    %InternalTransaction{
+      from_address_hash: insert(:address).hash,
+      to_address_hash: insert(:address).hash,
+      call_type: :delegatecall,
+      gas: gas,
+      gas_used: gas_used,
+      output: %Data{bytes: <<1>>},
+      # caller MUST suppy `index`
+      trace_address: [],
+      transaction_hash: receipt.transaction_hash,
+      type: type,
+      value: sequence("internal_transaction_value", &Decimal.new(&1))
+    }
   end
 
   defp internal_transaction_factory(:create = type) do


### PR DESCRIPTION
Fixes #187

## Changelog

### Bugfixes
* Include internal transactions of type `create` even when they appear alone in a parent transaction

### Other Changes
* Add internal transaction factory for `call` type