### PR TITLE
Increase characters in address and remove address icon

### DIFF
--- a/apps/explorer_web/assets/css/components/_address_link.scss
+++ b/apps/explorer_web/assets/css/components/_address_link.scss
@@ -2,6 +2,7 @@
   border: 1px solid $border-color;
   white-space: nowrap;
   display: inline-block;
+  padding-left: 3px;
 
   &__font {
     font-family: $font-family-monospace;

--- a/apps/explorer_web/lib/explorer_web/templates/address/_link.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/_link.html.eex
@@ -7,10 +7,8 @@
     title: @address do %>
       <%= if contract?(@address) do %>
         <i class="address-link__type fas fa-file"></i>
-      <% else %>
-        <i class="address-link__type fas fa-address-card"></i>
       <% end %>
-    <%= @address |> hash() |> String.slice(0..3) %><i class="fas fa-ellipsis-v address-link__seperator"></i><%= @address |> hash() |> String.slice(-4..-1) %>
+    <%= @address |> hash() |> String.slice(0..5) %><i class="fas fa-ellipsis-v address-link__seperator"></i><%= @address |> hash() |> String.slice(-6..-1) %>
 <% end %>
 <button class="address-link__copy-button" data-clipboard-text="<%= @address %>" aria-label="copy address">
   <i class="fa fa-copy"></i>


### PR DESCRIPTION
Fixes #268 and #260 

Increase the number of characters in the address to 12 and remove the icon when an address is not a contract. It's very difficult to see the difference between an address icon and file icon.