### PR TITLE
Improve paging query #200

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1855,8 +1855,6 @@ defmodule Explorer.Chain do
     end)
   end
 
-  defp page_transaction(query, nil), do: query
-
   defp page_transaction(query, %PagingOptions{key: nil}), do: query
 
   defp page_transaction(query, %PagingOptions{key: {block_number, index}}) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1639,13 +1639,11 @@ defmodule Explorer.Chain do
       {:ok, hash} ->
         from(
           transaction in query,
-          inner_join: block in assoc(transaction, :block),
           join: hash_transaction in Transaction,
           on: hash_transaction.hash == ^hash,
-          inner_join: hash_block in assoc(hash_transaction, :block),
           where:
-            block.number > hash_block.number or
-              (block.number == hash_block.number and transaction.index > hash_transaction.index)
+            transaction.block_number > hash_transaction.block_number or
+              (transaction.block_number == hash_transaction.block_number and transaction.index > hash_transaction.index)
         )
 
       :error ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -50,7 +50,7 @@ defmodule Explorer.Chain do
   @typep inserted_after_option :: {:inserted_after, DateTime.t()}
   @typep necessity_by_association_option :: {:necessity_by_association, necessity_by_association}
   @typep pagination_option :: {:pagination, pagination}
-  @typep paging_options :: PagingOptions.t()
+  @typep paging_options :: {:paging_options, PagingOptions.t()}
   @typep params_option :: {:params, map()}
   @typep timeout_option :: {:timeout, timeout}
   @typep timestamps :: %{inserted_at: DateTime.t(), updated_at: DateTime.t()}

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -53,6 +53,11 @@ defmodule Explorer.Chain.Transaction do
   @type standard_v :: 0..3
 
   @typedoc """
+    The index of the transaction in its block.
+  """
+  @type transaction_index :: non_neg_integer()
+
+  @typedoc """
   `t:standard_v/0` + `27`
 
   | `v`  | X      | Y    |
@@ -114,7 +119,7 @@ defmodule Explorer.Chain.Transaction do
           gas_price: wei_per_gas,
           gas_used: Gas.t() | nil,
           hash: Hash.t(),
-          index: non_neg_integer() | nil,
+          index: transaction_index | nil,
           input: Data.t(),
           internal_transactions: %Ecto.Association.NotLoaded{} | [InternalTransaction.t()],
           internal_transactions_indexed_at: DateTime.t(),

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -53,7 +53,7 @@ defmodule Explorer.Chain.Transaction do
   @type standard_v :: 0..3
 
   @typedoc """
-    The index of the transaction in its block.
+  The index of the transaction in its block.
   """
   @type transaction_index :: non_neg_integer()
 

--- a/apps/explorer/lib/explorer/paging_options.ex
+++ b/apps/explorer/lib/explorer/paging_options.ex
@@ -1,0 +1,13 @@
+defmodule Explorer.PagingOptions do
+  @moduledoc """
+  Defines paging options for paging by a stable key such as a timestamp or block
+  number and index.
+  """
+
+  @type t :: %__MODULE__{key: key, page_size: page_size}
+
+  @typep key :: any()
+  @typep page_size :: non_neg_integer()
+
+  defstruct [:key, :page_size]
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -861,4 +861,15 @@ defmodule Explorer.ChainTest do
       assert block_reward.reward == Chain.block_reward(block)
     end
   end
+
+  describe "recent_collated_transactions/1" do
+    test "with no collated transactions it returns an empty list" do
+      assert [] == Explorer.Chain.recent_collated_transactions()
+    end
+
+    test "it excludes pending transactions" do
+      insert(:transaction)
+      assert [] == Explorer.Chain.recent_collated_transactions()
+    end
+  end
 end

--- a/apps/explorer_web/lib/explorer_web/controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controller.ex
@@ -15,4 +15,11 @@ defmodule ExplorerWeb.Controller do
     |> put_view(ExplorerWeb.ErrorView)
     |> render("404.html")
   end
+
+  def unprocessable_entity(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ExplorerWeb.ErrorView)
+    |> render("422.html")
+  end
 end

--- a/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
@@ -22,9 +22,7 @@ defmodule ExplorerWeb.TransactionController do
       Keyword.merge(
         [
           necessity_by_association: %{
-            block: :required,
-            from_address: :optional,
-            to_address: :optional
+            block: :required
           }
         ],
         options

--- a/apps/explorer_web/lib/explorer_web/templates/address/_link.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/_link.html.eex
@@ -1,14 +1,14 @@
 <div class="address-link">
-<%= if @address do %>
-  <%= link to: address_path(@conn, :show, @conn.assigns.locale, @address),
+<%= if @address_hash do %>
+  <%= link to: address_path(@conn, :show, @conn.assigns.locale, @address_hash),
       "data-toggle": "tooltip",
       "data-placement": "top",
       class: "address-link__font",
-      title: @address do %>
+      title: @address_hash do %>
         <i class="address-link__type fas fa-address-card"></i>
-    <%= @address |> hash |> String.slice(0..3) %><i class="fas fa-ellipsis-v address-link__seperator"></i><%= @address |> hash |> String.slice(-4..-1) %>
+    <%= @address_hash |> hash() |> String.slice(0..3) %><i class="fas fa-ellipsis-v address-link__seperator"></i><%= @address_hash |> hash() |> String.slice(-4..-1) %>
 <% end %>
-<button class="address-link__copy-button" data-clipboard-text="<%= @address %>" aria-label="copy address">
+<button class="address-link__copy-button" data-clipboard-text="<%= @address_hash %>" aria-label="copy address">
   <i class="fa fa-copy"></i>
 </button>
 <% end %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -96,10 +96,10 @@
                   </td>
                   <td><%= ExplorerWeb.BlockView.age(internal_transaction.transaction.block) %></td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: internal_transaction.from_address_hash %>
                   </td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: internal_transaction.to_address_hash %>
                   </td>
                   <td><%= ExplorerWeb.TransactionView.value(internal_transaction, include_label: false) %></td>
                 </tr>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -103,11 +103,11 @@
                 </td>
                 <td><%= transaction.block.timestamp |> Timex.from_now %></td>
                 <td class="address-cell">
-                  <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
+                  <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.from_address_hash %>
                 </td>
                 <td class="u-text-center"><i class="fas fa-arrow-circle-right"></i></td>
                 <td>
-                  <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                  <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.to_address_hash %>
                 </td>
                 <td><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %></td>
                 <td><%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %></td>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -164,11 +164,11 @@
                     <%= transaction.block.timestamp |> Timex.from_now %>
                   </td>
                   <td class="address-cell">
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.from_address_hash %>
                   </td>
                   <td class="u-text-center"><i class="fas fa-arrow-circle-right"></i></td>
                   <td>
-                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.to_address_hash %>
                   </td>
                   <td>
                     <%= ExplorerWeb.TransactionView.value(transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_blocks.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_blocks.html.eex
@@ -21,7 +21,7 @@
           <td><%= block.transactions |> Enum.count %></td>
           <td><%= block.gas_used |> Cldr.Number.to_string! %></td>
           <td>
-            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: block.miner %>
+            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: block.miner_hash %>
           </td>
         </tr>
         <% end %>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -17,10 +17,10 @@
             <%= render ExplorerWeb.TransactionView, "_link.html", conn: @conn, transaction: transaction %>
           </td>
           <td>
-            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
+            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.from_address_hash %>
           </td>
           <td>
-            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.to_address_hash %>
           </td>
           <td><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> </td>
           <td><%= transaction.block.timestamp |> Timex.from_now() %></td>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -50,10 +50,10 @@
               </td>
               <td><%= last_seen(transaction) %></td>
               <td>
-                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
+                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.from_address_hash %>
               </td>
               <td>
-                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.to_address_hash %>
               </td>
               <td>
               <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -59,10 +59,10 @@
                 <%= transaction.block.timestamp %>
               </td>
               <td>
-                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
+                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.from_address_hash %>
               </td>
               <td>
-                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: transaction.to_address_hash %>
               </td>
               <td>
                 <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -50,13 +50,13 @@
               </td>
               <td>
                 <%= link(
-                      transaction.block,
+                      transaction.block_number,
                       class: "transactions__link",
                       to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
                     ) %>
               </td>
               <td>
-                <%= transaction.block.timestamp |> Timex.from_now %>
+                <%= transaction.block.timestamp %>
               </td>
               <td>
                 <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
@@ -73,16 +73,16 @@
       </table>
     </div>
   </div>
-  <%= if @last_seen_collated_hash do %>
+  <%= if @earliest do %>
     <%= link(
-          gettext("Next Page"),
-          class: "button button--secondary button--sm u-float-right mt-3",
-          to: transaction_path(
-            @conn,
-            :index,
-            @conn.assigns.locale,
-            %{"last_seen_collated_hash" => to_string(@last_seen_collated_hash)}
-          )
-        ) %>
+      gettext("Older"),
+      class: "button button--secondary button--sm u-float-right mt-3",
+      to: transaction_path(
+        @conn,
+        :index,
+        @conn.assigns.locale,
+        %{"block_number" => @earliest.block_number, "index" => @earliest.index}
+      )
+    ) %>
   <% end %>
 </section>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
@@ -38,10 +38,10 @@
                 <tr>
                   <td><%= internal_transaction.call_type %></td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: internal_transaction.from_address_hash %>
                   </td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address_hash: internal_transaction.to_address_hash %>
                   </td>
                   <td><%= ExplorerWeb.TransactionView.value(internal_transaction, include_label: false) %></td>
                   <td><%= ExplorerWeb.TransactionView.gas(internal_transaction) %></td>

--- a/apps/explorer_web/lib/explorer_web/views/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_view.ex
@@ -2,6 +2,7 @@ defmodule ExplorerWeb.AddressView do
   use ExplorerWeb, :view
 
   alias Explorer.Chain.{Address, Wei}
+  alias Explorer.Chain.Hash
   alias Explorer.ExchangeRates.Token
   alias ExplorerWeb.ExchangeRates.USD
 
@@ -41,7 +42,7 @@ defmodule ExplorerWeb.AddressView do
     end
   end
 
-  def hash(%Address{hash: hash}) do
+  def hash(%Hash{} = hash) do
     to_string(hash)
   end
 

--- a/apps/explorer_web/lib/explorer_web/views/error_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/error_view.ex
@@ -6,7 +6,7 @@ defmodule ExplorerWeb.ErrorView do
   end
 
   def render("422.html", _assigns) do
-    "Unprocessible entity"
+    "Unprocessable entity"
   end
 
   def render("500.html", _assigns) do

--- a/apps/explorer_web/lib/explorer_web/views/error_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/error_view.ex
@@ -5,6 +5,10 @@ defmodule ExplorerWeb.ErrorView do
     "Page not found"
   end
 
+  def render("422.html", _assigns) do
+    "Unprocessible entity"
+  end
+
   def render("500.html", _assigns) do
     "Internal server error"
   end

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -155,7 +155,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/views/address_view.ex:17
+#: lib/explorer_web/views/address_view.ex:18
 msgid "Address"
 msgstr ""
 
@@ -302,7 +302,6 @@ msgid "TPM"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:78
 msgid "Next Page"
 msgstr ""
 
@@ -497,7 +496,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/explorer_web/views/address_view.ex:15
+#: lib/explorer_web/views/address_view.ex:16
 msgid "Contract Address"
 msgstr ""
 
@@ -507,4 +506,8 @@ msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:181
 msgid "There are no Transactions"
+msgstr ""
+
+#: lib/explorer_web/templates/transaction/index.html.eex:78
+msgid "Older"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -167,7 +167,7 @@ msgstr "%{count} transactions in this block"
 
 #: lib/explorer_web/templates/address/overview.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/views/address_view.ex:17
+#: lib/explorer_web/views/address_view.ex:18
 msgid "Address"
 msgstr "Address"
 
@@ -314,7 +314,6 @@ msgid "TPM"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:78
 msgid "Next Page"
 msgstr ""
 
@@ -509,7 +508,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/explorer_web/views/address_view.ex:15
+#: lib/explorer_web/views/address_view.ex:16
 msgid "Contract Address"
 msgstr ""
 
@@ -519,4 +518,8 @@ msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:181
 msgid "There are no Transactions"
+msgstr ""
+
+#: lib/explorer_web/templates/transaction/index.html.eex:78
+msgid "Older"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -51,7 +51,11 @@ defmodule ExplorerWeb.TransactionControllerTest do
         |> insert()
         |> with_block()
 
-      conn = get(conn, "/en/transactions", %{"block_number" => block_number, "index" => index})
+      conn =
+        get(conn, "/en/transactions", %{
+          "block_number" => Integer.to_string(block_number),
+          "index" => Integer.to_string(index)
+        })
 
       actual_hashes =
         conn.assigns.transactions
@@ -59,6 +63,16 @@ defmodule ExplorerWeb.TransactionControllerTest do
         |> Enum.reverse()
 
       assert second_page_hashes == actual_hashes
+    end
+
+    test "guards against bad block_number input", %{conn: conn} do
+      conn = get(conn, "/en/transactions", %{"block_number" => "foo", "index" => "2"})
+      assert html_response(conn, 422)
+    end
+
+    test "guards against bad index input", %{conn: conn} do
+      conn = get(conn, "/en/transactions", %{"block_number" => "2", "index" => "bar"})
+      assert html_response(conn, 422)
     end
 
     test "sends back the number of transactions", %{conn: conn} do

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -1,10 +1,11 @@
 defmodule ExplorerWeb.TransactionControllerTest do
   use ExplorerWeb.ConnCase
+  alias Explorer.Chain.Transaction
 
   import ExplorerWeb.Router.Helpers, only: [transaction_path: 4, transaction_internal_transaction_path: 4]
 
   describe "GET index/2" do
-    test "returns a transaction with a receipt", %{conn: conn} do
+    test "returns a collated transactions", %{conn: conn} do
       transaction =
         :transaction
         |> insert()
@@ -22,43 +23,47 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
       conn = get(conn, "/en/transactions")
 
-      assert length(conn.assigns.transactions) == 1
+      assert conn.assigns.transaction_count == 1
     end
 
-    test "returns no pending transactions", %{conn: conn} do
-      insert(:transaction)
-
-      conn = get(conn, "/en/transactions")
-
-      assert conn.assigns.transactions == []
-    end
-
-    test "only returns transactions that have a receipt", %{conn: conn} do
-      insert(:transaction)
-
-      conn = get(conn, "/en/transactions")
-
-      assert length(conn.assigns.transactions) == 0
-    end
-
-    test "paginates transactions using the last seen transaction", %{conn: conn} do
-      transaction =
+    test "excludes pending transactions", %{conn: conn} do
+      %Transaction{hash: hash} =
         :transaction
         |> insert()
         |> with_block()
 
-      conn =
-        get(
-          conn,
-          "/en/transactions",
-          last_seen_collated_hash: to_string(transaction.hash)
-        )
+      insert(:transaction)
 
-      assert conn.assigns.transactions == []
+      conn = get(conn, "/en/transactions")
+
+      assert [%Transaction{hash: ^hash}] = conn.assigns.transactions
+    end
+
+    test "returns next page of results based on last seen transaction", %{conn: conn} do
+      second_page_hashes =
+        50
+        |> insert_list(:transaction)
+        |> with_block()
+        |> Enum.map(& &1.hash)
+
+      %Transaction{block_number: block_number, index: index} =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      conn = get(conn, "/en/transactions", %{"block_number" => block_number, "index" => index})
+
+      actual_hashes =
+        conn.assigns.transactions
+        |> Enum.map(& &1.hash)
+        |> Enum.reverse()
+
+      assert second_page_hashes == actual_hashes
     end
 
     test "sends back the number of transactions", %{conn: conn} do
       insert(:transaction)
+      |> with_block()
 
       conn = get(conn, "/en/transactions")
 

--- a/apps/explorer_web/test/explorer_web/views/error_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/error_view_test.exs
@@ -8,6 +8,10 @@ defmodule ExplorerWeb.ErrorViewTest do
     assert render_to_string(ExplorerWeb.ErrorView, "404.html", []) == "Page not found"
   end
 
+  test "renders 422.html" do
+    assert render_to_string(ExplorerWeb.ErrorView, "422.html", []) == "Unprocessable entity"
+  end
+
   test "render 500.html" do
     assert render_to_string(ExplorerWeb.ErrorView, "500.html", []) == "Internal server error"
   end


### PR DESCRIPTION
Resolves #200 

## Changelog

### Bugfixes
* Fix paging
* Remove unnecessary joins by switching to `block_number` and `index` for paging instead of `hash` and using information already in the transactions table


Here are the before and after representative queries and plans for the transactions query:

Before:

```sql
SELECT t0."hash", t0."block_number", t0."cumulative_gas_used", t0."gas", t0."gas_price", t0."gas_used", t0."index", t0."internal_transactions_indexed_at", t0."input", t0."nonce", t0."public_key", t0."r", t0."s", t0."standard_v", t0."status", t0."v", t0."value", t0."inserted_at", t0."updated_at", t0."block_hash", t0."from_address_hash", t0."to_address_hash", b4."hash", b4."difficulty", b4."gas_limit", b4."gas_used", b4."nonce", b4."number", b4."size", b4."timestamp", b4."total_difficulty", b4."inserted_at", b4."updated_at", b4."miner_hash", b4."parent_hash" 
FROM "transactions" AS t0 
INNER JOIN "blocks" AS b1 ON b1."hash" = t0."block_hash" 
INNER JOIN "transactions" AS t2 ON t2."hash" = decode('676c0fcbfc9ba79cb29ce5eb42e55ae097989e0f86da765f357b6c3b525a06f9', 'hex')
INNER JOIN "blocks" AS b3 ON b3."hash" = t2."block_hash" 
INNER JOIN "blocks" AS b4 ON b4."hash" = t0."block_hash" 
WHERE (NOT (t0."block_number" IS NULL) AND NOT (t0."index" IS NULL)) AND ((b1."number" > b3."number") OR ((b1."number" = b3."number") AND (t0."index" > t2."index"))) 
ORDER BY t0."block_number" DESC, t0."index" DESC 
LIMIT 10
```

```
QUERY PLAN
Limit  (cost=2.26..43.55 rows=10 width=589) (actual time=1.473..23611.238 rows=9 loops=1)
  ->  Nested Loop  (cost=2.26..5506576.45 rows=1333538 width=589) (actual time=1.472..23611.236 rows=9 loops=1)
        Join Filter: (b1.hash = b4.hash)
        ->  Nested Loop  (cost=1.83..4402802.55 rows=1333538 width=438) (actual time=1.450..23611.196 rows=9 loops=1)
              Join Filter: ((b1.number > b3.number) OR ((b1.number = b3.number) AND (t0.index > t2.index)))
              Rows Removed by Join Filter: 4000603
              ->  Nested Loop  (cost=0.85..4322773.30 rows=4000612 width=446) (actual time=0.953..21958.180 rows=4000612 loops=1)
                    ->  Index Scan using transactions_recent_collated_index on transactions t0  (cost=0.43..1061460.44 rows=4000612 width=405) (actual time=0.508..8195.987 rows=4000612 loops=1)
                          Index Cond: ((block_number IS NOT NULL) AND (index IS NOT NULL))
                    ->  Index Scan using blocks_pkey on blocks b1  (cost=0.42..0.82 rows=1 width=41) (actual time=0.003..0.003 rows=1 loops=4000612)
                          Index Cond: (hash = t0.block_hash)
              ->  Materialize  (cost=0.98..17.02 rows=1 width=12) (actual time=0.000..0.000 rows=1 loops=4000612)
                    ->  Nested Loop  (cost=0.98..17.02 rows=1 width=12) (actual time=0.486..0.487 rows=1 loops=1)
                          ->  Index Scan using transactions_pkey on transactions t2  (cost=0.56..8.57 rows=1 width=37) (actual time=0.473..0.473 rows=1 loops=1)
                                Index Cond: (hash = '\x676c0fcbfc9ba79cb29ce5eb42e55ae097989e0f86da765f357b6c3b525a06f9'::bytea)
                          ->  Index Scan using blocks_pkey on blocks b3  (cost=0.42..8.44 rows=1 width=41) (actual time=0.008..0.008 rows=1 loops=1)
                                Index Cond: (hash = t2.block_hash)
        ->  Index Scan using blocks_pkey on blocks b4  (cost=0.42..0.82 rows=1 width=184) (actual time=0.003..0.003 rows=1 loops=9)
              Index Cond: (hash = t0.block_hash)
Planning time: 6.085 ms
Execution time: 23611.356 ms
```

After:
```sql
SELECT t0."hash", t0."block_number", t0."cumulative_gas_used", t0."gas", t0."gas_price", t0."gas_used", t0."index", t0."internal_transactions_indexed_at", t0."input", t0."nonce", t0."public_key", t0."r", t0."s", t0."standard_v", t0."status", t0."v", t0."value", t0."inserted_at", t0."updated_at", t0."block_hash", t0."from_address_hash", t0."to_address_hash", b1."hash", b1."difficulty", b1."gas_limit", b1."gas_used", b1."nonce", b1."number", b1."size", b1."timestamp", b1."total_difficulty", b1."inserted_at", b1."updated_at", b1."miner_hash", b1."parent_hash" 
FROM "transactions" AS t0 
INNER JOIN "blocks" AS b1 ON b1."hash" = t0."block_hash" 
WHERE (NOT (t0."block_number" IS NULL) AND NOT (t0."index" IS NULL)) AND ((t0."block_number" < 776809) OR ((t0."block_number" = 776809) AND (t0."index" < 37))) 
ORDER BY t0."block_number" DESC, t0."index" DESC 
LIMIT 50
```

```
QUERY PLAN
Limit  (cost=0.85..33.65 rows=50 width=589) (actual time=0.100..0.462 rows=50 loops=1)
  ->  Nested Loop  (cost=0.85..2624275.68 rows=4000612 width=589) (actual time=0.100..0.453 rows=50 loops=1)
        ->  Index Scan using transactions_recent_collated_index on transactions t0  (cost=0.43..735497.10 rows=4000612 width=405) (actual time=0.080..0.291 rows=50 loops=1)
              Index Cond: ((block_number IS NOT NULL) AND (index IS NOT NULL))
              Filter: ((block_number < 776809) OR ((block_number = 776809) AND (index < 37)))
              Rows Removed by Filter: 10
        ->  Index Scan using blocks_pkey on blocks b1  (cost=0.42..0.47 rows=1 width=184) (actual time=0.002..0.002 rows=1 loops=50)
              Index Cond: (hash = t0.block_hash)
Planning time: 0.938 ms
Execution time: 0.502 ms
```