### PR TITLE
Index pending transactions

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -207,6 +207,19 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
+  A request payload for a JSONRPC.
+  """
+  @spec request(%{id: term, method: String.t(), params: list()}) :: %{String.t() => term}
+  def request(%{id: id, method: method, params: params}) do
+    %{
+      "id" => id,
+      "jsonrpc" => "2.0",
+      "method" => method,
+      "params" => params
+    }
+  end
+
+  @doc """
   Converts `t:timestamp/0` to `t:DateTime.t/0`
   """
   def timestamp_to_datetime(timestamp) do
@@ -252,15 +265,6 @@ defmodule EthereumJSONRPC do
   defp get_block_by_tag_request(tag) do
     # eth_getBlockByNumber accepts either a number OR a tag
     get_block_by_number_request(%{id: tag, tag: tag, transactions: :hashes})
-  end
-
-  defp request(%{id: id, method: method, params: params}) do
-    %{
-      "id" => id,
-      "jsonrpc" => "2.0",
-      "method" => method,
-      "params" => params
-    }
   end
 
   defp get_block_by_number_params(options) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
@@ -6,6 +6,7 @@ defmodule EthereumJSONRPC.Parity do
   import EthereumJSONRPC, only: [config: 1, json_rpc: 2, request: 1]
 
   alias EthereumJSONRPC.Parity.Traces
+  alias EthereumJSONRPC.{Transaction, Transactions}
 
   @doc """
   Fetches the `t:Explorer.Chain.InternalTransaction.changeset/2` params from the Parity trace URL.
@@ -43,6 +44,27 @@ defmodule EthereumJSONRPC.Parity do
         |> Traces.elixir_to_params()
 
       {:ok, internal_transactions_params}
+    end
+  end
+
+  @doc """
+  Fetches the pending transactions from the Parity node.
+
+  *NOTE*: The pending transactions are local to the node that is contacted and may not be consistent across nodes based
+  on the transactions that each node has seen and how each node prioritizes collating transactions into the next block.
+  """
+  @spec fetch_pending_transactions() :: {:ok, [Transaction.params()]} | {:error, reason :: term}
+  def fetch_pending_transactions do
+    with {:ok, transactions} <-
+           %{id: 1, method: "parity_pendingTransactions", params: []}
+           |> request()
+           |> json_rpc(config(:url)) do
+      transactions_params =
+        transactions
+        |> Transactions.to_elixir()
+        |> Transactions.elixir_to_params()
+
+      {:ok, transactions_params}
     end
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
@@ -3,7 +3,7 @@ defmodule EthereumJSONRPC.Parity do
   Ethereum JSONRPC methods that are only supported by [Parity](https://wiki.parity.io/).
   """
 
-  import EthereumJSONRPC, only: [config: 1, json_rpc: 2]
+  import EthereumJSONRPC, only: [config: 1, json_rpc: 2, request: 1]
 
   alias EthereumJSONRPC.Parity.Traces
 
@@ -34,7 +34,7 @@ defmodule EthereumJSONRPC.Parity do
   def fetch_internal_transactions(transaction_hashes) when is_list(transaction_hashes) do
     with {:ok, responses} <-
            transaction_hashes
-           |> Enum.map(&transaction_hash_to_internal_transaction_json/1)
+           |> Enum.map(&transaction_hash_to_internal_transaction_request/1)
            |> json_rpc(config(:trace_url)) do
       internal_transactions_params =
         responses
@@ -58,12 +58,7 @@ defmodule EthereumJSONRPC.Parity do
     Enum.flat_map(responses, &response_to_trace/1)
   end
 
-  defp transaction_hash_to_internal_transaction_json(transaction_hash) do
-    %{
-      "id" => transaction_hash,
-      "jsonrpc" => "2.0",
-      "method" => "trace_replayTransaction",
-      "params" => [transaction_hash, ["trace"]]
-    }
+  defp transaction_hash_to_internal_transaction_request(transaction_hash) do
+    request(%{id: transaction_hash, method: "trace_replayTransaction", params: [transaction_hash, ["trace"]]})
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -132,6 +132,57 @@ defmodule EthereumJSONRPC.Transaction do
 
   @doc """
   Decodes the stringly typed numerical fields to `t:non_neg_integer/0`.
+
+  Pending transactions have a `nil` `"blockHash"`, `"blockNumber"`, and `"transactionIndex"` because those fields are
+  related to the block the transaction is collated in.
+
+    iex> EthereumJSONRPC.Transaction.to_elixir(
+    ...>   %{
+    ...>     "blockHash" => nil,
+    ...>     "blockNumber" => nil,
+    ...>     "chainId" => "0x4d",
+    ...>     "condition" => nil,
+    ...>     "creates" => nil,
+    ...>     "from" => "0x40aa34fb35ef0804a41c2b4be7d3e3d65c7f6d5c",
+    ...>     "gas" => "0xcf08",
+    ...>     "gasPrice" => "0x0",
+    ...>     "hash" => "0x6b80a90c958fb5791a070929379ed6eb7a33ecdf9f9cafcada2f6803b3f25ec3",
+    ...>     "input" => "0x",
+    ...>     "nonce" => "0x77",
+    ...>     "publicKey" => "0xd0bf6fb4ce4ada1ddfb754b98cd89dc61c3ff143a260cf1712517af2af602b699aab554a2532051e5ba205eb41068c3423f23acde87313211750a8cbf862170e",
+    ...>     "r" => "0x3cfc2a34c2e4e09913934a5ade1055206e39b1e34fabcfcc820f6f70c740944c",
+    ...>     "raw" => "0xf868778082cf08948e854802d695269a6f1f3fcabb2111d2f5a0e6f9880de0b6b3a76400008081bea03cfc2a34c2e4e09913934a5ade1055206e39b1e34fabcfcc820f6f70c740944ca014cf6f15b5855f9b68eb58c95f76603a54b2ca612f921bb8d424de11bf085390",
+    ...>     "s" => "0x14cf6f15b5855f9b68eb58c95f76603a54b2ca612f921bb8d424de11bf085390",
+    ...>     "standardV" => "0x1",
+    ...>     "to" => "0x8e854802d695269a6f1f3fcabb2111d2f5a0e6f9",
+    ...>     "transactionIndex" => nil,
+    ...>     "v" => "0xbe",
+    ...>     "value" => "0xde0b6b3a7640000"
+    ...>   }
+    ...> )
+    %{
+      "blockHash" => nil,
+      "blockNumber" => nil,
+      "chainId" => 77,
+      "condition" => nil,
+      "creates" => nil,
+      "from" => "0x40aa34fb35ef0804a41c2b4be7d3e3d65c7f6d5c",
+      "gas" => 53000,
+      "gasPrice" => 0,
+      "hash" => "0x6b80a90c958fb5791a070929379ed6eb7a33ecdf9f9cafcada2f6803b3f25ec3",
+      "input" => "0x",
+      "nonce" => 119,
+      "publicKey" => "0xd0bf6fb4ce4ada1ddfb754b98cd89dc61c3ff143a260cf1712517af2af602b699aab554a2532051e5ba205eb41068c3423f23acde87313211750a8cbf862170e",
+      "r" => 27584307671108667307432650922507113611469948945973084068788107666229588694092,
+      "raw" => "0xf868778082cf08948e854802d695269a6f1f3fcabb2111d2f5a0e6f9880de0b6b3a76400008081bea03cfc2a34c2e4e09913934a5ade1055206e39b1e34fabcfcc820f6f70c740944ca014cf6f15b5855f9b68eb58c95f76603a54b2ca612f921bb8d424de11bf085390",
+      "s" => 9412760993194218539611435541875082818858943210434840876051960418568625476496,
+      "standardV" => 1,
+      "to" => "0x8e854802d695269a6f1f3fcabb2111d2f5a0e6f9",
+      "transactionIndex" => nil,
+      "v" => 190,
+      "value" => 1000000000000000000
+    }
+
   """
   def to_elixir(transaction) when is_map(transaction) do
     Enum.into(transaction, %{}, &entry_to_elixir/1)
@@ -144,9 +195,19 @@ defmodule EthereumJSONRPC.Transaction do
        when key in ~w(blockHash condition creates from hash input jsonrpc publicKey raw to),
        do: {key, value}
 
-  defp entry_to_elixir({key, quantity})
-       when key in ~w(blockNumber gas gasPrice nonce r s standardV transactionIndex v value) do
+  defp entry_to_elixir({key, quantity}) when key in ~w(gas gasPrice nonce r s standardV v value) and quantity != nil do
     {key, quantity_to_integer(quantity)}
+  end
+
+  # quantity or nil for pending
+  defp entry_to_elixir({key, quantity_or_nil}) when key in ~w(blockNumber transactionIndex) do
+    elixir =
+      case quantity_or_nil do
+        nil -> nil
+        quantity -> quantity_to_integer(quantity)
+      end
+
+    {key, elixir}
   end
 
   # chainId is *sometimes* nil

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -56,7 +56,7 @@ defmodule Explorer.Chain do
   @typep timeout_option :: {:timeout, timeout}
   @typep timestamps :: %{inserted_at: DateTime.t(), updated_at: DateTime.t()}
   @typep timestamps_option :: {:timestamps, timestamps}
-  @typep addresses_option :: {:adddresses, [params_option | timeout_option]}
+  @typep addresses_option :: {:addresses, [params_option | timeout_option]}
   @typep blocks_option :: {:blocks, [params_option | timeout_option]}
   @typep internal_transactions_option :: {:internal_transactions, [params_option | timeout_option]}
   @typep logs_option :: {:logs, [params_option | timeout_option]}

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -52,7 +52,7 @@ defmodule Explorer.Chain do
   @typep on_conflict_option :: {:on_conflict, :nothing | :replace_all}
   @typep pagination_option :: {:pagination, pagination}
   @typep paging_options :: {:paging_options, PagingOptions.t()}
-  @typep params_option :: {:params, map()}
+  @typep params_option :: {:params, [map()]}
   @typep timeout_option :: {:timeout, timeout}
   @typep timestamps :: %{inserted_at: DateTime.t(), updated_at: DateTime.t()}
   @typep timestamps_option :: {:timestamps, timestamps}

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1947,11 +1947,13 @@ defmodule Explorer.Chain do
        when is_map(ecto_schema_module_to_changes_list) and is_list(options) do
     case ecto_schema_module_to_changes_list do
       %{Address => addresses_changes} ->
+        timestamps = Keyword.fetch!(options, :timestamps)
+
         Multi.run(multi, :addresses, fn _ ->
           insert_addresses(
             addresses_changes,
             timeout: options[:addresses][:timeout] || @insert_addresses_timeout,
-            timestamps: Keyword.fetch!(options, :timestamps)
+            timestamps: timestamps
           )
         end)
 
@@ -1964,11 +1966,13 @@ defmodule Explorer.Chain do
        when is_map(ecto_schema_module_to_changes_list) and is_list(options) do
     case ecto_schema_module_to_changes_list do
       %{Block => blocks_changes} ->
+        timestamps = Keyword.fetch!(options, :timestamps)
+
         Multi.run(multi, :blocks, fn _ ->
           insert_blocks(
             blocks_changes,
             timeout: options[:blocks][:timeout] || @insert_blocks_timeout,
-            timestamps: Keyword.fetch!(options, :timestamps)
+            timestamps: timestamps
           )
         end)
 
@@ -1981,11 +1985,13 @@ defmodule Explorer.Chain do
        when is_map(ecto_schema_module_to_changes_list) and is_list(options) do
     case ecto_schema_module_to_changes_list do
       %{Transaction => transactions_changes} ->
+        timestamps = Keyword.fetch!(options, :timestamps)
+
         Multi.run(multi, :transactions, fn _ ->
           insert_transactions(
             transactions_changes,
             timeout: options[:transations][:timeout] || @insert_transactions_timeout,
-            timestamps: Keyword.fetch!(options, :timestamps)
+            timestamps: timestamps
           )
         end)
 
@@ -1998,11 +2004,13 @@ defmodule Explorer.Chain do
        when is_map(ecto_schema_module_to_changes_list) and is_list(options) do
     case ecto_schema_module_to_changes_list do
       %{InternalTransaction => internal_transactions_changes} ->
+        timestamps = Keyword.fetch!(options, :timestamps)
+
         Multi.run(multi, :internal_transactions, fn _ ->
           insert_internal_transactions(
             internal_transactions_changes,
             timeout: options[:internal_transactions][:timeout] || @insert_internal_transactions_timeout,
-            timestamps: Keyword.fetch!(options, :timestamps)
+            timestamps: timestamps
           )
         end)
 
@@ -2015,11 +2023,13 @@ defmodule Explorer.Chain do
        when is_map(ecto_schema_module_to_changes_list) and is_list(options) do
     case ecto_schema_module_to_changes_list do
       %{Log => logs_changes} ->
+        timestamps = Keyword.fetch!(options, :timestamps)
+
         Multi.run(multi, :logs, fn _ ->
           insert_logs(
             logs_changes,
             timeout: options[:logs][:timeout] || @insert_logs_timeout,
-            timestamps: Keyword.fetch!(options, :timestamps)
+            timestamps: timestamps
           )
         end)
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -7,8 +7,8 @@ defmodule Explorer.Chain.Transaction do
   alias Explorer.Chain.{Address, Block, Data, Gas, Hash, InternalTransaction, Log, Wei}
   alias Explorer.Chain.Transaction.Status
 
-  @optional_attrs ~w(block_hash block_number cumulative_gas_used from_address_hash gas_used index status
-                     to_address_hash)a
+  @optional_attrs ~w(block_hash block_number cumulative_gas_used from_address_hash gas_used index
+                     internal_transactions_indexed_at status to_address_hash)a
   @required_attrs ~w(gas gas_price hash input nonce public_key r s standard_v v value)a
 
   @typedoc """

--- a/apps/explorer/lib/explorer/indexer.ex
+++ b/apps/explorer/lib/explorer/indexer.ex
@@ -4,7 +4,7 @@ defmodule Explorer.Indexer do
   """
   require Logger
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Indexer}
 
   @doc """
   The maximum `t:Explorer.Chain.Block.t/0` `number` that was indexed
@@ -77,6 +77,16 @@ defmodule Explorer.Indexer do
   """
   def disable_debug_logs do
     Application.put_env(:explorer, :indexer, Keyword.put(config(), :debug_logs, false))
+  end
+
+  @doc """
+  Starts a child task of `Indexer.TaskSupervisor` and monitors it, instead of linking to it.
+  """
+  @spec start_monitor((() -> term())) :: {:ok, pid, reference}
+  def start_monitor(task_function) when is_function(task_function, 0) do
+    {:ok, pid} = Task.Supervisor.start_child(Indexer.TaskSupervisor, task_function)
+    ref = Process.monitor(pid)
+    {:ok, pid, ref}
   end
 
   defp debug_logs_enabled? do

--- a/apps/explorer/lib/explorer/indexer/address_extraction.ex
+++ b/apps/explorer/lib/explorer/indexer/address_extraction.ex
@@ -1,4 +1,4 @@
-defmodule Explorer.Indexer.BlockFetcher.AddressExtraction do
+defmodule Explorer.Indexer.AddressExtraction do
   @moduledoc """
   Extract Addresses from data fetched from the Blockchain and structured as Blocks, InternalTransactions,
   Transactions and Logs.

--- a/apps/explorer/lib/explorer/indexer/address_extraction.ex
+++ b/apps/explorer/lib/explorer/indexer/address_extraction.ex
@@ -43,6 +43,11 @@ defmodule Explorer.Indexer.AddressExtraction do
       }
   """
 
+  @transactions_address_maps [
+    %{from: :from_address_hash, to: :hash},
+    %{from: :to_address_hash, to: :hash}
+  ]
+
   @entity_to_address_map %{
     blocks: [%{from: :miner_hash, to: :hash}],
     internal_transactions: [
@@ -53,10 +58,7 @@ defmodule Explorer.Indexer.AddressExtraction do
         %{from: :created_contract_code, to: :contract_code}
       ]
     ],
-    transactions: [
-      %{from: :from_address_hash, to: :hash},
-      %{from: :to_address_hash, to: :hash}
-    ],
+    transactions: @transactions_address_maps,
     logs: [%{from: :address_hash, to: :hash}]
   }
 
@@ -64,6 +66,22 @@ defmodule Explorer.Indexer.AddressExtraction do
   Parameters for `Explorer.Chain.Address.changeset/2`.
   """
   @type params :: %{required(:hash) => String.t(), optional(:contract_code) => String.t()}
+
+  @doc """
+  Extracts the `from_address_hash` and `to_address_hash` from all the `transactions_params`.
+  """
+  @spec transactions_params_to_addresses_params([
+          %{
+            required(:from_address_hash) => String.t(),
+            optional(:to_address_hash) => String.t()
+          }
+        ]) :: [params]
+  def transactions_params_to_addresses_params(transactions_params) do
+    transactions_params
+    |> extract_addresses_from_collection(@transactions_address_maps)
+    |> List.flatten()
+    |> merge_addresses()
+  end
 
   @doc """
   Extract addresses from block, internal transaction, transaction, and log parameters.

--- a/apps/explorer/lib/explorer/indexer/address_extraction.ex
+++ b/apps/explorer/lib/explorer/indexer/address_extraction.ex
@@ -60,6 +60,40 @@ defmodule Explorer.Indexer.AddressExtraction do
     logs: [%{from: :address_hash, to: :hash}]
   }
 
+  @typedoc """
+  Parameters for `Explorer.Chain.Address.changeset/2`.
+  """
+  @type params :: %{required(:hash) => String.t(), optional(:contract_code) => String.t()}
+
+  @doc """
+  Extract addresses from block, internal transaction, transaction, and log parameters.
+  """
+  @spec extract_addresses(%{
+          optional(:blocks) => [
+            %{
+              required(:miner_hash) => String.t()
+            }
+          ],
+          optional(:internal_transactions) => [
+            %{
+              required(:from_address_hash) => String.t(),
+              optional(:to_address_hash) => String.t(),
+              optional(:created_contract_address_hash) => String.t(),
+              optional(:created_contract_code) => String.t()
+            }
+          ],
+          optional(:transactions) => [
+            %{
+              required(:from_address_hash) => String.t(),
+              optional(:to_address_hash) => String.t()
+            }
+          ],
+          optional(:logs) => [
+            %{
+              required(:address_hash) => String.t()
+            }
+          ]
+        }) :: [params]
   def extract_addresses(fetched_data) do
     addresses =
       for {entity_key, entity_fields} <- @entity_to_address_map,

--- a/apps/explorer/lib/explorer/indexer/block_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/block_fetcher.ex
@@ -279,7 +279,7 @@ defmodule Explorer.Indexer.BlockFetcher do
         blocks: [params: blocks],
         logs: [params: logs],
         receipts: [params: receipts],
-        transactions: [params: transactions_with_receipts]
+        transactions: [on_conflict: :replace_all, params: transactions_with_receipts]
       )
     else
       {step, {:error, reason}} ->

--- a/apps/explorer/lib/explorer/indexer/block_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/block_fetcher.ex
@@ -87,13 +87,13 @@ defmodule Explorer.Indexer.BlockFetcher do
 
   @impl GenServer
   def handle_info(:catchup_index, %{} = state) do
-    {:ok, genesis_task, _ref} = monitor_task(fn -> genesis_task(state) end)
+    {:ok, genesis_task, _ref} = Indexer.start_monitor(fn -> genesis_task(state) end)
 
     {:noreply, %{state | genesis_task: genesis_task}}
   end
 
   def handle_info(:realtime_index, %{} = state) do
-    {:ok, realtime_task, _ref} = monitor_task(fn -> realtime_task(state) end)
+    {:ok, realtime_task, _ref} = Indexer.start_monitor(fn -> realtime_task(state) end)
 
     {:noreply, %{state | realtime_task: realtime_task}}
   end
@@ -314,11 +314,5 @@ defmodule Explorer.Indexer.BlockFetcher do
   defp schedule_next_realtime_fetch(state) do
     Process.send_after(self(), :realtime_index, state.realtime_interval)
     state
-  end
-
-  defp monitor_task(task_func) do
-    {:ok, pid} = Task.Supervisor.start_child(Indexer.TaskSupervisor, task_func)
-    ref = Process.monitor(pid)
-    {:ok, pid, ref}
   end
 end

--- a/apps/explorer/lib/explorer/indexer/block_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/block_fetcher.ex
@@ -12,8 +12,7 @@ defmodule Explorer.Indexer.BlockFetcher do
   alias EthereumJSONRPC
   alias EthereumJSONRPC.Transactions
   alias Explorer.{BufferedTask, Chain, Indexer}
-  alias Explorer.Indexer.BlockFetcher.AddressExtraction
-  alias Explorer.Indexer.{AddressBalanceFetcher, InternalTransactionFetcher, Sequence}
+  alias Explorer.Indexer.{AddressBalanceFetcher, AddressExtraction, InternalTransactionFetcher, Sequence}
 
   # dialyzer thinks that Logger.debug functions always have no_local_return
   @dialyzer {:nowarn_function, import_range: 3}

--- a/apps/explorer/lib/explorer/indexer/internal_transaction_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/internal_transaction_fetcher.ex
@@ -6,8 +6,7 @@ defmodule Explorer.Indexer.InternalTransactionFetcher do
   """
 
   alias Explorer.{BufferedTask, Chain, Indexer}
-  alias Explorer.Indexer.BlockFetcher.AddressExtraction
-  alias Explorer.Indexer.AddressBalanceFetcher
+  alias Explorer.Indexer.{AddressBalanceFetcher, AddressExtraction}
   alias Explorer.Chain.{Hash, Transaction}
 
   @behaviour BufferedTask

--- a/apps/explorer/lib/explorer/indexer/pending_transaction_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/pending_transaction_fetcher.ex
@@ -1,0 +1,101 @@
+defmodule Explorer.Indexer.PendingTransactionFetcher do
+  @moduledoc """
+  Fetches pending transactions and imports them.
+
+  *NOTE*: Pending transactions are imported with with `on_conflict: :nothing`, so that they don't overwrite their own
+  validated version that may make it to the database first.
+  """
+  use GenServer
+
+  require Logger
+
+  import EthereumJSONRPC.Parity, only: [fetch_pending_transactions: 0]
+  import Explorer.Indexer.AddressExtraction, only: [transactions_params_to_addresses_params: 1]
+
+  alias Explorer.{Chain, Indexer}
+  alias Explorer.Indexer.PendingTransactionFetcher
+
+  # milliseconds
+  @default_interval 1_000
+
+  defstruct interval: @default_interval,
+            task_ref: nil,
+            task_pid: nil
+
+  @gen_server_options ~w(debug name spawn_opt timeout)a
+
+  @doc """
+  Starts the pending transaction fetcher.
+
+  ## Options
+
+    * `:debug` - if present, the corresponding function in the [`:sys` module](http://www.erlang.org/doc/man/sys.html)
+      is invoked
+    * `:name` - used for name registration as described in the "Name registration" section of the `GenServer` module
+      documentation
+    * `:pending_transaction_interval` - the millisecond time between checking for pending transactions.  Defaults to
+      `#{@default_interval}` milliseconds.
+    * `:spawn_opt` - if present, its value is passed as options to the underlying process as in `Process.spawn/4`
+    * `:timeout` - if present, the server is allowed to spend the given number of milliseconds initializing or it will
+      be terminated and the start function will return `{:error, :timeout}`
+
+  """
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, Keyword.drop(opts, @gen_server_options), Keyword.take(opts, @gen_server_options))
+  end
+
+  @impl GenServer
+  def init(opts) do
+    opts =
+      :explorer
+      |> Application.fetch_env!(:indexer)
+      |> Keyword.merge(opts)
+
+    state =
+      %PendingTransactionFetcher{interval: opts[:pending_transaction_interval] || @default_interval}
+      |> schedule_fetch()
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:fetch, %PendingTransactionFetcher{} = state) do
+    {:ok, pid, ref} = Indexer.start_monitor(fn -> task(state) end)
+    {:noreply, %PendingTransactionFetcher{state | task_ref: ref, task_pid: pid}}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, reason}, %PendingTransactionFetcher{task_ref: ref, task_pid: pid} = state) do
+    case reason do
+      :normal ->
+        :ok
+
+      _ ->
+        Logger.error(fn -> "pending transaction fetcher task exited due to #{inspect(reason)}.  Rescheduling." end)
+    end
+
+    new_state =
+      %PendingTransactionFetcher{state | task_ref: nil, task_pid: nil}
+      |> schedule_fetch()
+
+    {:noreply, new_state}
+  end
+
+  defp schedule_fetch(%PendingTransactionFetcher{interval: interval} = state) do
+    Process.send_after(self(), :fetch, interval)
+    state
+  end
+
+  defp task(%PendingTransactionFetcher{} = _state) do
+    {:ok, transactions_params} = fetch_pending_transactions()
+    addresses_params = transactions_params_to_addresses_params(transactions_params)
+
+    # There's no need to queue up fetching the address balance since theses are pending transactions and cannot have
+    # affected the address balance yet since address balance is a balance at a give block and these transactions are
+    # blockless.
+    {:ok, _} =
+      Chain.import_blocks(
+        addresses: [params: addresses_params],
+        transactions: [on_conflict: :nothing, params: transactions_params]
+      )
+  end
+end

--- a/apps/explorer/lib/explorer/indexer/supervisor.ex
+++ b/apps/explorer/lib/explorer/indexer/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Indexer.Supervisor do
 
   use Supervisor
 
-  alias Explorer.Indexer.{AddressBalanceFetcher, BlockFetcher, InternalTransactionFetcher}
+  alias Explorer.Indexer.{AddressBalanceFetcher, BlockFetcher, InternalTransactionFetcher, PendingTransactionFetcher}
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -16,6 +16,7 @@ defmodule Explorer.Indexer.Supervisor do
     children = [
       {Task.Supervisor, name: Explorer.Indexer.TaskSupervisor},
       {AddressBalanceFetcher, name: AddressBalanceFetcher},
+      {PendingTransactionFetcher, name: PendingTransactionFetcher},
       {InternalTransactionFetcher, name: InternalTransactionFetcher},
       {BlockFetcher, []}
     ]

--- a/apps/explorer/test/explorer/indexer/address_extraction_test.exs
+++ b/apps/explorer/test/explorer/indexer/address_extraction_test.exs
@@ -1,7 +1,7 @@
-defmodule Explorer.Indexer.BlockFetcher.AddressExtractionTest do
+defmodule Explorer.Indexer.AddressExtractionTest do
   use Explorer.DataCase, async: true
 
-  alias Explorer.Indexer.BlockFetcher.AddressExtraction
+  alias Explorer.Indexer.AddressExtraction
 
   describe "extract_addresses/1" do
     test "returns all hashes entities data in a list" do

--- a/apps/explorer/test/explorer/indexer/block_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/block_fetcher_test.exs
@@ -51,7 +51,7 @@ defmodule Explorer.Indexer.BlockFetcherTest do
       InternalTransactionFetcherCase.start_supervised!()
       start_supervised!(BlockFetcher)
 
-      wait(fn ->
+      wait_for_results(fn ->
         Repo.one!(from(block in Block, where: block.number == ^latest_block_number))
       end)
 
@@ -59,7 +59,7 @@ defmodule Explorer.Indexer.BlockFetcherTest do
 
       previous_batch_block_number = latest_block_number - default_blocks_batch_size
 
-      wait(fn ->
+      wait_for_results(fn ->
         Repo.one!(from(block in Block, where: block.number == ^previous_batch_block_number))
       end)
 
@@ -275,24 +275,5 @@ defmodule Explorer.Indexer.BlockFetcherTest do
       counts = Explorer.BufferedTask.debug_count(buffered_task)
       counts.buffer == 0 and counts.tasks == 0
     end)
-  end
-
-  defp wait(producer) do
-    producer.()
-  rescue
-    Ecto.NoResultsError ->
-      Process.sleep(100)
-      wait(producer)
-  catch
-    :exit,
-    {:timeout,
-     {GenServer, :call,
-      [
-        _,
-        {:checkout, _, _, _},
-        _
-      ]}} ->
-      Process.sleep(100)
-      wait(producer)
   end
 end

--- a/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
@@ -1,7 +1,26 @@
 defmodule Explorer.Indexer.InternalTransactionFetcherTest do
-  use Explorer.DataCase, async: true
+  use Explorer.DataCase, async: false
 
-  alias Explorer.Indexer.InternalTransactionFetcher
+  alias Explorer.Chain.Transaction
+  alias Explorer.Indexer.{AddressBalanceFetcherCase, InternalTransactionFetcher, PendingTransactionFetcher}
+
+  test "does not try to fetch pending transactions from Explorer.Indexer.PendingTransactionFetcher" do
+    start_supervised!({Task.Supervisor, name: Explorer.Indexer.TaskSupervisor})
+    AddressBalanceFetcherCase.start_supervised!()
+    start_supervised!(PendingTransactionFetcher)
+
+    wait_for_results(fn ->
+      Repo.one!(from(transaction in Transaction, where: is_nil(transaction.block_hash), limit: 1))
+    end)
+
+    :transaction
+    |> insert(hash: "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6")
+    |> with_block()
+
+    hash_strings = InternalTransactionFetcher.init([], fn hash_string, acc -> [hash_string | acc] end)
+
+    assert :ok = InternalTransactionFetcher.run(hash_strings, 0)
+  end
 
   describe "init/2" do
     test "does not buffer pending transactions" do

--- a/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Indexer.InternalTransactionFetcherTest do
+  use Explorer.DataCase, async: true
+
+  alias Explorer.Indexer.InternalTransactionFetcher
+
+  describe "init/2" do
+    test "does not buffer pending transactions" do
+      insert(:transaction)
+
+      assert InternalTransactionFetcher.init([], fn hash_string, acc -> [hash_string | acc] end) == []
+    end
+
+    test "buffers collated transactions with unfetched internal transactions" do
+      collated_unfetched_transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      assert InternalTransactionFetcher.init([], fn hash_string, acc -> [hash_string | acc] end) == [
+               to_string(collated_unfetched_transaction.hash)
+             ]
+    end
+
+    test "does not buffer collated transactions with fetched internal transactions" do
+      :transaction
+      |> insert()
+      |> with_block(internal_transactions_indexed_at: DateTime.utc_now())
+
+      assert InternalTransactionFetcher.init([], fn hash_string, acc -> [hash_string | acc] end) == []
+    end
+  end
+end

--- a/apps/explorer/test/explorer/indexer/pending_transaction_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/pending_transaction_fetcher_test.exs
@@ -1,0 +1,23 @@
+defmodule Explorer.Indexer.PendingTransactionFetcherTest do
+  # `async: false` due to use of named GenServer
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.Transaction
+  alias Explorer.Indexer.PendingTransactionFetcher
+
+  describe "start_link/1" do
+    # this test may fail if Sokol so low volume that the pending transactions are empty for too long
+    test "starts fetching pending transactions" do
+      assert Repo.aggregate(Transaction, :count, :hash) == 0
+
+      start_supervised!({Task.Supervisor, name: Explorer.Indexer.TaskSupervisor})
+      start_supervised!(PendingTransactionFetcher)
+
+      wait_for_results(fn ->
+        Repo.one!(from(transaction in Transaction, where: is_nil(transaction.block_hash), limit: 1))
+      end)
+
+      assert Repo.aggregate(Transaction, :count, :hash) >= 1
+    end
+  end
+end

--- a/apps/explorer/test/support/data_case.ex
+++ b/apps/explorer/test/support/data_case.ex
@@ -39,4 +39,23 @@ defmodule Explorer.DataCase do
 
     :ok
   end
+
+  def wait_for_results(producer) do
+    producer.()
+  rescue
+    Ecto.NoResultsError ->
+      Process.sleep(100)
+      wait_for_results(producer)
+  catch
+    :exit,
+    {:timeout,
+     {GenServer, :call,
+      [
+        _,
+        {:checkout, _, _, _},
+        _
+      ]}} ->
+      Process.sleep(100)
+      wait_for_results(producer)
+  end
 end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -95,6 +95,7 @@ defmodule Explorer.Factory do
 
     cumulative_gas_used = collated_params[:cumulative_gas_used] || Enum.random(21_000..100_000)
     gas_used = collated_params[:gas_used] || Enum.random(21_000..100_000)
+    internal_transactions_indexed_at = collated_params[:internal_transactions_indexed_at]
     status = collated_params[:status] || Enum.random(0..1)
 
     transaction
@@ -104,6 +105,7 @@ defmodule Explorer.Factory do
       cumulative_gas_used: cumulative_gas_used,
       gas_used: gas_used,
       index: next_transaction_index,
+      internal_transactions_indexed_at: internal_transactions_indexed_at,
       status: status
     })
     |> Repo.update!()

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 92.9
+    "minimum_coverage": 92.7
   },
   "terminal_options": {
     "file_column_width": 120

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 92.7
+    "minimum_coverage": 92.9
   },
   "terminal_options": {
     "file_column_width": 120


### PR DESCRIPTION
Resolves #250

# Changelog
## Enhancements
* Document `AddressExtraction.extract_addresses`.
* Use `EthereumJSONRPC.request/1` in `EthereumJSONRPC.Parity`.
* Rename `Indexer.BlockFetcher.monitor_task` to `Indexer.start_monitor` and make it public, so that all `*Fetcher`s can use it.
*  Check for required `timestamps` option as soon as possible as not including timestamps is a developer error, so it should be caught as soon as possible to allow the code to be fixed in development.
* Use `parity_pendingTransactions` JSONRPC to get the pending transactions and import them.  If they conflict with pre-existing transactions, then the previous transactions win, under the assumption that sometimes pending transactions repository transaction will `COMMIT` after the the
realtime index has `COMMIT`ed that same transaction being validated as the timeout for transactions is 60 seconds while the block rate is faster than that.

## Bug Fixes
* Move `AddressExtraction` out of `BlockFetcher` because it is used in the
`InternalTransactionFetcher` and `PendingTransactionFetcher`.
* Pending transactions have `nil` for `"blockNumber"` and `"transactionIndex"`, which broke `quantity_to_integer`, so for those keys, check if `nil` and pass through.  For others, check that the value is not `nil` as it gives a better error message with both the key and value instead of just the `nil` value passed to quantity_to_integer as happened before.
*  Exclude pending transactions for unfetched internal transactions as Parity doesn't support asking for the internal transactions of pending transactions.
* Add `:transactions` `:on_conflict` option that is required when `:transactions` `:params` as passed because the repository transaction for a pending `Explorer.Chain.Transaction`s could `COMMIT` after the repository transaction for that same transaction being collated into a block, writers, it is recommended to use `:nothing` for pending transactions and `:replace_all` for collated transactions, so that collated transactions win.
* `params_option` value should be `[map]`, not `map` since it is a list of params for the given schema.
* Fix typo `adddresses` -> `addresses` in `addresses_option`.