### PR TITLE
Use table statistics estimate for total transaction

### DIFF
--- a/apps/explorer_web/lib/explorer_web/controllers/pending_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/pending_transaction_controller.ex
@@ -16,13 +16,13 @@ defmodule ExplorerWeb.PendingTransactionController do
     full_options = Keyword.merge([necessity_by_association: %{from_address: :optional, to_address: :optional}], options)
     transactions = Chain.recent_pending_transactions(full_options)
     last_seen_pending_inserted_at = last_seen_pending_inserted_at(transactions.entries)
-    transaction_count = Chain.transaction_count(:pending)
+    pending_transaction_count = Chain.pending_transaction_count()
 
     render(
       conn,
       "index.html",
       last_seen_pending_inserted_at: last_seen_pending_inserted_at,
-      transaction_count: transaction_count,
+      pending_transaction_count: pending_transaction_count,
       transactions: transactions
     )
   end

--- a/apps/explorer_web/lib/explorer_web/controllers/pending_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/pending_transaction_controller.ex
@@ -16,7 +16,7 @@ defmodule ExplorerWeb.PendingTransactionController do
     full_options = Keyword.merge([necessity_by_association: %{from_address: :optional, to_address: :optional}], options)
     transactions = Chain.recent_pending_transactions(full_options)
     last_seen_pending_inserted_at = last_seen_pending_inserted_at(transactions.entries)
-    transaction_count = Chain.transaction_count(pending: true)
+    transaction_count = Chain.transaction_count(:pending)
 
     render(
       conn,

--- a/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
@@ -36,13 +36,13 @@ defmodule ExplorerWeb.TransactionController do
       )
 
     transactions = Chain.recent_collated_transactions(full_options)
-    transaction_count = Chain.transaction_count(:all)
+    transaction_estimated_count = Chain.transaction_estimated_count()
 
     render(
       conn,
       "index.html",
       earliest: earliest(transactions),
-      transaction_count: transaction_count,
+      transaction_estimated_count: transaction_estimated_count,
       transactions: transactions
     )
   end

--- a/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/transaction_controller.ex
@@ -36,7 +36,7 @@ defmodule ExplorerWeb.TransactionController do
       )
 
     transactions = Chain.recent_collated_transactions(full_options)
-    transaction_count = Chain.transaction_count()
+    transaction_count = Chain.transaction_count(:all)
 
     render(
       conn,

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -3,7 +3,7 @@
     Transactions
   </h1>
   <p>
-    <%= gettext("Showing %{count} Pending Transactions", count: @transaction_count) %>
+    <%= gettext("Showing %{count} Pending Transactions", count: @pending_transaction_count) %>
   </p>
 
   <div class="card">

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -3,7 +3,7 @@
     Transactions
   </h1>
   <p>
-    <%= gettext("Showing %{count} Validated Transactions", count: @transaction_count) %>
+    <%= gettext("Showing %{count} Validated Transactions", count: @transaction_estimated_count) %>
   </p>
 
   <div class="card">

--- a/apps/explorer_web/test/explorer_web/controllers/pending_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/pending_transaction_controller_test.exs
@@ -45,7 +45,7 @@ defmodule ExplorerWeb.PendingTransactionControllerTest do
       conn = get(conn, pending_transaction_path(ExplorerWeb.Endpoint, :index, :en))
 
       assert html_response(conn, 200)
-      assert 1 == conn.assigns.transaction_count
+      assert 1 == conn.assigns.pending_transaction_count
     end
 
     test "paginates transactions using the last seen transaction", %{conn: conn} do

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -23,7 +23,7 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
       conn = get(conn, "/en/transactions")
 
-      assert conn.assigns.transaction_count == 1
+      assert is_integer(conn.assigns.transaction_count)
     end
 
     test "excludes pending transactions", %{conn: conn} do

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_controller_test.exs
@@ -23,7 +23,7 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
       conn = get(conn, "/en/transactions")
 
-      assert is_integer(conn.assigns.transaction_count)
+      assert is_integer(conn.assigns.transaction_estimated_count)
     end
 
     test "excludes pending transactions", %{conn: conn} do
@@ -81,13 +81,13 @@ defmodule ExplorerWeb.TransactionControllerTest do
 
       conn = get(conn, "/en/transactions")
 
-      refute conn.assigns.transaction_count == nil
+      refute conn.assigns.transaction_estimated_count == nil
     end
 
     test "works when there are no transactions", %{conn: conn} do
       conn = get(conn, "/en/transactions")
 
-      assert conn.assigns.transaction_count == 0
+      assert conn.assigns.transaction_estimated_count == 0
       assert conn.assigns.transactions == []
     end
   end


### PR DESCRIPTION
Resolves #251 

## Changelog

### Enahancements
* Use statistics table to get estimated count of total transactions