### PR TITLE
Index from latest to genesis

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -139,7 +139,7 @@ defmodule EthereumJSONRPC do
 
     batched_requests
     |> json_rpc(config(:url))
-    |> handle_get_block_by_number()
+    |> handle_get_block()
     |> case do
       {:ok, _next, results} -> {:ok, results}
       {:error, reason} -> {:error, reason}
@@ -153,7 +153,7 @@ defmodule EthereumJSONRPC do
     block_start
     |> build_batch_get_block_by_number(block_end)
     |> json_rpc(config(:url))
-    |> handle_get_block_by_number()
+    |> handle_get_block()
   end
 
   @doc """
@@ -260,7 +260,7 @@ defmodule EthereumJSONRPC do
       raise("bad jason")
   end
 
-  defp handle_get_block_by_number({:ok, results}) do
+  defp handle_get_block({:ok, results}) do
     {blocks, next} =
       Enum.reduce(results, {[], :more}, fn
         %{"result" => nil}, {blocks, _} -> {blocks, :end_of_chain}
@@ -279,7 +279,7 @@ defmodule EthereumJSONRPC do
      }}
   end
 
-  defp handle_get_block_by_number({:error, reason}) do
+  defp handle_get_block({:error, reason}) do
     {:error, reason}
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -62,20 +62,6 @@ defmodule EthereumJSONRPC do
   @type timestamp :: String.t()
 
   @doc """
-  Lists changes for a given filter subscription.
-  """
-  def check_for_updates(filter_id) do
-    request = %{
-      "id" => filter_id,
-      "jsonrpc" => "2.0",
-      "method" => "eth_getFilterChanges",
-      "params" => [filter_id]
-    }
-
-    json_rpc(request, config(:url))
-  end
-
-  @doc """
   Fetches configuration for this module under `key`
 
   Configuration can be set a compile time using `config`
@@ -188,22 +174,6 @@ defmodule EthereumJSONRPC do
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}
     end
-  end
-
-  @doc """
-  Creates a filter subscription that can be polled for retreiving new blocks.
-  """
-  def listen_for_new_blocks do
-    id = DateTime.utc_now() |> DateTime.to_unix()
-
-    request = %{
-      "id" => id,
-      "jsonrpc" => "2.0",
-      "method" => "eth_newBlockFilter",
-      "params" => []
-    }
-
-    json_rpc(request, config(:url))
   end
 
   @doc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -128,9 +128,9 @@ defmodule EthereumJSONRPC do
   @doc """
   Fetches blocks by block number range.
   """
-  def fetch_blocks_by_range(block_start, block_end) do
-    block_start
-    |> get_block_by_number_requests(block_end)
+  def fetch_blocks_by_range(_first.._last = range) do
+    range
+    |> get_block_by_number_requests()
     |> json_rpc(config(:url))
     |> handle_get_blocks()
   end
@@ -239,8 +239,8 @@ defmodule EthereumJSONRPC do
     [hash, get_block_transactions(options)]
   end
 
-  defp get_block_by_number_requests(block_start, block_end) do
-    for current <- block_start..block_end do
+  defp get_block_by_number_requests(range) do
+    for current <- range do
       get_block_by_number_request(%{id: current, quantity: current, transactions: :full})
     end
   end

--- a/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
@@ -1,0 +1,5 @@
+defmodule EthereumJSONRPCTest do
+  use ExUnit.Case, async: true
+
+  doctest EthereumJSONRPC
+end

--- a/apps/explorer/lib/explorer/indexer/block_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/block_fetcher.ex
@@ -30,6 +30,9 @@ defmodule Explorer.Indexer.BlockFetcher do
   @receipts_batch_size 250
   @receipts_concurrency 10
 
+  @doc false
+  def default_blocks_batch_size, do: @blocks_batch_size
+
   @doc """
   Starts the server.
 
@@ -68,6 +71,7 @@ defmodule Explorer.Indexer.BlockFetcher do
       genesis_task: nil,
       realtime_task: nil,
       realtime_interval: (opts[:block_rate] || @block_rate) * 2,
+      starting_block_number: nil,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),
       receipts_batch_size: Keyword.get(opts, :receipts_batch_size, @receipts_batch_size),
@@ -139,12 +143,18 @@ defmodule Explorer.Indexer.BlockFetcher do
     {:noreply, state}
   end
 
-  defp cap_seq(seq, :end_of_chain, {_block_start, _block_end}) do
-    :ok = Sequence.cap(seq)
-  end
+  defp cap_seq(seq, next, range) do
+    case next do
+      :more ->
+        debug(fn ->
+          first_block_number..last_block_number = range
+          "got blocks #{first_block_number} - #{last_block_number}"
+        end)
 
-  defp cap_seq(_seq, :more, {block_start, block_end}) do
-    debug(fn -> "got blocks #{block_start} - #{block_end}" end)
+      :end_of_chain ->
+        Sequence.cap(seq)
+    end
+
     :ok
   end
 
@@ -170,12 +180,13 @@ defmodule Explorer.Indexer.BlockFetcher do
   end
 
   defp genesis_task(%{} = state) do
-    {count, missing_ranges} = missing_block_numbers(state)
-    current_block = Indexer.next_block_number()
+    {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest")
+    missing_ranges = missing_block_number_ranges(state, latest_block_number..0)
+    count = Enum.count(missing_ranges)
 
-    debug(fn -> "#{count} missed block ranges between genesis and #{current_block}" end)
+    debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
 
-    {:ok, seq} = Sequence.start_link(missing_ranges, current_block, state.blocks_batch_size)
+    {:ok, seq} = Sequence.start_link(missing_ranges, latest_block_number, -1 * state.blocks_batch_size)
     stream_import(state, seq, max_concurrency: state.blocks_concurrency)
   end
 
@@ -202,28 +213,30 @@ defmodule Explorer.Indexer.BlockFetcher do
     InternalTransactionFetcher.async_fetch(transaction_hashes, 10_000)
   end
 
-  defp missing_block_numbers(%{blocks_batch_size: blocks_batch_size}) do
-    {count, missing_ranges} = Chain.missing_block_numbers()
+  defp missing_block_number_ranges(%{blocks_batch_size: blocks_batch_size}, range) do
+    range
+    |> Chain.missing_block_number_ranges()
+    |> chunk_ranges(blocks_batch_size)
+  end
 
-    chunked_ranges =
-      Enum.flat_map(missing_ranges, fn
-        {start, ending} when ending - start <= blocks_batch_size ->
-          [{start, ending}]
+  defp chunk_ranges(ranges, size) do
+    Enum.flat_map(ranges, fn
+      first..last = range when last - first <= size ->
+        [range]
 
-        {start, ending} ->
-          start
-          |> Stream.iterate(&(&1 + blocks_batch_size))
-          |> Enum.reduce_while([], fn
-            chunk_start, acc when chunk_start + blocks_batch_size >= ending ->
-              {:halt, [{chunk_start, ending} | acc]}
+      first..last ->
+        first
+        |> Stream.iterate(&(&1 + size))
+        |> Enum.reduce_while([], fn
+          chunk_first, acc when chunk_first + size >= last ->
+            {:halt, [chunk_first..last | acc]}
 
-            chunk_start, acc ->
-              {:cont, [{chunk_start, chunk_start + blocks_batch_size - 1} | acc]}
-          end)
-          |> Enum.reverse()
-      end)
-
-    {count, chunked_ranges}
+          chunk_first, acc ->
+            chunk_last = chunk_first + size - 1
+            {:cont, [chunk_first..chunk_last | acc]}
+        end)
+        |> Enum.reverse()
+    end)
   end
 
   defp realtime_task(%{} = state) do
@@ -245,8 +258,8 @@ defmodule Explorer.Indexer.BlockFetcher do
   # Run at state.blocks_concurrency max_concurrency when called by `stream_import/3`
   # Only public for testing
   @doc false
-  def import_range({block_start, block_end} = range, %{} = state, seq) do
-    with {:blocks, {:ok, next, result}} <- {:blocks, EthereumJSONRPC.fetch_blocks_by_range(block_start, block_end)},
+  def import_range(range, %{} = state, seq) do
+    with {:blocks, {:ok, next, result}} <- {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range)},
          %{blocks: blocks, transactions: transactions_without_receipts} = result,
          cap_seq(seq, next, range),
          transaction_hashes = Transactions.params_to_hashes(transactions_without_receipts),
@@ -272,7 +285,8 @@ defmodule Explorer.Indexer.BlockFetcher do
     else
       {step, {:error, reason}} ->
         debug(fn ->
-          "failed to fetch #{step} for blocks #{block_start} - #{block_end}: #{inspect(reason)}. Retrying block range."
+          first..last = range
+          "failed to fetch #{step} for blocks #{first} - #{last}: #{inspect(reason)}. Retrying block range."
         end)
 
         :ok = Sequence.inject_range(seq, range)

--- a/apps/explorer/test/explorer/indexer/sequence_test.exs
+++ b/apps/explorer/test/explorer/indexer/sequence_test.exs
@@ -4,31 +4,31 @@ defmodule Explorer.Indexer.SequenceTest do
   alias Explorer.Indexer.Sequence
 
   test "start_link" do
-    {:ok, pid} = Sequence.start_link([{1, 4}], 5, 1)
+    {:ok, pid} = Sequence.start_link([1..4], 5, 1)
 
     assert state(pid) == %Sequence{
              current: 5,
              mode: :infinite,
-             queue: {[{1, 4}], []},
+             queue: {[1..4], []},
              step: 1
            }
   end
 
   test "inject_range" do
-    {:ok, pid} = Sequence.start_link([{1, 2}], 5, 1)
+    {:ok, pid} = Sequence.start_link([1..2], 5, 1)
 
-    assert :ok = Sequence.inject_range(pid, {3, 4})
+    assert :ok = Sequence.inject_range(pid, 3..4)
 
     assert state(pid) == %Sequence{
              current: 5,
              mode: :infinite,
-             queue: {[{3, 4}], [{1, 2}]},
+             queue: {[3..4], [1..2]},
              step: 1
            }
   end
 
   test "cap" do
-    {:ok, pid} = Sequence.start_link([{1, 2}], 5, 1)
+    {:ok, pid} = Sequence.start_link([1..2], 5, 1)
 
     assert :ok = Sequence.cap(pid)
     assert state(pid).mode == :finite
@@ -36,20 +36,20 @@ defmodule Explorer.Indexer.SequenceTest do
 
   describe "pop" do
     test "with a non-empty queue in finite and infinite modes" do
-      {:ok, pid} = Sequence.start_link([{1, 4}, {6, 9}], 99, 5)
+      {:ok, pid} = Sequence.start_link([1..4, 6..9], 99, 5)
 
-      assert {1, 4} == Sequence.pop(pid)
+      assert 1..4 == Sequence.pop(pid)
 
       assert state(pid) == %Sequence{
                current: 99,
                mode: :infinite,
-               queue: {[], [{6, 9}]},
+               queue: {[], [6..9]},
                step: 5
              }
 
       :ok = Sequence.cap(pid)
 
-      assert {6, 9} == Sequence.pop(pid)
+      assert 6..9 == Sequence.pop(pid)
 
       assert state(pid) == %Sequence{
                current: 99,
@@ -62,13 +62,26 @@ defmodule Explorer.Indexer.SequenceTest do
     test "with an empty queue in infinite mode" do
       {:ok, pid} = Sequence.start_link([], 5, 5)
 
-      assert {5, 9} == Sequence.pop(pid)
+      assert 5..9 == Sequence.pop(pid)
 
       assert state(pid) == %Sequence{
                current: 10,
                mode: :infinite,
                queue: {[], []},
                step: 5
+             }
+    end
+
+    test "with an empty queue in infinit mode with negative step" do
+      {:ok, pid} = Sequence.start_link([], 4, -5)
+
+      assert 4..0 == Sequence.pop(pid)
+
+      assert state(pid) == %Sequence{
+               current: 0,
+               mode: :finite,
+               queue: {[], []},
+               step: -5
              }
     end
 

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 92.2
+    "minimum_coverage": 92.7
   },
   "terminal_options": {
     "file_column_width": 120

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 92.5
+    "minimum_coverage": 92.2
   },
   "terminal_options": {
     "file_column_width": 120


### PR DESCRIPTION
Resolves #245

# Changelog
## Enhancements
*  Extract common request code.
* Reverse the genesis index order as most users will care about recent blocks as opposed to the very beginning of the chain.  This should shorten the Time-to-Usefulness.

## Bug Fixes
* `handle_get_block_by_number` handles the result from both `fetch_blocks_by_number` AND `fetch_blocks_by_number`, so it isn't handling just the `_by_number` result and is a misnomer.
* Remove unused `eth_*Filter` functions