### PR TITLE
Display contract create address #241

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1412,6 +1412,10 @@ defmodule Explorer.Chain do
     paging_options = Keyword.get(options, :paging_options, %PagingOptions{page_size: 50})
 
     Transaction
+    |> load_contract_creation()
+    |> select_merge([_, internal_transaction], %{
+      created_contract_address_hash: internal_transaction.created_contract_address_hash
+    })
     |> where([transaction], not is_nil(transaction.block_number) and not is_nil(transaction.index))
     |> page_transaction(paging_options)
     |> limit(^paging_options.page_size)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1685,6 +1685,10 @@ defmodule Explorer.Chain do
     pagination = Keyword.get(named_arguments, :pagination, %{})
 
     Transaction
+    |> load_contract_creation()
+    |> select_merge([_, internal_transaction], %{
+      created_contract_address_hash: internal_transaction.created_contract_address_hash
+    })
     |> join_associations(necessity_by_association)
     |> reverse_chronologically()
     |> where_address_fields_match(address_hash, direction)

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -28,6 +28,8 @@ defmodule Explorer.Chain.InternalTransaction do
   """
   @type t :: %__MODULE__{
           call_type: CallType.t() | nil,
+          created_contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
+          created_contract_address_hash: Explorer.Chain.Hash.t(),
           created_contract_code: Data.t() | nil,
           error: String.t(),
           from_address: %Ecto.Association.NotLoaded{} | Address.t(),

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -115,9 +115,14 @@ defmodule Explorer.Chain.Statistics do
       )
 
     transactions =
-      [paging_options: %PagingOptions{page_size: 5}]
-      |> Chain.recent_collated_transactions()
-      |> Repo.preload([:block])
+      Chain.recent_collated_transactions(
+        necessity_by_association: %{
+          block: :required,
+          from_address: :required,
+          to_address: :optional
+        },
+        paging_options: %PagingOptions{page_size: 5}
+      )
 
     %__MODULE__{
       average_time: query_duration(@average_time_query),

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -154,6 +154,7 @@ defmodule Explorer.Chain.Transaction do
     field(:status, Status)
     field(:v, :integer)
     field(:value, Wei)
+    field(:created_contract_address_hash, Hash.Truncated, virtual: true)
 
     timestamps()
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -887,5 +887,11 @@ defmodule Explorer.ChainTest do
       insert(:transaction)
       assert [] == Explorer.Chain.recent_collated_transactions()
     end
+
+    test "it has contract_creation_address_hash added" do
+      %InternalTransaction{created_contract_address_hash: hash} = insert(:internal_transaction_create, index: 0)
+
+      assert [%Transaction{created_contract_address_hash: ^hash}] = Explorer.Chain.recent_collated_transactions()
+    end
   end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -330,6 +330,22 @@ defmodule Explorer.ChainTest do
                  necessity_by_association: %{block: :optional}
                )
     end
+
+    test "created_contract_address_hash populated when existing" do
+      %Transaction{hash: hash_with_block} =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      %InternalTransaction{created_contract_address_hash: contract_hash} =
+        insert(:internal_transaction_create, transaction_hash: hash_with_block, index: 0)
+
+      assert {:ok, %Transaction{hash: ^hash_with_block, created_contract_address_hash: ^contract_hash}} =
+               Chain.hash_to_transaction(
+                 hash_with_block,
+                 necessity_by_association: %{block: :required}
+               )
+    end
   end
 
   describe "list_blocks/2" do
@@ -545,7 +561,7 @@ defmodule Explorer.ChainTest do
         |> insert(to_address_hash: address.hash)
         |> with_block()
 
-      insert(:internal_transaction_call, index: 0, to_address_hash: address.hash, transaction_hash: transaction.hash)
+      insert(:internal_transaction, index: 0, to_address_hash: address.hash, transaction_hash: transaction.hash)
 
       assert Enum.empty?(Chain.address_to_internal_transactions(address))
     end
@@ -637,7 +653,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      insert(:internal_transaction_call, transaction_hash: hash, index: 0)
+      insert(:internal_transaction, transaction_hash: hash, index: 0)
 
       result = Chain.transaction_hash_to_internal_transactions(hash)
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -161,7 +161,7 @@ defmodule Explorer.Factory do
 
     transaction =
       :transaction
-      |> insert()
+      |> insert(to_address: nil, to_address_hash: nil)
       |> with_block()
 
     %InternalTransaction{

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -131,23 +131,52 @@ defmodule Explorer.Factory do
     data
   end
 
-  def internal_transaction_factory do
-    type = internal_transaction_type()
+  def internal_transaction_factory() do
+    gas = Enum.random(21_000..100_000)
+    gas_used = Enum.random(0..gas)
 
-    internal_transaction_factory(type)
+    transaction =
+      :transaction
+      |> insert()
+      |> with_block()
+
+    %InternalTransaction{
+      from_address_hash: insert(:address).hash,
+      to_address_hash: insert(:address).hash,
+      call_type: :delegatecall,
+      gas: gas,
+      gas_used: gas_used,
+      output: %Data{bytes: <<1>>},
+      # caller MUST suppy `index`
+      trace_address: [],
+      transaction_hash: transaction.hash,
+      type: :call,
+      value: sequence("internal_transaction_value", &Decimal.new(&1))
+    }
   end
 
-  def internal_transaction_create_factory do
-    internal_transaction_factory(:create)
-  end
+  def internal_transaction_create_factory() do
+    gas = Enum.random(21_000..100_000)
+    gas_used = Enum.random(0..gas)
 
-  def internal_transaction_call_factory do
-    internal_transaction_factory(:call)
-  end
+    transaction =
+      :transaction
+      |> insert()
+      |> with_block()
 
-  # TODO add reward and suicide
-  def internal_transaction_type do
-    Enum.random(~w(call create)a)
+    %InternalTransaction{
+      created_contract_code: data(:internal_transaction_created_contract_code),
+      created_contract_address_hash: insert(:address).hash,
+      from_address_hash: insert(:address).hash,
+      gas: gas,
+      gas_used: gas_used,
+      # caller MUST suppy `index`
+      init: data(:internal_transaction_init),
+      trace_address: [],
+      transaction_hash: transaction.hash,
+      type: :create,
+      value: sequence("internal_transaction_value", &Decimal.new(&1))
+    }
   end
 
   def log_factory do
@@ -250,54 +279,6 @@ defmodule Explorer.Factory do
         where: transaction.block_hash == ^block_hash
       )
     )
-  end
-
-  defp internal_transaction_factory(:call = type) do
-    gas = Enum.random(21_000..100_000)
-    gas_used = Enum.random(0..gas)
-
-    transaction =
-      :transaction
-      |> insert()
-      |> with_block()
-
-    %InternalTransaction{
-      from_address_hash: insert(:address).hash,
-      to_address_hash: insert(:address).hash,
-      call_type: :delegatecall,
-      gas: gas,
-      gas_used: gas_used,
-      output: %Data{bytes: <<1>>},
-      # caller MUST suppy `index`
-      trace_address: [],
-      transaction_hash: transaction.hash,
-      type: type,
-      value: sequence("internal_transaction_value", &Decimal.new(&1))
-    }
-  end
-
-  defp internal_transaction_factory(:create = type) do
-    gas = Enum.random(21_000..100_000)
-    gas_used = Enum.random(0..gas)
-
-    transaction =
-      :transaction
-      |> insert()
-      |> with_block()
-
-    %InternalTransaction{
-      created_contract_code: data(:internal_transaction_created_contract_code),
-      created_contract_address_hash: insert(:address).hash,
-      from_address_hash: insert(:address).hash,
-      gas: gas,
-      gas_used: gas_used,
-      # caller MUST suppy `index`
-      init: data(:internal_transaction_init),
-      trace_address: [],
-      transaction_hash: transaction.hash,
-      type: type,
-      value: sequence("internal_transaction_value", &Decimal.new(&1))
-    }
   end
 
   defp price do

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -107,7 +107,19 @@
                 </td>
                 <td class="u-text-center"><i class="fas fa-arrow-circle-right"></i></td>
                 <td>
-                  <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                  <%= cond do %>
+                    <% transaction.to_address_hash != nil -> %>
+                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                    <% transaction.created_contract_address_hash != nil -> %>
+                      <%= link(
+                        "Contract Creation",
+                        class: "transaction__link",
+                        "data-address-hash": transaction.created_contract_address_hash,
+                        to: address_path(@conn, :show, @conn.assigns.locale, transaction.created_contract_address_hash),
+                        title: transaction.created_contract_address_hash
+                      ) %>
+                    <% true -> %>
+                  <% end %>
                 </td>
                 <td><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %></td>
                 <td><%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %></td>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -111,6 +111,7 @@
                     <% transaction.to_address_hash != nil -> %>
                       <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
                     <% transaction.created_contract_address_hash != nil -> %>
+                      <i class="fas fa-plus-square"></i>
                       <%= link(
                         "Contract Creation",
                         class: "transaction__link",

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -172,6 +172,7 @@
                       <% transaction.to_address_hash != nil -> %>
                         <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
                       <% transaction.created_contract_address_hash != nil -> %>
+                        <i class="fas fa-plus-square"></i>
                         <%= link(
                           "Contract Creation",
                           class: "transaction__link",

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -168,7 +168,19 @@
                   </td>
                   <td class="u-text-center"><i class="fas fa-arrow-circle-right"></i></td>
                   <td>
-                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                    <%= cond do %>
+                      <% transaction.to_address_hash != nil -> %>
+                        <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                      <% transaction.created_contract_address_hash != nil -> %>
+                        <%= link(
+                          "Contract Creation",
+                          class: "transaction__link",
+                          "data-address-hash": transaction.created_contract_address_hash,
+                          to: address_path(@conn, :show, @conn.assigns.locale, transaction.created_contract_address_hash),
+                          title: transaction.created_contract_address_hash
+                        ) %>
+                      <% true -> %>
+                    <% end %>
                   </td>
                   <td>
                     <%= ExplorerWeb.TransactionView.value(transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -20,7 +20,19 @@
             <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
           </td>
           <td>
-            <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+            <%= cond do %>
+              <% transaction.to_address_hash != nil -> %>
+                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+              <% transaction.created_contract_address_hash != nil -> %>
+                <%= link(
+                  "Contract Creation",
+                  class: "transaction__link",
+                  "data-address-hash": transaction.created_contract_address_hash,
+                  to: address_path(@conn, :show, @conn.assigns.locale, transaction.created_contract_address_hash),
+                  title: transaction.created_contract_address_hash
+                ) %>
+              <% true -> %>
+            <% end %>
           </td>
           <td><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> </td>
           <td><%= transaction.block.timestamp |> Timex.from_now() %></td>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -24,6 +24,7 @@
               <% transaction.to_address_hash != nil -> %>
                 <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
               <% transaction.created_contract_address_hash != nil -> %>
+                <i class="fas fa-plus-square"></i>
                 <%= link(
                   "Contract Creation",
                   class: "transaction__link",

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -62,7 +62,19 @@
                 <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
               </td>
               <td>
-                <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                <%= cond do %>
+                  <% transaction.to_address_hash != nil -> %>
+                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.to_address %>
+                  <% transaction.created_contract_address_hash != nil -> %>
+                    <%= link(
+                      "Contract Creation",
+                      class: "transaction__link",
+                      "data-address-hash": transaction.created_contract_address_hash,
+                      to: address_path(@conn, :show, @conn.assigns.locale, transaction.created_contract_address_hash),
+                      title: transaction.created_contract_address_hash
+                    ) %>
+                  <% true -> %>
+                <% end %>
               </td>
               <td>
                 <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -85,19 +85,21 @@
                   <%= gettext "To" %>
                 </th>
                 <td>
-                  <%= if @transaction.to_address do %>
-                    <%= link(
-                          @transaction.to_address,
-                          class: "transaction__link",
-                          to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address)
-                        ) %>
-                  <% else %>
-                    [Contract <%= link(
-                      @transaction.created_contract_address_hash,
-                      class: "transaction__link",
-                      "data-test": "created_contract_address_hash",
-                      to: address_path(@conn, :show, @conn.assigns.locale, @transaction.created_contract_address_hash)
-                    ) %> Created]
+                  <%= cond do %>
+                    <% @transaction.to_address_hash != nil -> %>
+                      <%= link(
+                            @transaction.to_address,
+                            class: "transaction__link",
+                            to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address)
+                          ) %>
+                    <% @transaction.created_contract_address_hash != nil -> %>
+                      [Contract <%= link(
+                        @transaction.created_contract_address_hash,
+                        class: "transaction__link",
+                        "data-test": "created_contract_address_hash",
+                        to: address_path(@conn, :show, @conn.assigns.locale, @transaction.created_contract_address_hash)
+                      ) %> Created]
+                    <% true -> %>
                   <% end %>
                 </td>
               </tr>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -93,12 +93,12 @@
                             to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address)
                           ) %>
                     <% @transaction.created_contract_address_hash != nil -> %>
-                      [Contract <%= link(
+                      <i class="fas fa-plus-square"></i> Contract <%= link(
                         @transaction.created_contract_address_hash,
                         class: "transaction__link",
                         "data-test": "created_contract_address_hash",
                         to: address_path(@conn, :show, @conn.assigns.locale, @transaction.created_contract_address_hash)
-                      ) %> Created]
+                      ) %> Created
                     <% true -> %>
                   <% end %>
                 </td>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -73,15 +73,11 @@
                   <%= gettext "From" %>
                 </th>
                 <td>
-                  <%= if @transaction.from_address do %>
-                    <%= link(
-                          @transaction.from_address,
-                          class: "transaction__link",
-                          to: address_path(@conn, :show, @conn.assigns.locale, @transaction.from_address)
-                        ) %>
-                  <% else %>
-                    <%= gettext "Pending" %>
-                  <% end %>
+                  <%= link(
+                        @transaction.from_address,
+                        class: "transaction__link",
+                        to: address_path(@conn, :show, @conn.assigns.locale, @transaction.from_address)
+                      ) %>
                 </td>
               </tr>
               <tr>
@@ -96,7 +92,12 @@
                           to: address_path(@conn, :show, @conn.assigns.locale, @transaction.to_address)
                         ) %>
                   <% else %>
-                    <%= gettext "Pending" %>
+                    [Contract <%= link(
+                      @transaction.created_contract_address_hash,
+                      class: "transaction__link",
+                      "data-test": "created_contract_address_hash",
+                      to: address_path(@conn, :show, @conn.assigns.locale, @transaction.created_contract_address_hash)
+                    ) %> Created]
                   <% end %>
                 </td>
               </tr>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -29,7 +29,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction/overview.html.eex:170
+#: lib/explorer_web/templates/transaction/overview.html.eex:173
 msgid "Gas Used"
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:137
+#: lib/explorer_web/templates/transaction/overview.html.eex:140
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Limit"
 msgstr ""
@@ -93,7 +93,7 @@ msgid "Miner"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:105
+#: lib/explorer_web/templates/transaction/overview.html.eex:108
 msgid "Nonce"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgid "Gas"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:145
+#: lib/explorer_web/templates/transaction/overview.html.eex:148
 msgid "Gas Price"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:178
+#: lib/explorer_web/templates/transaction/overview.html.eex:181
 msgid "Input"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
-#: lib/explorer_web/templates/transaction/overview.html.eex:89
+#: lib/explorer_web/templates/transaction/overview.html.eex:85
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
 #: lib/explorer_web/views/address_transaction_view.ex:10
@@ -238,8 +238,6 @@ msgstr ""
 #: lib/explorer_web/templates/layout/_topnav.html.eex:31
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:21
 #: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:83
-#: lib/explorer_web/templates/transaction/overview.html.eex:99
 #: lib/explorer_web/views/transaction_view.ex:18
 #: lib/explorer_web/views/transaction_view.ex:72
 #: lib/explorer_web/views/transaction_view.ex:79
@@ -247,12 +245,12 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:119
+#: lib/explorer_web/templates/transaction/overview.html.eex:122
 msgid "First Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/transaction/overview.html.eex:128
+#: lib/explorer_web/templates/transaction/overview.html.eex:131
 msgid "Last Seen"
 msgstr ""
 
@@ -335,7 +333,7 @@ msgstr ""
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:154
+#: lib/explorer_web/templates/transaction/overview.html.eex:157
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
@@ -431,7 +429,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:32
 #: lib/explorer_web/templates/transaction/overview.html.eex:65
-#: lib/explorer_web/templates/transaction/overview.html.eex:162
+#: lib/explorer_web/templates/transaction/overview.html.eex:165
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
@@ -485,8 +483,8 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:154
-#: lib/explorer_web/templates/transaction/overview.html.eex:162
+#: lib/explorer_web/templates/transaction/overview.html.eex:157
+#: lib/explorer_web/templates/transaction/overview.html.eex:165
 msgid "TX Fee"
 msgstr ""
 
@@ -504,10 +502,10 @@ msgstr ""
 msgid "Contract bytecode"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:181
+#: lib/explorer_web/templates/block_transaction/index.html.eex:194
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:78
+#: lib/explorer_web/templates/transaction/index.html.eex:90
 msgid "Older"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -41,7 +41,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction/overview.html.eex:170
+#: lib/explorer_web/templates/transaction/overview.html.eex:173
 msgid "Gas Used"
 msgstr "Gas Used"
 
@@ -95,7 +95,7 @@ msgstr "Difficulty"
 
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:137
+#: lib/explorer_web/templates/transaction/overview.html.eex:140
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Limit"
 msgstr "Gas Limit"
@@ -105,7 +105,7 @@ msgid "Miner"
 msgstr "Validator"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:105
+#: lib/explorer_web/templates/transaction/overview.html.eex:108
 msgid "Nonce"
 msgstr "Nonce"
 
@@ -149,11 +149,11 @@ msgid "Gas"
 msgstr "Gas"
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:145
+#: lib/explorer_web/templates/transaction/overview.html.eex:148
 msgid "Gas Price"
 msgstr "Gas Price"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:178
+#: lib/explorer_web/templates/transaction/overview.html.eex:181
 msgid "Input"
 msgstr "Input"
 
@@ -203,7 +203,7 @@ msgstr "Success"
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
-#: lib/explorer_web/templates/transaction/overview.html.eex:89
+#: lib/explorer_web/templates/transaction/overview.html.eex:85
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
 #: lib/explorer_web/views/address_transaction_view.ex:10
@@ -250,8 +250,6 @@ msgstr "Showing %{count} Transactions"
 #: lib/explorer_web/templates/layout/_topnav.html.eex:31
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:21
 #: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:83
-#: lib/explorer_web/templates/transaction/overview.html.eex:99
 #: lib/explorer_web/views/transaction_view.ex:18
 #: lib/explorer_web/views/transaction_view.ex:72
 #: lib/explorer_web/views/transaction_view.ex:79
@@ -259,12 +257,12 @@ msgstr "Showing %{count} Transactions"
 msgid "Pending"
 msgstr "Pending"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:119
+#: lib/explorer_web/templates/transaction/overview.html.eex:122
 msgid "First Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/transaction/overview.html.eex:128
+#: lib/explorer_web/templates/transaction/overview.html.eex:131
 msgid "Last Seen"
 msgstr ""
 
@@ -347,7 +345,7 @@ msgstr ""
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:154
+#: lib/explorer_web/templates/transaction/overview.html.eex:157
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
@@ -443,7 +441,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:32
 #: lib/explorer_web/templates/transaction/overview.html.eex:65
-#: lib/explorer_web/templates/transaction/overview.html.eex:162
+#: lib/explorer_web/templates/transaction/overview.html.eex:165
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
@@ -497,8 +495,8 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:154
-#: lib/explorer_web/templates/transaction/overview.html.eex:162
+#: lib/explorer_web/templates/transaction/overview.html.eex:157
+#: lib/explorer_web/templates/transaction/overview.html.eex:165
 msgid "TX Fee"
 msgstr ""
 
@@ -516,10 +514,10 @@ msgstr ""
 msgid "Contract bytecode"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:181
+#: lib/explorer_web/templates/block_transaction/index.html.eex:194
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:78
+#: lib/explorer_web/templates/transaction/index.html.eex:90
 msgid "Older"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -60,10 +60,18 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
     end
 
     test "with no to_address_hash overview contains contract create address", %{conn: conn} do
-      transaction = insert(:transaction, to_address_hash: nil)
-      insert(:internal_transaction_create, transaction_hash: transaction.hash, index: 0)
+      internal_transaction = insert(:internal_transaction_create, index: 0)
 
-      conn = get(conn, transaction_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, transaction.hash))
+      conn =
+        get(
+          conn,
+          transaction_internal_transaction_path(
+            ExplorerWeb.Endpoint,
+            :index,
+            :en,
+            internal_transaction.transaction_hash
+          )
+        )
 
       refute is_nil(conn.assigns.transaction.created_contract_address_hash)
     end

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -58,5 +58,14 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
 
       assert %Token{} = conn.assigns.exchange_rate
     end
+
+    test "with no to_address_hash overview contains contract create address", %{conn: conn} do
+      transaction = insert(:transaction, to_address_hash: nil)
+      insert(:internal_transaction_create, transaction_hash: transaction.hash, index: 0)
+
+      conn = get(conn, transaction_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, transaction.hash))
+
+      refute is_nil(conn.assigns.transaction.created_contract_address_hash)
+    end
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -3,7 +3,7 @@ defmodule ExplorerWeb.AddressPage do
 
   use Wallaby.DSL
   import Wallaby.Query, only: [css: 1, css: 2]
-  alias Explorer.Chain.{Address, Hash, Transaction}
+  alias Explorer.Chain.{Address, InternalTransaction, Hash, Transaction}
 
   def apply_filter(session, direction) do
     session
@@ -17,6 +17,10 @@ defmodule ExplorerWeb.AddressPage do
 
   def click_internal_transactions(session) do
     click(session, css("[data-test='internal_transactions_tab_link']"))
+  end
+
+  def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
+    css("[data-address-hash='#{hash}']", text: "Contract Creation")
   end
 
   def detail_hash(%Address{hash: address_hash}) do

--- a/apps/explorer_web/test/explorer_web/features/pages/block_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/block_page.ex
@@ -5,9 +5,17 @@ defmodule ExplorerWeb.BlockPage do
 
   import Wallaby.Query, only: [css: 2]
 
-  alias Explorer.Chain.Block
+  alias Explorer.Chain.{Block, InternalTransaction}
+
+  def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
+    css("[data-address-hash='#{hash}']", text: "Contract Creation")
+  end
 
   def detail_number(%Block{number: block_number}) do
     css("[data-test='block_detail_number']", text: to_string(block_number))
+  end
+
+  def visit_page(session, %Block{number: block_number}) do
+    visit(session, "/en/blocks/#{block_number}/transactions")
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/home_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/home_page.ex
@@ -5,8 +5,14 @@ defmodule ExplorerWeb.HomePage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
+  alias Explorer.Chain.InternalTransaction
+
   def blocks(count: count) do
     css("[data-test='chain_block']", count: count)
+  end
+
+  def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
+    css("[data-address-hash='#{hash}']", text: "Contract Creation")
   end
 
   def search(session, text) do
@@ -15,11 +21,11 @@ defmodule ExplorerWeb.HomePage do
     |> send_keys([:enter])
   end
 
-  def visit_page(session) do
-    visit(session, "/")
-  end
-
   def transactions(count: count) do
     css("[data-test='chain_transaction']", count: count)
+  end
+
+  def visit_page(session) do
+    visit(session, "/")
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
@@ -16,7 +16,7 @@ defmodule ExplorerWeb.TransactionListPage do
   end
 
   def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
-    css("[data-address-hash='#{hash}']", text: "Contract Created")
+    css("[data-address-hash='#{hash}']", text: "Contract Creation")
   end
 
   def transaction(%Transaction{hash: transaction_hash}) do

--- a/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
@@ -3,23 +3,27 @@ defmodule ExplorerWeb.TransactionListPage do
 
   use Wallaby.DSL
 
-  import Wallaby.Query, only: [css: 1]
+  import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.Transaction
+  alias Explorer.Chain.{InternalTransaction, Transaction}
 
   def click_transaction(session, %Transaction{hash: transaction_hash}) do
     click(session, css("[data-test='transaction_hash'][data-transaction-hash='#{transaction_hash}']"))
-  end
-
-  def visit_page(session) do
-    visit(session, "/en/transactions")
   end
 
   def click_pending(session) do
     click(session, css("[data-test='pending_transactions_link']"))
   end
 
+  def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
+    css("[data-address-hash='#{hash}']", text: "Contract Created")
+  end
+
   def transaction(%Transaction{hash: transaction_hash}) do
     css("[data-test='transaction_hash'][data-transaction-hash='#{transaction_hash}']")
+  end
+
+  def visit_page(session) do
+    visit(session, "/en/transactions")
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/pages/transaction_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/transaction_page.ex
@@ -5,7 +5,7 @@ defmodule ExplorerWeb.TransactionPage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.{Transaction, Hash}
+  alias Explorer.Chain.{InternalTransaction, Transaction, Hash}
 
   def click_logs(session) do
     click(session, css("[data-test='transaction_logs_link']"))
@@ -13,6 +13,10 @@ defmodule ExplorerWeb.TransactionPage do
 
   def detail_hash(%Transaction{hash: transaction_hash}) do
     css("[data-test='transaction_detail_hash']", text: Hash.to_string(transaction_hash))
+  end
+
+  def contract_creation_address_hash(%InternalTransaction{created_contract_address_hash: hash}) do
+    css("[data-test='created_contract_address_hash']", text: Hash.to_string(hash))
   end
 
   def visit_page(session, %Transaction{hash: transaction_hash}) do

--- a/apps/explorer_web/test/explorer_web/features/pages/transaction_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/transaction_page.ex
@@ -11,15 +11,19 @@ defmodule ExplorerWeb.TransactionPage do
     click(session, css("[data-test='transaction_logs_link']"))
   end
 
-  def detail_hash(%Transaction{hash: transaction_hash}) do
-    css("[data-test='transaction_detail_hash']", text: Hash.to_string(transaction_hash))
-  end
-
   def contract_creation_address_hash(%InternalTransaction{created_contract_address_hash: hash}) do
     css("[data-test='created_contract_address_hash']", text: Hash.to_string(hash))
   end
 
+  def detail_hash(%Transaction{hash: transaction_hash}) do
+    css("[data-test='transaction_detail_hash']", text: Hash.to_string(transaction_hash))
+  end
+
   def visit_page(session, %Transaction{hash: transaction_hash}) do
+    visit(session, "/en/transactions/#{transaction_hash}")
+  end
+
+  def visit_page(session, transaction_hash = %Hash{}) do
     visit(session, "/en/transactions/#{transaction_hash}")
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -21,8 +21,9 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     {:ok,
      %{
-       transactions: %{from_lincoln: from_lincoln, from_taft: from_taft},
-       addresses: %{lincoln: lincoln, taft: taft}
+       addresses: %{lincoln: lincoln, taft: taft},
+       block: block,
+       transactions: %{from_lincoln: from_lincoln, from_taft: from_taft}
      }}
   end
 
@@ -77,6 +78,31 @@ defmodule ExplorerWeb.ViewingAddressesTest do
       |> AddressPage.apply_filter("To")
       |> refute_has(AddressPage.transaction(transactions.from_lincoln))
       |> assert_has(AddressPage.transaction(transactions.from_taft))
+    end
+
+    test "contract creation is shown for to_address on list page", %{
+      addresses: addresses,
+      block: block,
+      session: session
+    } do
+      lincoln_hash = addresses.lincoln.hash
+
+      from_lincoln =
+        :transaction
+        |> insert(from_address_hash: lincoln_hash, to_address_hash: nil)
+        |> with_block(block)
+
+      internal_transaction =
+        insert(
+          :internal_transaction_create,
+          transaction_hash: from_lincoln.hash,
+          from_address_hash: lincoln_hash,
+          index: 0
+        )
+
+      session
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> assert_has(AddressPage.contract_creation(internal_transaction))
     end
   end
 

--- a/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
@@ -20,12 +20,26 @@ defmodule ExplorerWeb.ViewingBlocksTest do
     {:ok, block: block}
   end
 
-  test "search for blocks", %{session: session} do
+  test "viewing blocks on the home page", %{session: session} do
+    session
+    |> HomePage.visit_page()
+    |> assert_has(HomePage.blocks(count: 5))
+  end
+
+  test "search for blocks from home page", %{session: session} do
     block = insert(:block, number: 42)
 
     session
     |> HomePage.visit_page()
     |> HomePage.search(to_string(block.number))
+    |> assert_has(BlockPage.detail_number(block))
+  end
+
+  test "show block detail page", %{session: session} do
+    block = insert(:block, number: 42)
+
+    session
+    |> BlockPage.visit_page(block)
     |> assert_has(BlockPage.detail_number(block))
   end
 
@@ -42,12 +56,6 @@ defmodule ExplorerWeb.ViewingBlocksTest do
     session
     |> BlockPage.visit_page(block)
     |> assert_has(BlockPage.contract_creation(internal_transaction))
-  end
-
-  test "viewing blocks on the home page", %{session: session} do
-    session
-    |> HomePage.visit_page()
-    |> assert_has(HomePage.blocks(count: 5))
   end
 
   test "viewing the blocks index page", %{block: block, session: session} do

--- a/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
@@ -29,6 +29,21 @@ defmodule ExplorerWeb.ViewingBlocksTest do
     |> assert_has(BlockPage.detail_number(block))
   end
 
+  test "contract creation is shown for to_address in transaction list", %{session: session} do
+    block = insert(:block, number: 42)
+
+    transaction =
+      :transaction
+      |> insert(to_address: nil, to_address_hash: nil)
+      |> with_block(block)
+
+    internal_transaction = insert(:internal_transaction_create, transaction_hash: transaction.hash, index: 0)
+
+    session
+    |> BlockPage.visit_page(block)
+    |> assert_has(BlockPage.contract_creation(internal_transaction))
+  end
+
   test "viewing blocks on the home page", %{session: session} do
     session
     |> HomePage.visit_page()

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -106,6 +106,15 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       |> assert_has(TransactionPage.detail_hash(transaction))
     end
 
+    test "can see a contract creation address in to_address", %{session: session} do
+      transaction = insert(:transaction, to_address_hash: nil)
+      internal_transaction = insert(:internal_transaction_create, transaction_hash: transaction.hash, index: 0)
+
+      session
+      |> TransactionPage.visit_page(transaction)
+      |> assert_has(TransactionPage.contract_creation_address_hash(internal_transaction))
+    end
+
     test "can view a transaction's logs", %{session: session, transaction: transaction} do
       session
       |> TransactionPage.visit_page(transaction)

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -87,8 +87,14 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       |> TransactionListPage.visit_page()
       |> TransactionListPage.click_pending()
       |> assert_has(TransactionListPage.transaction(pending))
+    end
 
-      # |> click(css(".transactions__link", text: to_string(pending.hash)))
+    test "contract creation is shown for to_address", %{session: session} do
+      internal_transaction = insert(:internal_transaction_create, index: 0)
+
+      session
+      |> TransactionListPage.visit_page()
+      |> assert_has(TransactionListPage.contract_creation(internal_transaction))
     end
   end
 
@@ -107,11 +113,10 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     end
 
     test "can see a contract creation address in to_address", %{session: session} do
-      transaction = insert(:transaction, to_address_hash: nil)
-      internal_transaction = insert(:internal_transaction_create, transaction_hash: transaction.hash, index: 0)
+      internal_transaction = insert(:internal_transaction_create, index: 0)
 
       session
-      |> TransactionPage.visit_page(transaction)
+      |> TransactionPage.visit_page(internal_transaction.transaction_hash)
       |> assert_has(TransactionPage.contract_creation_address_hash(internal_transaction))
     end
 

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -75,6 +75,14 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       |> assert_has(HomePage.transactions(count: 5))
     end
 
+    test "contract creation is shown for to_address on home page", %{session: session} do
+      internal_transaction = insert(:internal_transaction_create, index: 0)
+
+      session
+      |> HomePage.visit_page()
+      |> assert_has(HomePage.contract_creation(internal_transaction))
+    end
+
     test "viewing the default transactions tab", %{session: session, transaction: transaction, pending: pending} do
       session
       |> TransactionListPage.visit_page()
@@ -89,7 +97,7 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       |> assert_has(TransactionListPage.transaction(pending))
     end
 
-    test "contract creation is shown for to_address", %{session: session} do
+    test "contract creation is shown for to_address on list page", %{session: session} do
       internal_transaction = insert(:internal_transaction_create, index: 0)
 
       session


### PR DESCRIPTION
Resolves #241 

## Changelog
### Enhancements
* When transaction contains a contract creation, the to field contains the contract address

### Screenshots
![screen shot 2018-06-11 at 4 19 39 pm](https://user-images.githubusercontent.com/20226535/41255111-79acc646-6d93-11e8-8e5e-707d4e0fa060.png)
![screen shot 2018-06-11 at 4 19 50 pm](https://user-images.githubusercontent.com/20226535/41255113-79bfc890-6d93-11e8-9d77-e1815a84ed10.png)
