### PR TITLE
Add API for getting total/circulating supply values

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2320,4 +2320,24 @@ defmodule Explorer.Chain do
         ) > 1
     )
   end
+
+  @doc """
+  The current total number of coins minted minus verifiably burned coins.
+  """
+  @spec total_supply :: non_neg_integer()
+  def total_supply do
+    supply_module().total()
+  end
+
+  @doc """
+  The current number coins in the market for trading.
+  """
+  @spec circulating_supply :: non_neg_integer()
+  def circulating_supply do
+    supply_module().circulating()
+  end
+
+  defp supply_module do
+    Application.get_env(:explorer, :supply, Explorer.Chain.Supply.ProofOfAuthority)
+  end
 end

--- a/apps/explorer/lib/explorer/chain/supply.ex
+++ b/apps/explorer/lib/explorer/chain/supply.ex
@@ -1,0 +1,18 @@
+defmodule Explorer.Chain.Supply do
+  @moduledoc """
+  Behaviour for API needed to calculate data related to a chain's supply.
+
+  Since each chain may calculate these values differently, each chain will
+  likely need to implement their own calculations for the behaviour.
+  """
+
+  @doc """
+  The current total number of coins minted minus verifiably burned coins.
+  """
+  @callback total :: non_neg_integer()
+
+  @doc """
+  The current number coins in the market for trading.
+  """
+  @callback circulating :: non_neg_integer()
+end

--- a/apps/explorer/lib/explorer/chain/supply/proof_of_authority.ex
+++ b/apps/explorer/lib/explorer/chain/supply/proof_of_authority.ex
@@ -1,0 +1,71 @@
+defmodule Explorer.Chain.Supply.ProofOfAuthority do
+  @moduledoc """
+  Defines the supply API for calculating supply for POA.
+
+  POA launched on Dec 15, 2017 with 252,460,800 coins with 20% reserved for
+  vesting (50,492,160). After 6 months from launch, 25% of the vested amount,
+  or 12,623,040, will be unlocked and included in the circulating supply.
+  Every 3 months after that, 12.5% of the vested amount, or 6,311,520, will
+  be unlocked until the remaining vested portion is unlocked.
+
+
+  See https://github.com/poanetwork/wiki/wiki/POA-Token-Supply for more
+  information.
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.Supply
+
+  @behaviour Supply
+
+  @initial_supply 252_460_800
+  @reserved_for_vesting 50_492_160
+
+  @vesting_unlock_dates_and_percentages %{
+    ~D[2018-06-15] => 0.25,
+    ~D[2018-09-15] => 0.125,
+    ~D[2018-12-15] => 0.125,
+    ~D[2019-03-15] => 0.125,
+    ~D[2019-06-15] => 0.125,
+    ~D[2019-09-15] => 0.125,
+    ~D[2019-12-15] => 0.125
+  }
+
+  @impl Supply
+  def circulating do
+    total() - reserved_supply(Date.utc_today())
+  end
+
+  @impl Supply
+  def total do
+    initial_supply = initial_supply()
+    block_height = block_height()
+
+    initial_supply + block_height
+  end
+
+  defp block_height do
+    case Chain.max_block_number() do
+      {:ok, height} -> height
+      _ -> 0
+    end
+  end
+
+  @doc false
+  def initial_supply, do: @initial_supply
+
+  @doc false
+  @spec reserved_supply(Date.t()) :: non_neg_integer()
+  def reserved_supply(%Date{} = date) do
+    reserved_as_float =
+      Enum.reduce(@vesting_unlock_dates_and_percentages, @reserved_for_vesting, fn {unlock_date, percentage}, acc ->
+        if Date.compare(date, unlock_date) in [:eq, :gt] do
+          acc - percentage * @reserved_for_vesting
+        else
+          acc
+        end
+      end)
+
+    Kernel.trunc(reserved_as_float)
+  end
+end

--- a/apps/explorer/test/explorer/chain/supply/proof_of_authority_test.exs
+++ b/apps/explorer/test/explorer/chain/supply/proof_of_authority_test.exs
@@ -1,0 +1,40 @@
+defmodule Explorer.Chain.Supply.ProofOfAuthorityTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Supply.ProofOfAuthority
+
+  describe "total/0" do
+    test "without blocks present" do
+      assert ProofOfAuthority.total() == ProofOfAuthority.initial_supply()
+    end
+
+    test "with blocks present" do
+      height = 2_000_000
+      insert(:block, number: height)
+      expected = ProofOfAuthority.initial_supply() + height
+
+      assert ProofOfAuthority.total() == expected
+    end
+  end
+
+  test "circulating/0" do
+    if Date.compare(Date.utc_today(), ~D[2019-12-15]) == :lt do
+      assert ProofOfAuthority.circulating() < ProofOfAuthority.total()
+    else
+      assert ProofOfAuthority.circulating() == ProofOfAuthority.total()
+    end
+  end
+
+  test "reserved_supply/1" do
+    initial_reserved = 50_492_160
+
+    assert ProofOfAuthority.reserved_supply(~D[2018-06-14]) == initial_reserved
+    assert ProofOfAuthority.reserved_supply(~D[2018-06-15]) == 37_869_120
+    assert ProofOfAuthority.reserved_supply(~D[2018-09-15]) == 31_557_600
+    assert ProofOfAuthority.reserved_supply(~D[2018-12-15]) == 25_246_080
+    assert ProofOfAuthority.reserved_supply(~D[2019-03-15]) == 18_934_560
+    assert ProofOfAuthority.reserved_supply(~D[2019-06-15]) == 12_623_040
+    assert ProofOfAuthority.reserved_supply(~D[2019-09-15]) == 6_311_520
+    assert ProofOfAuthority.reserved_supply(~D[2019-12-15]) == 0
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4,8 +4,8 @@ defmodule Explorer.ChainTest do
   import Explorer.Factory
 
   alias Explorer.{Chain, Repo, Factory}
-
   alias Explorer.Chain.{Address, Block, InternalTransaction, Log, Transaction, Wei, SmartContract}
+  alias Explorer.Chain.Supply.ProofOfAuthority
 
   doctest Explorer.Chain
 
@@ -1023,5 +1023,17 @@ defmodule Explorer.ChainTest do
 
       assert address.contract_code != nil
     end
+  end
+
+  test "total_supply/0" do
+    height = 2_000_000
+    insert(:block, number: height)
+    expected = ProofOfAuthority.initial_supply() + height
+
+    assert Chain.total_supply() == expected
+  end
+
+  test "circulating_supply/0" do
+    assert Chain.circulating_supply() == ProofOfAuthority.circulating()
   end
 end

--- a/apps/explorer_web/lib/explorer_web/controllers/api/v1/supply_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/api/v1/supply_controller.ex
@@ -1,0 +1,12 @@
+defmodule ExplorerWeb.API.V1.SupplyController do
+  use ExplorerWeb, :controller
+
+  alias Explorer.Chain
+
+  def supply(conn, _) do
+    total_supply = Chain.total_supply()
+    circulating_supply = Chain.circulating_supply()
+
+    render(conn, :supply, total: total_supply, circulating: circulating_supply)
+  end
+end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -26,6 +26,12 @@ defmodule ExplorerWeb.Router do
     plug(SetLocale, gettext: ExplorerWeb.Gettext, default_locale: "en")
   end
 
+  scope "/api/v1", ExplorerWeb.API.V1, as: :api_v1 do
+    pipe_through(:api)
+
+    get("/supply", SupplyController, :supply)
+  end
+
   scope "/api", ExplorerWeb.API.RPC do
     pipe_through(:api)
 

--- a/apps/explorer_web/lib/explorer_web/views/api/v1/supply_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/api/v1/supply_view.ex
@@ -1,0 +1,10 @@
+defmodule ExplorerWeb.API.V1.SupplyView do
+  use ExplorerWeb, :view
+
+  def render("supply.json", %{total: total_supply, circulating: circulating_supply}) do
+    %{
+      "total_supply" => total_supply,
+      "circulating_supply" => circulating_supply
+    }
+  end
+end

--- a/apps/explorer_web/test/explorer_web/controllers/api/v1/supply_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api/v1/supply_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule ExplorerWeb.API.V1.SupplyControllerTest do
+  use ExplorerWeb.ConnCase
+
+  alias Explorer.Chain
+
+  test "supply", %{conn: conn} do
+    request = get(conn, api_v1_supply_path(conn, :supply))
+    assert response = json_response(request, 200)
+
+    assert response["total_supply"] == Chain.total_supply()
+    assert response["circulating_supply"] == Chain.circulating_supply()
+  end
+end


### PR DESCRIPTION
Resolves #225.

## Overview

This PR adds API for calculating the total supply and circulating supply for a given coin. Each coin that adopts the explorer will need to implement the `Explorer.Chain.Supply` behavior and use its implementation for retrieving those values. For now, the explorer will default to using POA's implementation.

## V1 API

This PR also exposes a new route of `/api/v1` for an initial implantation of an explorer API. This allows for easier versioning going forward. If we want some sort of wrapper that includes extra data as part of any request, we will to create a ticket and discuss that shape.

## Supply Endpoint

The endpoint at `/api/v1/supply` will return a simple response in the format of:
```json
{
  "total_supply": 123,
  "circulating_supply": 100
}
```