### PR TITLE
Add Smart Contract details when verified

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="col-sm-10 align-self-center">
-      <h1><%= gettext "Address" %></h1>
+      <h1><%= address_title(@address) %></h1>
       <p class="mb-0" data-test="address_detail_hash"><%= @address %></p>
     </div>
   </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -35,8 +35,6 @@
     </div>
 
     <div class="card-body">
-      <h2 class="card-title"><%= gettext "Contract bytecode" %></h2>
-
       <%= if !smart_contract_verified?(@address) do %>
         <p>
           <%= link(
@@ -48,7 +46,39 @@
         </p>
       <% end %>
 
-      <pre class="pre-wrap p-2 bg-light mb-0">
+      <%= if smart_contract_verified?(@address) do %>
+        <table class="table">
+          <tr>
+            <th>Contract name:</th>
+            <td><%= @address.smart_contract.name %></td>
+          </tr>
+          <tr>
+            <th>Optimization enabled:</th>
+            <td><%= format_optimization(@address.smart_contract.optimization) %></td>
+          </tr>
+          <tr>
+            <th>Compiler version:</th>
+            <td><%= @address.smart_contract.compiler_version %></td>
+          </tr>
+        </table>
+
+        <h4>Contract source code</h4>
+        <pre class="p-2 bg-light mb-4">
+          <code>
+            <%= text_to_html(@address.smart_contract.contract_source_code, insert_brs: false) %>
+          </code>
+        </pre>
+
+        <h4>Contract ABI</h4>
+        <pre class="p-2 bg-light mb-4">
+          <code>
+            <%= format_smart_contract_abi(@address.smart_contract.abi) %>
+          </code>
+        </pre>
+      <% end %>
+
+      <h4>Contract creation code</h4>
+      <pre class="pre-wrap p-2 bg-light mb-4">
         <code><%= @address.contract_code %></code>
       </pre>
     </div>

--- a/apps/explorer_web/lib/explorer_web/views/address_contract_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_contract_view.ex
@@ -2,4 +2,9 @@ defmodule ExplorerWeb.AddressContractView do
   use ExplorerWeb, :view
 
   import ExplorerWeb.AddressView, only: [smart_contract_verified?: 1]
+
+  def format_smart_contract_abi(abi), do: Poison.encode!(abi, pretty: true)
+
+  def format_optimization(true), do: gettext("true")
+  def format_optimization(false), do: gettext("false")
 end

--- a/apps/explorer_web/mix.exs
+++ b/apps/explorer_web/mix.exs
@@ -96,7 +96,10 @@ defmodule ExplorerWeb.Mixfile do
       {:timex_ecto, "~> 3.2.1"},
       {:wallaby, "~> 0.20", only: [:test], runtime: false},
       {:qrcode, "~> 0.1.0"},
-      {:bypass, "~> 0.8", only: :test}
+      {:bypass, "~> 0.8", only: :test},
+      # Waiting for the Pretty Print to be implemented at the Jason lib
+      # https://github.com/michalmuskala/jason/issues/15
+      {:poison, "~> 3.1"}
     ]
   end
 

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,5 +1,5 @@
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:81
-#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:87
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -9,8 +9,8 @@
 msgid "Age"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_transaction/index.html.eex:82
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_transaction/index.html.eex:86
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:81
+#: lib/explorer_web/templates/address_transaction/index.html.eex:85
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:138
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -61,8 +61,8 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
@@ -158,10 +158,10 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:63
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
-#: lib/explorer_web/templates/address_transaction/index.html.eex:61
-#: lib/explorer_web/templates/address_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
+#: lib/explorer_web/templates/address_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
@@ -182,10 +182,10 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:51
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
-#: lib/explorer_web/templates/address_transaction/index.html.eex:49
-#: lib/explorer_web/templates/address_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:53
+#: lib/explorer_web/templates/address_transaction/index.html.eex:90
 #: lib/explorer_web/templates/block_transaction/index.html.eex:143
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:79
+#: lib/explorer_web/templates/address_transaction/index.html.eex:83
 #: lib/explorer_web/templates/block_transaction/index.html.eex:136
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -329,8 +329,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:24
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -358,7 +358,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:110
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:114
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:53
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -387,14 +387,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:45
-#: lib/explorer_web/templates/address_transaction/index.html.eex:43
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:49
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 msgid "Fee"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Block Details"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:79
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
 msgid "Parent Tx Hash"
 msgstr ""
 
@@ -512,13 +512,15 @@ msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
 msgid "Code"
 msgstr ""
 
-#: lib/explorer_web/views/address_contract_view.ex:12
+#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr ""
 
-#: lib/explorer_web/views/address_contract_view.ex:11
+#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -153,7 +153,6 @@ msgstr ""
 msgid "%{count} transactions in this block"
 msgstr ""
 
-#: lib/explorer_web/templates/address/overview.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
 #: lib/explorer_web/views/address_view.ex:17
 msgid "Address"
@@ -500,7 +499,7 @@ msgstr ""
 msgid "Contract Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:38
+#: lib/explorer_web/templates/address_contract/index.html.eex:39
 msgid "Contract bytecode"
 msgstr ""
 
@@ -508,10 +507,18 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr ""
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:46
+#: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
 msgid "Code"
+msgstr ""
+
+#: lib/explorer_web/views/address_contract_view.ex:12
+msgid "false"
+msgstr ""
+
+#: lib/explorer_web/views/address_contract_view.ex:11
+msgid "true"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:81
-#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:87
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -21,8 +21,8 @@ msgstr ""
 msgid "Age"
 msgstr "Age"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_transaction/index.html.eex:82
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_transaction/index.html.eex:86
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
@@ -45,7 +45,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 msgid "Gas Used"
 msgstr "Gas Used"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:81
+#: lib/explorer_web/templates/address_transaction/index.html.eex:85
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:138
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -73,8 +73,8 @@ msgstr "POA Network Explorer"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
@@ -170,10 +170,10 @@ msgstr "%{count} transactions in this block"
 msgid "Address"
 msgstr "Address"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:63
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
-#: lib/explorer_web/templates/address_transaction/index.html.eex:61
-#: lib/explorer_web/templates/address_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
+#: lib/explorer_web/templates/address_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
@@ -194,10 +194,10 @@ msgstr "Overview"
 msgid "Success"
 msgstr "Success"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:51
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
-#: lib/explorer_web/templates/address_transaction/index.html.eex:49
-#: lib/explorer_web/templates/address_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:53
+#: lib/explorer_web/templates/address_transaction/index.html.eex:90
 #: lib/explorer_web/templates/block_transaction/index.html.eex:143
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -325,7 +325,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:79
+#: lib/explorer_web/templates/address_transaction/index.html.eex:83
 #: lib/explorer_web/templates/block_transaction/index.html.eex:136
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -341,8 +341,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:24
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:110
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:114
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:53
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -399,14 +399,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:45
-#: lib/explorer_web/templates/address_transaction/index.html.eex:43
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:49
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 msgid "Fee"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Block Details"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:79
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
 msgid "Parent Tx Hash"
 msgstr ""
 
@@ -524,13 +524,15 @@ msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
 msgid "Code"
 msgstr ""
 
-#: lib/explorer_web/views/address_contract_view.ex:12
+#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr "No"
 
-#: lib/explorer_web/views/address_contract_view.ex:11
+#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr "Yes"

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -165,7 +165,6 @@ msgstr "%{confirmations} block confirmations"
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
-#: lib/explorer_web/templates/address/overview.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
 #: lib/explorer_web/views/address_view.ex:17
 msgid "Address"
@@ -512,7 +511,7 @@ msgstr ""
 msgid "Contract Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:38
+#: lib/explorer_web/templates/address_contract/index.html.eex:39
 msgid "Contract bytecode"
 msgstr ""
 
@@ -520,10 +519,18 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr "Contract Source Code"
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:46
+#: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
 msgid "Code"
 msgstr ""
+
+#: lib/explorer_web/views/address_contract_view.ex:12
+msgid "false"
+msgstr "No"
+
+#: lib/explorer_web/views/address_contract_view.ex:11
+msgid "true"
+msgstr "Yes"


### PR DESCRIPTION
#69

Shows the Smart Contract details at the `Code` tab, once it is verified.

![contract details](https://user-images.githubusercontent.com/840531/40991993-d4f45ef0-68cb-11e8-8410-792f94c44253.png)
