### PR TITLE
Add note at readme noticing the Solidity dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Configure your local CCMenu with the following url: [`https://circleci.com/gh/po
 #### Prerequisites
 
   * PhantomJS (for wallaby)
+  * `Solidity` - http://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html
 
 #### Running the tests
 


### PR DESCRIPTION
This PR adds a notification at the `readme` file, warning about a `Solidity` dependency we now have to run our tests.