### PR TITLE
Fix Contract address not showing code tab

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1756,7 +1756,16 @@ defmodule Explorer.Chain do
     insert_changes_list(
       ordered_changes_list,
       conflict_target: :hash,
-      on_conflict: [set: [balance_fetched_at: nil]],
+      on_conflict:
+        from(
+          address in Address,
+          update: [
+            set: [
+              balance_fetched_at: nil,
+              contract_code: fragment("COALESCE(?, EXCLUDED.contract_code)", address.contract_code)
+            ]
+          ]
+        ),
       for: Address,
       timeout: timeout,
       timestamps: timestamps

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -948,4 +948,58 @@ defmodule Explorer.ChainTest do
       assert smart_contract.abi != ""
     end
   end
+
+  describe "import_internal_transactions/1" do
+    test "updates address with contract code" do
+      smart_contract_bytecode =
+        "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582040d82a7379b1ee1632ad4d8a239954fd940277b25628ead95259a85c5eddb2120029"
+
+      address_hash = "0x1c494fa496f1cfd918b5ff190835af3aaf60987e"
+      insert(:address, hash: address_hash)
+
+      from_address_hash = "0x8cc2e4b51b4340cb3727cffe3f1878756e732cee"
+      insert(:address, hash: from_address_hash)
+
+      transaction_string_hash = "0x0705ea0a5b997d9aafd5c531e016d9aabe3297a28c0bd4ef005fe6ea329d301b"
+      insert(:transaction, from_address_hash: from_address_hash, hash: transaction_string_hash)
+
+      options = [
+        addresses: [
+          params: [
+            %{
+              contract_code: smart_contract_bytecode,
+              hash: address_hash
+            }
+          ]
+        ],
+        internal_transactions: [
+          params: [
+            %{
+              created_contract_address_hash: address_hash,
+              created_contract_code: smart_contract_bytecode,
+              from_address_hash: from_address_hash,
+              gas: 184_531,
+              gas_used: 84531,
+              index: 0,
+              init:
+                "0x6060604052341561000c57fe5b5b6101a68061001c6000396000f300606060405263ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416631d3b9edf811461005b57806366098d4f1461007b578063a12f69e01461009b578063f4f3bdc1146100bb575bfe5b6100696004356024356100db565b60408051918252519081900360200190f35b61006960043560243561010a565b60408051918252519081900360200190f35b610069600435602435610124565b60408051918252519081900360200190f35b610069600435602435610163565b60408051918252519081900360200190f35b60008282028315806100f757508284828115156100f457fe5b04145b15156100ff57fe5b8091505b5092915050565b6000828201838110156100ff57fe5b8091505b5092915050565b60008080831161013057fe5b828481151561013b57fe5b049050828481151561014957fe5b0681840201841415156100ff57fe5b8091505b5092915050565b60008282111561016f57fe5b508082035b929150505600a165627a7a7230582020c944d8375ca14e2c92b14df53c2d044cb99dc30c3ba9f55e2bcde87bd4709b0029",
+              trace_address: [],
+              transaction_hash: transaction_string_hash,
+              type: "create",
+              value: 0
+            }
+          ]
+        ],
+        transactions: [
+          hashes: [transaction_string_hash]
+        ]
+      ]
+
+      assert {:ok, _} = Chain.import_internal_transactions(options)
+
+      address = Explorer.Repo.one(from(address in Explorer.Chain.Address, where: address.hash == ^address_hash))
+
+      assert address.contract_code != nil
+    end
+  end
 end


### PR DESCRIPTION
Solves https://github.com/poanetwork/poa-explorer/issues/263

There is a bug when an Address is a Contract one, it is not showing the Code tab.

This happened because we separated the `InternalTransaction` creation in an asynchronous operation, so when we create an `Address` we are no longer creating an `InternalTransaction` and we no longer have the `contract_code`at this moment.

In the `InternalTransactionFetcher` we use a function called `ecto_schema_module_to_changes_list_to_multi` that runs multiples inserts operations inside a `Ecto.Multi` but since our address is already created the `contract_code` wasn't being saved at the database.

This PRs adds alters the `on_conflict` in the `insert_addresses` so we make sure to update all `Addresses` with its `contract_code`