### PR TITLE
fetched_balance_block_number instead of fetched_balance_at

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -39,6 +39,7 @@ defmodule EthereumJSONRPC.Log do
       ...> )
       %{
         address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+        block_number: 37,
         data: "0x000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
         first_topic: "0x600bcf04a13e752d1e3670a5a9f1c21177ca2a93c6f5391d4f1298d098097c22",
         fourth_topic: nil,
@@ -52,6 +53,7 @@ defmodule EthereumJSONRPC.Log do
   """
   def elixir_to_params(%{
         "address" => address_hash,
+        "blockNumber" => block_number,
         "data" => data,
         "logIndex" => index,
         "topics" => topics,
@@ -60,6 +62,7 @@ defmodule EthereumJSONRPC.Log do
       }) do
     %{
       address_hash: address_hash,
+      block_number: block_number,
       data: data,
       index: index,
       transaction_hash: transaction_hash,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
@@ -3,7 +3,7 @@ defmodule EthereumJSONRPC.Parity do
   Ethereum JSONRPC methods that are only supported by [Parity](https://wiki.parity.io/).
   """
 
-  import EthereumJSONRPC, only: [config: 1, json_rpc: 2, request: 1]
+  import EthereumJSONRPC, only: [config: 1, id_to_params: 1, json_rpc: 2, request: 1]
 
   alias EthereumJSONRPC.Parity.Traces
   alias EthereumJSONRPC.{Transaction, Transactions}
@@ -12,11 +12,15 @@ defmodule EthereumJSONRPC.Parity do
   Fetches the `t:Explorer.Chain.InternalTransaction.changeset/2` params from the Parity trace URL.
 
       iex> EthereumJSONRPC.Parity.fetch_internal_transactions([
-      ...>   "0x0fa6f723216dba694337f9bb37d8870725655bdf2573526a39454685659e39b1"
+      ...>   %{
+      ...>     block_number: 1,
+      ...>     hash_data: "0x0fa6f723216dba694337f9bb37d8870725655bdf2573526a39454685659e39b1"
+      ...>   }
       ...> ])
       {:ok,
        [
          %{
+           block_number: 1,
            created_contract_address_hash: "0x1e0eaa06d02f965be2dfe0bc9ff52b2d82133461",
            created_contract_code: "0x60606040526004361061008e576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063247b3210146100935780632ffdfc8a146100bc57806374294144146100f6578063ae4b1b5b14610125578063bf7370d11461017a578063d1104cb2146101a3578063eecd1079146101f8578063fcff021c14610221575b600080fd5b341561009e57600080fd5b6100a661024a565b6040518082815260200191505060405180910390f35b34156100c757600080fd5b6100e0600480803560ff16906020019091905050610253565b6040518082815260200191505060405180910390f35b341561010157600080fd5b610123600480803590602001909190803560ff16906020019091905050610276565b005b341561013057600080fd5b61013861037a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561018557600080fd5b61018d61039f565b6040518082815260200191505060405180910390f35b34156101ae57600080fd5b6101b66104d9565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561020357600080fd5b61020b610588565b6040518082815260200191505060405180910390f35b341561022c57600080fd5b6102346105bd565b6040518082815260200191505060405180910390f35b600060c8905090565b6000600160008360ff1660ff168152602001908152602001600020549050919050565b61027e6104d9565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415156102b757600080fd5b60008160ff161115156102c957600080fd5b6002808111156102d557fe5b60ff168160ff16111515156102e957600080fd5b6000821180156103125750600160008260ff1660ff168152602001908152602001600020548214155b151561031d57600080fd5b81600160008360ff1660ff168152602001908152602001600020819055508060ff167fe868bbbdd6cd2efcd9ba6e0129d43c349b0645524aba13f8a43bfc7c5ffb0889836040518082815260200191505060405180910390a25050565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000806000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16638b8414c46000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b151561042f57600080fd5b6102c65a03f1151561044057600080fd5b5050506040518051905090508073ffffffffffffffffffffffffffffffffffffffff16630eaba26a6000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b15156104b857600080fd5b6102c65a03f115156104c957600080fd5b5050506040518051905091505090565b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a3b3fff16000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b151561056857600080fd5b6102c65a03f1151561057957600080fd5b50505060405180519050905090565b60006105b860016105aa600261059c61039f565b6105e590919063ffffffff16565b61060090919063ffffffff16565b905090565b60006105e06105ca61039f565b6105d261024a565b6105e590919063ffffffff16565b905090565b60008082848115156105f357fe5b0490508091505092915050565b600080828401905083811015151561061457fe5b80915050929150505600a165627a7a723058206b7eef2a57eb659d5e77e45ab5bc074e99c6a841921038cdb931e119c6aac46c0029",
            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
@@ -32,16 +36,15 @@ defmodule EthereumJSONRPC.Parity do
        ]}
 
   """
-  def fetch_internal_transactions(transaction_hashes) when is_list(transaction_hashes) do
+  def fetch_internal_transactions(transactions_params) when is_list(transactions_params) do
+    id_to_params = id_to_params(transactions_params)
+
     with {:ok, responses} <-
-           transaction_hashes
-           |> Enum.map(&transaction_hash_to_internal_transaction_request/1)
+           id_to_params
+           |> trace_replay_transaction_requests()
            |> json_rpc(config(:trace_url)) do
       internal_transactions_params =
-        responses
-        |> responses_to_traces()
-        |> Traces.to_elixir()
-        |> Traces.elixir_to_params()
+        trace_replay_transaction_responses_to_internal_transactions_params(responses, id_to_params)
 
       {:ok, internal_transactions_params}
     end
@@ -68,19 +71,37 @@ defmodule EthereumJSONRPC.Parity do
     end
   end
 
-  defp response_to_trace(%{"id" => transaction_hash, "result" => %{"trace" => traces}}) when is_list(traces) do
+  defp trace_replay_transaction_responses_to_internal_transactions_params(responses, id_to_params)
+       when is_list(responses) and is_map(id_to_params) do
+    responses
+    |> trace_replay_transaction_responses_to_traces(id_to_params)
+    |> Traces.to_elixir()
+    |> Traces.elixir_to_params()
+  end
+
+  defp trace_replay_transaction_responses_to_traces(responses, id_to_params)
+       when is_list(responses) and is_map(id_to_params) do
+    Enum.flat_map(responses, &trace_replay_transaction_response_to_traces(&1, id_to_params))
+  end
+
+  defp trace_replay_transaction_response_to_traces(%{"id" => id, "result" => %{"trace" => traces}}, id_to_params)
+       when is_list(traces) and is_map(id_to_params) do
+    %{block_number: block_number, hash_data: transaction_hash} = Map.fetch!(id_to_params, id)
+
     traces
     |> Stream.with_index()
     |> Enum.map(fn {trace, index} ->
-      Map.merge(trace, %{"index" => index, "transactionHash" => transaction_hash})
+      Map.merge(trace, %{"blockNumber" => block_number, "index" => index, "transactionHash" => transaction_hash})
     end)
   end
 
-  defp responses_to_traces(responses) when is_list(responses) do
-    Enum.flat_map(responses, &response_to_trace/1)
+  defp trace_replay_transaction_requests(id_to_params) when is_map(id_to_params) do
+    Enum.map(id_to_params, fn {id, %{hash_data: hash_data}} ->
+      trace_replay_transaction_request(%{id: id, hash_data: hash_data})
+    end)
   end
 
-  defp transaction_hash_to_internal_transaction_request(transaction_hash) do
-    request(%{id: transaction_hash, method: "trace_replayTransaction", params: [transaction_hash, ["trace"]]})
+  defp trace_replay_transaction_request(%{id: id, hash_data: hash_data}) do
+    request(%{id: id, method: "trace_replayTransaction", params: [hash_data, ["trace"]]})
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
@@ -18,6 +18,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "init" => "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b0029",
       ...>       "value" => 0
       ...>     },
+      ...>     "blockNumber" => 34,
       ...>     "index" => 0,
       ...>     "result" => %{
       ...>       "address" => "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
@@ -31,6 +32,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>   }
       ...> )
       %{
+        block_number: 34,
         created_contract_address_hash: "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
         created_contract_code: "0x606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b0029",
         from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
@@ -54,6 +56,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "init" => "0x4bb278f3",
       ...>       "value" => 0
       ...>     },
+      ...>     "blockNumber" => 35,
       ...>     "error" => "Bad instruction",
       ...>     "index" => 0,
       ...>     "subtraces" => 0,
@@ -63,6 +66,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>   }
       ...> )
       %{
+        block_number: 35,
         error: "Bad instruction",
         from_address_hash: "0x78a42d3705fb3c26a4b54737a784bf064f0815fb",
         gas: 3946728,
@@ -86,6 +90,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "to" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
       ...>       "value" => 0
       ...>     },
+      ...>     "blockNumber" => 35,
       ...>     "index" => 0,
       ...>     "result" => %{
       ...>       "gasUsed" => 27770,
@@ -98,6 +103,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>   }
       ...> )
       %{
+        block_number: 35,
         call_type: "call",
         from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
         gas: 4677320,
@@ -123,6 +129,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
      ...>       "to" => "0xfdca0da4158740a93693441b35809b5bb463e527",
      ...>       "value" => 10000000000000000
      ...>     },
+     ...>     "blockNumber" => 35,
      ...>     "error" => "Reverted",
      ...>     "index" => 0,
      ...>     "subtraces" => 7,
@@ -132,6 +139,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
      ...>   }
      ...> )
      %{
+       block_number: 35,
        call_type: "call",
        error: "Reverted",
        from_address_hash: "0xc9266e6fdf5182dc47d27e0dc32bdff9e4cd2e32",
@@ -160,6 +168,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "balance" => 0,
       ...>       "refundAddress" => "0x59e2e9ecf133649b1a7efc731162ff09d29ca5a5"
       ...>     },
+      ...>     "blockNumber" => 35,
       ...>     "index" => 1,
       ...>     "result" => nil,
       ...>     "subtraces" => 0,
@@ -169,6 +178,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>   }
       ...> )
       %{
+        block_number: 35,
         from_address_hash: "0xa7542d78b9a0be6147536887e0065f16182d294b",
         index: 1,
         to_address_hash: "0x59e2e9ecf133649b1a7efc731162ff09d29ca5a5",
@@ -189,12 +199,14 @@ defmodule EthereumJSONRPC.Parity.Trace do
         "to" => to_address_hash,
         "value" => value
       },
+      "blockNumber" => block_number,
       "index" => index,
       "traceAddress" => trace_address,
       "transactionHash" => transaction_hash
     } = elixir
 
     %{
+      block_number: block_number,
       call_type: call_type,
       from_address_hash: from_address_hash,
       gas: gas,
@@ -211,12 +223,14 @@ defmodule EthereumJSONRPC.Parity.Trace do
   def elixir_to_params(%{"type" => "create" = type} = elixir) do
     %{
       "action" => %{"from" => from_address_hash, "gas" => gas, "init" => init, "value" => value},
+      "blockNumber" => block_number,
       "index" => index,
       "traceAddress" => trace_address,
       "transactionHash" => transaction_hash
     } = elixir
 
     %{
+      block_number: block_number,
       from_address_hash: from_address_hash,
       gas: gas,
       index: index,
@@ -232,12 +246,14 @@ defmodule EthereumJSONRPC.Parity.Trace do
   def elixir_to_params(%{"type" => "suicide" = type} = elixir) do
     %{
       "action" => %{"address" => from_address_hash, "balance" => value, "refundAddress" => to_address_hash},
+      "blockNumber" => block_number,
       "index" => index,
       "traceAddress" => trace_address,
       "transactionHash" => transaction_hash
     } = elixir
 
     %{
+      block_number: block_number,
       from_address_hash: from_address_hash,
       index: index,
       to_address_hash: to_address_hash,
@@ -259,6 +275,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "init" => "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b0029",
       ...>       "value" => "0x0"
       ...>     },
+      ...>     "blockNumber" => 1,
       ...>     "index" => 0,
       ...>     "result" => %{
       ...>       "address" => "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
@@ -278,6 +295,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
           "init" => "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b0029",
           "value" => 0
         },
+        "blockNumber" => 1,
         "index" => 0,
         "result" => %{
           "address" => "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
@@ -290,8 +308,8 @@ defmodule EthereumJSONRPC.Parity.Trace do
         "type" => "create"
       }
 
-  The caller must put `"index"` and `"transactionHash"` into the incoming map, as Parity itself does not include that
-  information, but it is needed to locate the trace in history fully.
+  The caller must put `"blockNumber"`, `"index"`, and `"transactionHash"` into the incoming map, as Parity itself does
+  not include that information, but it is needed to locate the trace in history and update addresses fully.
 
       iex> EthereumJSONRPC.Parity.Trace.to_elixir(
       ...>   %{
@@ -311,7 +329,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>     "type" => "create"
       ...>   }
       ...> )
-      ** (ArgumentError) Caller must `Map.put/2` `"index"` and `"transactionHash"` in trace
+      ** (ArgumentError) Caller must `Map.put/2` `"blockNumber"`, `"index"`, and `"transactionHash"` in trace
 
   `"suicide"` `"type"` traces are different in that they have a `nil` `"result"`.  This is because the `"result"` key
   is used to indicate success from Parity.
@@ -323,6 +341,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "balance" => "0x0",
       ...>       "refundAddress" => "0x59e2e9ecf133649b1a7efc731162ff09d29ca5a5"
       ...>     },
+      ...>     "blockNumber" => 1,
       ...>     "index" => 1,
       ...>     "result" => nil,
       ...>     "subtraces" => 0,
@@ -337,6 +356,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
           "balance" => 0,
           "refundAddress" => "0x59e2e9ecf133649b1a7efc731162ff09d29ca5a5"
         },
+        "blockNumber" => 1,
         "index" => 1,
         "result" => nil,
         "subtraces" => 0,
@@ -357,6 +377,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
       ...>       "to" => "0xfdca0da4158740a93693441b35809b5bb463e527",
       ...>       "value" => "0x2386f26fc10000"
       ...>     },
+      ...>     "blockNumber" => 1,
       ...>     "error" => "Reverted",
       ...>     "index" => 0,
       ...>     "subtraces" => 7,
@@ -374,6 +395,7 @@ defmodule EthereumJSONRPC.Parity.Trace do
           "to" => "0xfdca0da4158740a93693441b35809b5bb463e527",
           "value" => 10000000000000000
         },
+        "blockNumber" => 1,
         "error" => "Reverted",
         "index" => 0,
         "subtraces" => 7,
@@ -384,12 +406,12 @@ defmodule EthereumJSONRPC.Parity.Trace do
 
   """
 
-  def to_elixir(%{"index" => _, "transactionHash" => _} = trace) when is_map(trace) do
+  def to_elixir(%{"blockNumber" => _, "index" => _, "transactionHash" => _} = trace) when is_map(trace) do
     Enum.into(trace, %{}, &entry_to_elixir/1)
   end
 
   def to_elixir(_) do
-    raise ArgumentError, ~S|Caller must `Map.put/2` `"index"` and `"transactionHash"` in trace|
+    raise ArgumentError, ~S|Caller must `Map.put/2` `"blockNumber"`, `"index"`, and `"transactionHash"` in trace|
   end
 
   # subtraces is an actual integer in JSON and not hex-encoded
@@ -399,6 +421,8 @@ defmodule EthereumJSONRPC.Parity.Trace do
   defp entry_to_elixir({"action" = key, action}) do
     {key, Action.to_elixir(action)}
   end
+
+  defp entry_to_elixir({"blockNumber", block_number} = entry) when is_integer(block_number), do: entry
 
   defp entry_to_elixir({"error", reason} = entry) when is_binary(reason), do: entry
 

--- a/apps/explorer/lib/explorer/indexer/internal_transaction_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/internal_transaction_fetcher.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Indexer.InternalTransactionFetcher do
 
   alias Explorer.{BufferedTask, Chain, Indexer}
   alias Explorer.Indexer.{AddressBalanceFetcher, AddressExtraction}
-  alias Explorer.Chain.{Hash, Transaction}
+  alias Explorer.Chain.{Block, Hash}
 
   @behaviour BufferedTask
 
@@ -22,7 +22,7 @@ defmodule Explorer.Indexer.InternalTransactionFetcher do
   ]
 
   @doc """
-  Asynchronously fetches internal transactions from list of `t:Explorer.Chain.Hash.t/0`.
+  Asynchronously fetches internal transactions.
 
   ## Limiting Upstream Load
 
@@ -37,10 +37,11 @@ defmodule Explorer.Indexer.InternalTransactionFetcher do
   *Note*: The internal transactions for individual transactions cannot be paginated,
   so the total number of internal transactions that could be produced is unknown.
   """
-  def async_fetch(transaction_hashes, timeout \\ 5000) do
-    string_hashes = for hash <- transaction_hashes, do: Hash.to_string(hash)
+  @spec async_fetch([%{required(:block_number) => Block.block_number(), required(:hash) => Hash.Full.t()}]) :: :ok
+  def async_fetch(transactions_fields, timeout \\ 5000) when is_list(transactions_fields) do
+    params_list = Enum.map(transactions_fields, &transaction_fields_to_params/1)
 
-    BufferedTask.buffer(__MODULE__, string_hashes, timeout)
+    BufferedTask.buffer(__MODULE__, params_list, timeout)
   end
 
   @doc false
@@ -52,45 +53,72 @@ defmodule Explorer.Indexer.InternalTransactionFetcher do
   @impl BufferedTask
   def init(initial, reducer) do
     {:ok, final} =
-      Chain.stream_transactions_with_unfetched_internal_transactions([:hash], initial, fn %Transaction{hash: hash},
-                                                                                          acc ->
-        reducer.(Hash.to_string(hash), acc)
-      end)
+      Chain.stream_transactions_with_unfetched_internal_transactions(
+        [:block_number, :hash],
+        initial,
+        fn transaction_fields, acc ->
+          transaction_fields
+          |> transaction_fields_to_params()
+          |> reducer.(acc)
+        end
+      )
 
     final
   end
 
-  @impl BufferedTask
-  def run(transaction_hashes, _retries) do
-    Indexer.debug(fn -> "fetching internal transactions for #{length(transaction_hashes)} transactions" end)
+  defp transaction_fields_to_params(%{block_number: block_number, hash: hash}) when is_integer(block_number) do
+    %{block_number: block_number, hash_data: to_string(hash)}
+  end
 
-    case EthereumJSONRPC.fetch_internal_transactions(transaction_hashes) do
+  @impl BufferedTask
+  def run(transactions_params, _retries) do
+    Indexer.debug(fn -> "fetching internal transactions for #{length(transactions_params)} transactions" end)
+
+    case EthereumJSONRPC.fetch_internal_transactions(transactions_params) do
       {:ok, internal_transactions_params} ->
         addresses_params = AddressExtraction.extract_addresses(%{internal_transactions: internal_transactions_params})
 
-        [
-          addresses: [params: addresses_params],
-          internal_transactions: [params: internal_transactions_params],
-          transactions: [hashes: transaction_hashes]
-        ]
-        |> Chain.import_internal_transactions()
-        |> fetch_new_balances()
+        address_hash_to_block_number =
+          Enum.into(addresses_params, %{}, fn %{fetched_balance_block_number: block_number, hash: hash} ->
+            {hash, block_number}
+          end)
+
+        transaction_hashes = Enum.map(transactions_params, &Map.fetch!(&1, :hash_data))
+
+        with {:ok, %{addresses: address_hashes}} <-
+               Chain.import_internal_transactions(
+                 addresses: [params: addresses_params],
+                 internal_transactions: [params: internal_transactions_params],
+                 transactions: [hashes: transaction_hashes]
+               ) do
+          address_hashes
+          |> Enum.map(fn address_hash ->
+            block_number = Map.fetch!(address_hash_to_block_number, to_string(address_hash))
+            %{block_number: block_number, hash: address_hash}
+          end)
+          |> AddressBalanceFetcher.async_fetch_balances()
+        else
+          {:error, step, reason, _changes_so_far} ->
+            Indexer.debug(fn ->
+              [
+                "failed to import internal transactions for ",
+                to_string(length(transactions_params)),
+                " transactions at ",
+                to_string(step),
+                ": ",
+                inspect(reason)
+              ]
+            end)
+
+            :retry
+        end
 
       {:error, reason} ->
         Indexer.debug(fn ->
-          "failed to fetch internal transactions for #{length(transaction_hashes)} transactions: #{inspect(reason)}"
+          "failed to fetch internal transactions for #{length(transactions_params)} transactions: #{inspect(reason)}"
         end)
 
         :retry
     end
-  end
-
-  defp fetch_new_balances({:ok, %{addresses: address_hashes}}) do
-    AddressBalanceFetcher.async_fetch_balances(address_hashes)
-    :ok
-  end
-
-  defp fetch_new_balances({:error, _step, _reason, _changes_so_far}) do
-    :retry
   end
 end

--- a/apps/explorer/lib/explorer/indexer/pending_transaction_fetcher.ex
+++ b/apps/explorer/lib/explorer/indexer/pending_transaction_fetcher.ex
@@ -10,10 +10,9 @@ defmodule Explorer.Indexer.PendingTransactionFetcher do
   require Logger
 
   import EthereumJSONRPC.Parity, only: [fetch_pending_transactions: 0]
-  import Explorer.Indexer.AddressExtraction, only: [transactions_params_to_addresses_params: 1]
 
   alias Explorer.{Chain, Indexer}
-  alias Explorer.Indexer.PendingTransactionFetcher
+  alias Explorer.Indexer.{AddressExtraction, PendingTransactionFetcher}
 
   # milliseconds
   @default_interval 1_000
@@ -87,7 +86,8 @@ defmodule Explorer.Indexer.PendingTransactionFetcher do
 
   defp task(%PendingTransactionFetcher{} = _state) do
     {:ok, transactions_params} = fetch_pending_transactions()
-    addresses_params = transactions_params_to_addresses_params(transactions_params)
+
+    addresses_params = AddressExtraction.extract_addresses(%{transactions: transactions_params}, pending: true)
 
     # There's no need to queue up fetching the address balance since theses are pending transactions and cannot have
     # affected the address balance yet since address balance is a balance at a give block and these transactions are

--- a/apps/explorer/priv/repo/migrations/20180117221921_create_address.exs
+++ b/apps/explorer/priv/repo/migrations/20180117221921_create_address.exs
@@ -4,7 +4,7 @@ defmodule Explorer.Repo.Migrations.CreateAddress do
   def change do
     create table(:addresses, primary_key: false) do
       add(:fetched_balance, :numeric, precision: 100)
-      add(:balance_fetched_at, :utc_datetime)
+      add(:fetched_balance_block_number, :bigint)
       add(:hash, :bytea, null: false, primary_key: true)
       add(:contract_code, :bytea, null: true)
 

--- a/apps/explorer/test/explorer/chain/address_test.exs
+++ b/apps/explorer/test/explorer/chain/address_test.exs
@@ -1,6 +1,7 @@
 defmodule Explorer.Chain.AddressTest do
   use Explorer.DataCase
 
+  alias Ecto.Changeset
   alias Explorer.Chain.Address
 
   describe "changeset/2" do
@@ -18,13 +19,21 @@ defmodule Explorer.Chain.AddressTest do
 
   describe "balance_changeset/2" do
     test "with a new balance" do
-      changeset = Address.balance_changeset(%Address{}, %{fetched_balance: 99})
+      changeset =
+        Address.balance_changeset(%Address{}, %{
+          hash: "0x0000000000000000000000000000000000000001",
+          fetched_balance: 99,
+          fetched_balance_block_number: 1
+        })
+
       assert changeset.valid?
     end
 
-    test "with other attributes" do
-      changeset = Address.balance_changeset(%Address{}, %{hash: "0xraisinets"})
-      refute changeset.valid?
+    test "hash, fetched_balance, and fetched_balance_block_number are required" do
+      assert %Changeset{errors: errors, valid?: false} = Address.balance_changeset(%Address{}, %{})
+      assert Keyword.get_values(errors, :hash) == [{"can't be blank", [validation: :required]}]
+      assert Keyword.get_values(errors, :fetched_balance) == [{"can't be blank", [validation: :required]}]
+      assert Keyword.get_values(errors, :fetched_balance_block_number) == [{"can't be blank", [validation: :required]}]
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -8,9 +8,9 @@ defmodule Explorer.Chain.LogTest do
 
   describe "changeset/2" do
     test "accepts valid attributes" do
-      params = params_for(:log)
-      changeset = Log.changeset(%Log{}, params)
-      assert changeset.valid?
+      params = params_for(:log, address_hash: build(:address).hash, transaction_hash: build(:transaction).hash)
+
+      assert %Changeset{valid?: true} = Log.changeset(%Log{}, params)
     end
 
     test "rejects missing attributes" do
@@ -20,9 +20,15 @@ defmodule Explorer.Chain.LogTest do
     end
 
     test "accepts optional attributes" do
-      params = Map.put(params_for(:log), :first_topic, "ham")
+      params =
+        params_for(
+          :log,
+          address_hash: build(:address).hash,
+          first_topic: "ham",
+          transaction_hash: build(:transaction).hash
+        )
 
-      assert %Changeset{valid?: true} = Log.changeset(%Log{}, params)
+      assert %Changeset{changes: %{first_topic: "ham"}, valid?: true} = Log.changeset(%Log{}, params)
     end
 
     test "assigns optional attributes" do

--- a/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
@@ -3,9 +3,10 @@ defmodule Explorer.Indexer.AddressBalanceFetcherTest do
   # connection allowed immediately.
   use Explorer.DataCase, async: false
 
-  alias Explorer.Chain.Address
+  alias Explorer.Chain.{Address, Hash, Wei}
   alias Explorer.Indexer.{AddressBalanceFetcher, AddressBalanceFetcherCase}
 
+  @block_number 2_932_838
   @hash %Explorer.Chain.Hash{
     byte_count: 20,
     bytes: <<139, 243, 141, 71, 100, 146, 144, 100, 242, 212, 211, 165, 101, 32, 167, 106, 179, 223, 65, 91>>
@@ -18,33 +19,43 @@ defmodule Explorer.Indexer.AddressBalanceFetcherTest do
   end
 
   describe "init/1" do
-    test "fetches unfetched addresses" do
-      unfetched_address = insert(:address, hash: @hash)
+    test "fetches unfetched Block miner balance" do
+      {:ok, miner_hash} = Hash.Truncated.cast("0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca")
+      miner = insert(:address, hash: miner_hash)
+      block = insert(:block, miner: miner, number: 34)
 
-      assert unfetched_address.fetched_balance == nil
-      assert unfetched_address.balance_fetched_at == nil
+      assert miner.fetched_balance == nil
+      assert miner.fetched_balance_block_number == nil
 
       AddressBalanceFetcherCase.start_supervised!()
 
       fetched_address =
         wait(fn ->
-          Repo.one!(from(address in Address, where: address.hash == ^@hash and not is_nil(address.fetched_balance)))
+          Repo.one!(
+            from(address in Address, where: address.hash == ^miner_hash and not is_nil(address.fetched_balance))
+          )
         end)
 
-      refute fetched_address.balance_fetched_at == nil
+      assert fetched_address.fetched_balance == %Wei{value: Decimal.new(252_460_834_000_000_000_000_000_000)}
+      assert fetched_address.fetched_balance_block_number == block.number
     end
 
     test "fetches unfetched addresses when less than max batch size" do
-      insert(:address, hash: @hash)
+      {:ok, miner_hash} = Hash.Truncated.cast("0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca")
+      miner = insert(:address, hash: miner_hash)
+      block = insert(:block, miner: miner, number: 34)
 
       AddressBalanceFetcherCase.start_supervised!(max_batch_size: 2)
 
       fetched_address =
         wait(fn ->
-          Repo.one!(from(address in Address, where: address.hash == ^@hash and not is_nil(address.fetched_balance)))
+          Repo.one!(
+            from(address in Address, where: address.hash == ^miner_hash and not is_nil(address.fetched_balance))
+          )
         end)
 
-      refute fetched_address.balance_fetched_at == nil
+      assert fetched_address.fetched_balance == %Wei{value: Decimal.new(252_460_834_000_000_000_000_000_000)}
+      assert fetched_address.fetched_balance_block_number == block.number
     end
   end
 
@@ -52,14 +63,15 @@ defmodule Explorer.Indexer.AddressBalanceFetcherTest do
     test "fetches balances for address_hashes" do
       AddressBalanceFetcherCase.start_supervised!()
 
-      assert :ok = AddressBalanceFetcher.async_fetch_balances([@hash])
+      assert :ok = AddressBalanceFetcher.async_fetch_balances([%{block_number: @block_number, hash: @hash}])
 
       address =
         wait(fn ->
           Repo.get!(Address, @hash)
         end)
 
-      refute address.fetched_balance == nil
+      assert address.fetched_balance == %Wei{value: Decimal.new(1)}
+      assert address.fetched_balance_block_number == @block_number
     end
   end
 

--- a/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/internal_transaction_fetcher_test.exs
@@ -30,13 +30,15 @@ defmodule Explorer.Indexer.InternalTransactionFetcherTest do
     end
 
     test "buffers collated transactions with unfetched internal transactions" do
+      block = insert(:block)
+
       collated_unfetched_transaction =
         :transaction
         |> insert()
-        |> with_block()
+        |> with_block(block)
 
       assert InternalTransactionFetcher.init([], fn hash_string, acc -> [hash_string | acc] end) == [
-               to_string(collated_unfetched_transaction.hash)
+               %{block_number: block.number, hash_data: to_string(collated_unfetched_transaction.hash)}
              ]
     end
 

--- a/apps/explorer/test/explorer/repo_test.exs
+++ b/apps/explorer/test/explorer/repo_test.exs
@@ -11,7 +11,16 @@ defmodule Explorer.RepoTest do
   describe "safe_insert_all/3" do
     test "inserting duplicate rows in one chunk is logged before re-raising exception" do
       transaction = insert(:transaction)
-      params = params_for(:internal_transaction, transaction_hash: transaction.hash, index: 0)
+
+      params =
+        params_for(
+          :internal_transaction,
+          from_address_hash: insert(:address).hash,
+          to_address_hash: insert(:address).hash,
+          transaction_hash: transaction.hash,
+          index: 0
+        )
+
       %Changeset{valid?: true, changes: changes} = InternalTransaction.changeset(%InternalTransaction{}, params)
       at = DateTime.utc_now()
       timestamped_changes = Map.merge(changes, %{inserted_at: at, updated_at: at})

--- a/apps/explorer/test/explorer/smart_contract/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/publisher_test.exs
@@ -17,10 +17,16 @@ defmodule Explorer.SmartContract.PublisherTest do
 
       created_contract_address = insert(:address, hash: address_hash, contract_code: smart_contract_bytecode)
 
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
       insert(
-        :internal_transaction,
+        :internal_transaction_create,
+        transaction: transaction,
         index: 0,
-        created_contract_address_hash: created_contract_address.hash,
+        created_contract_address: created_contract_address,
         created_contract_code: smart_contract_bytecode
       )
 

--- a/apps/explorer/test/explorer/smart_contract/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/verifier_test.exs
@@ -15,10 +15,16 @@ defmodule Explorer.SmartContract.VerifierTest do
 
       created_contract_address = insert(:address, hash: address_hash, contract_code: smart_contract_bytecode)
 
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
       insert(
-        :internal_transaction,
+        :internal_transaction_create,
+        transaction: transaction,
         index: 0,
-        created_contract_address_hash: created_contract_address.hash,
+        created_contract_address: created_contract_address,
         created_contract_code: smart_contract_bytecode
       )
 
@@ -42,10 +48,16 @@ defmodule Explorer.SmartContract.VerifierTest do
 
       created_contract_address = insert(:address, hash: address_hash, contract_code: wrong_smart_contract_bytecode)
 
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
       insert(
-        :internal_transaction,
+        :internal_transaction_create,
+        transaction: transaction,
         index: 0,
-        created_contract_address_hash: created_contract_address.hash,
+        created_contract_address: created_contract_address,
         created_contract_code: wrong_smart_contract_bytecode
       )
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -44,7 +44,7 @@ defmodule Explorer.Factory do
       hash: block_hash(),
       parent_hash: block_hash(),
       nonce: sequence("block_nonce", & &1),
-      miner_hash: insert(:address).hash,
+      miner: build(:address),
       difficulty: Enum.random(1..100_000),
       total_difficulty: Enum.random(1..100_000),
       size: Enum.random(1..100_000),
@@ -135,21 +135,17 @@ defmodule Explorer.Factory do
     gas = Enum.random(21_000..100_000)
     gas_used = Enum.random(0..gas)
 
-    transaction =
-      :transaction
-      |> insert()
-      |> with_block()
-
     %InternalTransaction{
-      from_address_hash: insert(:address).hash,
-      to_address_hash: insert(:address).hash,
+      from_address: build(:address),
+      to_address: build(:address),
       call_type: :delegatecall,
       gas: gas,
       gas_used: gas_used,
       output: %Data{bytes: <<1>>},
       # caller MUST suppy `index`
       trace_address: [],
-      transaction_hash: transaction.hash,
+      # caller MUST supply `transaction` because it can't be built lazily to allow overrides without creating an extra
+      # transaction
       type: :call,
       value: sequence("internal_transaction_value", &Decimal.new(&1))
     }
@@ -159,21 +155,17 @@ defmodule Explorer.Factory do
     gas = Enum.random(21_000..100_000)
     gas_used = Enum.random(0..gas)
 
-    transaction =
-      :transaction
-      |> insert(to_address: nil, to_address_hash: nil)
-      |> with_block()
-
     %InternalTransaction{
       created_contract_code: data(:internal_transaction_created_contract_code),
-      created_contract_address_hash: insert(:address).hash,
-      from_address_hash: insert(:address).hash,
+      created_contract_address: build(:address),
+      from_address: build(:address),
       gas: gas,
       gas_used: gas_used,
       # caller MUST suppy `index`
       init: data(:internal_transaction_init),
       trace_address: [],
-      transaction_hash: transaction.hash,
+      # caller MUST supply `transaction` because it can't be built lazily to allow overrides without creating an extra
+      # transaction
       type: :create,
       value: sequence("internal_transaction_value", &Decimal.new(&1))
     }
@@ -181,14 +173,14 @@ defmodule Explorer.Factory do
 
   def log_factory do
     %Log{
-      address_hash: insert(:address).hash,
+      address: build(:address),
       data: data(:log_data),
       first_topic: nil,
       fourth_topic: nil,
       index: 0,
       second_topic: nil,
       third_topic: nil,
-      transaction_hash: insert(:transaction).hash,
+      transaction: build(:transaction),
       type: sequence("0x")
     }
   end
@@ -228,7 +220,7 @@ defmodule Explorer.Factory do
 
   def transaction_factory do
     %Transaction{
-      from_address_hash: insert(:address).hash,
+      from_address: build(:address),
       gas: Enum.random(21_000..100_000),
       gas_price: Enum.random(10..99) * 1_000_000_00,
       hash: transaction_hash(),
@@ -238,7 +230,7 @@ defmodule Explorer.Factory do
       r: sequence(:transaction_r, & &1),
       s: sequence(:transaction_s, & &1),
       standard_v: Enum.random(0..3),
-      to_address_hash: insert(:address).hash,
+      to_address: build(:address),
       v: Enum.random(27..30),
       value: Enum.random(1..100_000)
     }

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -43,6 +43,14 @@
                   <%= Cldr.Number.to_string!(@transaction_count) %>
                 </td>
               </tr>
+              <tr>
+                <td>
+                  <%= gettext "Last Updated In Block" %>
+                </td>
+                <td>
+                  <%= balance_block_number(@address) %>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/apps/explorer_web/lib/explorer_web/views/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_view.ex
@@ -19,13 +19,20 @@ defmodule ExplorerWeb.AddressView do
     end
   end
 
-  def balance(%Address{fetched_balance: nil}), do: ""
-
   @doc """
   Returns a formatted address balance and includes the unit.
   """
+
+  def balance(%Address{fetched_balance: nil}), do: ""
+
   def balance(%Address{fetched_balance: balance}) do
     format_wei_value(balance, :ether)
+  end
+
+  def balance_block_number(%Address{fetched_balance_block_number: nil}), do: ""
+
+  def balance_block_number(%Address{fetched_balance_block_number: fetched_balance_block_number}) do
+    to_string(fetched_balance_block_number)
   end
 
   def formatted_usd(%Address{fetched_balance: nil}, _), do: nil

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -529,3 +529,7 @@ msgstr ""
 #: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr ""
+
+#: lib/explorer_web/templates/address/overview.html.eex:48
+msgid "Last Updated In Block"
+msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -541,3 +541,7 @@ msgstr "No"
 #: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr "Yes"
+
+#: lib/explorer_web/templates/address/overview.html.eex:48
+msgid "Last Updated In Block"
+msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
@@ -30,10 +30,9 @@ defmodule ExplorerWeb.AddressInternalTransactionControllerTest do
         |> with_block()
 
       from_internal_transaction =
-        insert(:internal_transaction, transaction_hash: transaction.hash, from_address_hash: address.hash, index: 1)
+        insert(:internal_transaction, transaction: transaction, from_address: address, index: 1)
 
-      to_internal_transaction =
-        insert(:internal_transaction, transaction_hash: transaction.hash, to_address_hash: address.hash, index: 2)
+      to_internal_transaction = insert(:internal_transaction, transaction: transaction, to_address: address, index: 2)
 
       path = address_internal_transaction_path(conn, :index, :en, address)
       conn = get(conn, path)

--- a/apps/explorer_web/test/explorer_web/controllers/address_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_transaction_controller_test.exs
@@ -25,12 +25,12 @@ defmodule ExplorerWeb.AddressTransactionControllerTest do
 
       from_transaction =
         :transaction
-        |> insert(from_address_hash: address.hash)
+        |> insert(from_address: address)
         |> with_block(block)
 
       to_transaction =
         :transaction
-        |> insert(to_address_hash: address.hash)
+        |> insert(to_address: address)
         |> with_block(block)
 
       conn = get(conn, address_transaction_path(conn, :index, :en, address))
@@ -47,7 +47,7 @@ defmodule ExplorerWeb.AddressTransactionControllerTest do
     test "does not return related transactions without a block", %{conn: conn} do
       address = insert(:address)
 
-      insert(:transaction, from_address_hash: address.hash, to_address_hash: address.hash)
+      insert(:transaction, from_address: address, to_address: address)
 
       conn = get(conn, address_transaction_path(ExplorerWeb.Endpoint, :index, :en, address))
 

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -60,7 +60,12 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
     end
 
     test "with no to_address_hash overview contains contract create address", %{conn: conn} do
-      internal_transaction = insert(:internal_transaction_create, index: 0)
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      internal_transaction = insert(:internal_transaction_create, transaction: transaction, index: 0)
 
       conn =
         get(

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_log_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_log_controller_test.exs
@@ -29,7 +29,7 @@ defmodule ExplorerWeb.TransactionLogControllerTest do
         |> with_block()
 
       address = insert(:address)
-      insert(:log, address_hash: address.hash, transaction_hash: transaction.hash)
+      insert(:log, address: address, transaction: transaction)
 
       conn = get(conn, transaction_log_path(conn, :index, :en, transaction))
 

--- a/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
@@ -23,10 +23,16 @@ defmodule ExplorerWeb.AddressContractVerificationTest do
 
     created_contract_address = insert(:address, hash: address_hash, contract_code: smart_contract_bytecode)
 
+    transaction =
+      :transaction
+      |> insert()
+      |> with_block()
+
     insert(
       :internal_transaction,
+      transaction: transaction,
       index: 0,
-      created_contract_address_hash: created_contract_address.hash,
+      created_contract_address: created_contract_address,
       created_contract_code: smart_contract_bytecode
     )
 

--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -11,12 +11,12 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     from_taft =
       :transaction
-      |> insert(from_address_hash: taft.hash, to_address_hash: lincoln.hash)
+      |> insert(from_address: taft, to_address: lincoln)
       |> with_block(block)
 
     from_lincoln =
       :transaction
-      |> insert(from_address_hash: lincoln.hash, to_address_hash: taft.hash)
+      |> insert(from_address: lincoln, to_address: taft)
       |> with_block(block)
 
     {:ok,
@@ -85,18 +85,18 @@ defmodule ExplorerWeb.ViewingAddressesTest do
       block: block,
       session: session
     } do
-      lincoln_hash = addresses.lincoln.hash
+      lincoln = addresses.lincoln
 
       from_lincoln =
         :transaction
-        |> insert(from_address_hash: lincoln_hash, to_address_hash: nil)
+        |> insert(from_address: lincoln, to_address: nil)
         |> with_block(block)
 
       internal_transaction =
         insert(
           :internal_transaction_create,
-          transaction_hash: from_lincoln.hash,
-          from_address_hash: lincoln_hash,
+          transaction: from_lincoln,
+          from_address: lincoln,
           index: 0
         )
 
@@ -108,10 +108,10 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
   describe "viewing internal transactions" do
     setup %{addresses: addresses, transactions: transactions} do
-      address_hash = addresses.lincoln.hash
-      transaction_hash = transactions.from_lincoln.hash
-      insert(:internal_transaction, transaction_hash: transaction_hash, to_address_hash: address_hash, index: 0)
-      insert(:internal_transaction, transaction_hash: transaction_hash, from_address_hash: address_hash, index: 1)
+      address = addresses.lincoln
+      transaction = transactions.from_lincoln
+      insert(:internal_transaction, transaction: transaction, to_address: address, index: 0)
+      insert(:internal_transaction, transaction: transaction, from_address: address, index: 1)
       :ok
     end
 
@@ -140,7 +140,7 @@ defmodule ExplorerWeb.ViewingAddressesTest do
   end
 
   test "viewing transaction count", %{addresses: addresses, session: session} do
-    insert_list(1000, :transaction, to_address_hash: addresses.lincoln.hash)
+    insert_list(1000, :transaction, to_address: addresses.lincoln)
 
     session
     |> AddressPage.visit_page(addresses.lincoln)

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -33,20 +33,20 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
         nonce: 99045,
         inserted_at: Timex.parse!("1970-01-01T00:00:18-00:00", "{ISO:Extended}"),
         updated_at: Timex.parse!("1980-01-01T00:00:18-00:00", "{ISO:Extended}"),
-        from_address_hash: taft.hash,
-        to_address_hash: lincoln.hash
+        from_address: taft,
+        to_address: lincoln
       )
       |> with_block(block, gas_used: Decimal.new(1_230_000_000_000_123_000), status: :ok)
 
-    insert(:log, address_hash: lincoln.hash, index: 0, transaction_hash: transaction.hash)
+    insert(:log, address: lincoln, index: 0, transaction: transaction)
 
     # From Lincoln to Taft.
     txn_from_lincoln =
       :transaction
-      |> insert(from_address_hash: lincoln.hash, to_address_hash: taft.hash)
+      |> insert(from_address: lincoln, to_address: taft)
       |> with_block(block)
 
-    internal = insert(:internal_transaction, index: 0, transaction_hash: transaction.hash)
+    internal = insert(:internal_transaction, index: 0, transaction: transaction)
 
     {:ok,
      %{
@@ -76,7 +76,12 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     end
 
     test "contract creation is shown for to_address on home page", %{session: session} do
-      internal_transaction = insert(:internal_transaction_create, index: 0)
+      transaction =
+        :transaction
+        |> insert(to_address: nil)
+        |> with_block()
+
+      internal_transaction = insert(:internal_transaction_create, transaction: transaction, index: 0)
 
       session
       |> HomePage.visit_page()
@@ -98,7 +103,12 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     end
 
     test "contract creation is shown for to_address on list page", %{session: session} do
-      internal_transaction = insert(:internal_transaction_create, index: 0)
+      transaction =
+        :transaction
+        |> insert(to_address: nil)
+        |> with_block()
+
+      internal_transaction = insert(:internal_transaction_create, transaction: transaction, index: 0)
 
       session
       |> TransactionListPage.visit_page()
@@ -121,10 +131,15 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     end
 
     test "can see a contract creation address in to_address", %{session: session} do
-      internal_transaction = insert(:internal_transaction_create, index: 0)
+      transaction =
+        :transaction
+        |> insert(to_address: nil)
+        |> with_block()
+
+      internal_transaction = insert(:internal_transaction_create, transaction: transaction, index: 0)
 
       session
-      |> TransactionPage.visit_page(internal_transaction.transaction_hash)
+      |> TransactionPage.visit_page(transaction.hash)
       |> assert_has(TransactionPage.contract_creation_address_hash(internal_transaction))
     end
 


### PR DESCRIPTION
Fixes #243

Instead of getting the address balance at the latest block and recording the timestamp of the insert, which is only loosely correlated with even the latest block's timestamp on-chain, use the block number for the last time an address was used in the indexed address foreign keys in the
chain:

* blocks
  * miner_hash
* internal_transactions
  * created_contract_address_hash
  * from_address_hash
  * to_address_hash
* logs
  * address_hash
* transactions
  * from_address_hash
  * to_address_hash

To gather `fetched_balance_block_number` on reboot, `Explorer.Chain.stream_unfetched_addresses` queries across the above columns for the `MAX(blocks.number)`, which is used in `Explorer.Indexer.AddressBalanceFetcher.init/2`.

During indexing, `Explorer.Indexer.AddressBalanceFetcher.async_fetch_balances/1` now requires a list of `%{block_number: Block.block_number(), hash: Hash.Truncated.t()}` instead of list of `Hash.Truncated.t()`.

Having a `block_number` available for all importable entities's addresses required changing `Explorer.Indexer.AddressExtraction` to extract the `block_number` too.  Because it was difficult to determine which parts of the indexer weren't supplying a `block_number` or `nil` block number, `Explorer.Indexer.AddressExtraction` was rewritten to error when no extract format matches for the list of extract formats for each entity.  These errors allowed to track where in block_number needed
to be passed along to prevent a missing block number except in the case of pending transaction where block number is expected to be `nil`.

The use of `insert` in the factories was making tests that show the count not make sense, so the factories were switched to `build` because it means only the exact count is created when a default value is overridden.  This does, unfortunately, mean that `params_for(factory)` no longer generates foreign keys and they must be set explicitly OR the association passed instead of the foreign key.

**NOTE**: This is a database drop and reindex change.