### PR TITLE
Add 'Read Smart Contract' page

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -45,10 +45,21 @@ defmodule EthereumJSONRPC.Encoder do
   def encode_function_call({function_selector, args}) do
     encoded_args =
       function_selector
-      |> ABI.encode(args)
+      |> ABI.encode(parse_args(args))
       |> Base.encode16(case: :lower)
 
     {function_selector.function, "0x" <> encoded_args}
+  end
+
+  defp parse_args(args) do
+    args
+    |> Enum.map(fn
+      <<"0x", hexadecimal_digits::binary>> ->
+        Base.decode16!(hexadecimal_digits, case: :mixed)
+
+      item ->
+        item
+    end)
   end
 
   @doc """

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
@@ -26,6 +26,20 @@ defmodule EthereumJSONRPC.EncoderTest do
       assert Encoder.encode_function_call({function_selector, [10]}) ==
                {"get", "0x9507d39a000000000000000000000000000000000000000000000000000000000000000a"}
     end
+
+    test "generates the correct encoding with addresses arguments" do
+      function_selector = %ABI.FunctionSelector{
+        function: "tokens",
+        returns: {:uint, 256},
+        types: [:address, :address]
+      }
+
+      args = ["0xdab1c67232f92b7707f49c08047b96a4db7a9fc6", "0x6937cb25eb54bc013b9c13c47ab38eb63edd1493"]
+
+      assert Encoder.encode_function_call({function_selector, args}) ==
+               {"tokens",
+                "0x508493bc000000000000000000000000dab1c67232f92b7707f49c08047b96a4db7a9fc60000000000000000000000006937cb25eb54bc013b9c13c47ab38eb63edd1493"}
+    end
   end
 
   describe "get_selectors/2" do

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -7,6 +7,7 @@ config :explorer, Explorer.Repo,
   hostname: "localhost",
   loggers: [],
   pool_size: 20,
-  pool_timeout: 60_000
+  pool_timeout: 60_000,
+  timeout: 80_000
 
 import_config "dev.secret.exs"

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -65,25 +65,25 @@ defmodule Explorer.SmartContract.Reader do
 
     $ Explorer.SmartContract.Reader.read_only_functions("0x798465571ae21a184a272f044f991ad1d5f87a3f")
     => [
-      %{
-        "constant" => true,
-        "inputs" => [],
-        "name" => "get",
-        "outputs" => [%{"name" => "", "type" => "uint256", "value" => 0}],
-        "payable" => false,
-        "stateMutability" => "view",
-        "type" => "function"
-      },
-      %{
-        "constant" => true,
-        "inputs" => [%{"name" => "x", "type" => "uint256"}],
-        "name" => "with_arguments",
-        "outputs" => [%{"name" => "", "type" => "bool", "value" => ""}],
-        "payable" => false,
-        "stateMutability" => "view",
-        "type" => "function"
-      }
-    ]
+        %{
+          "constant" => true,
+          "inputs" => [],
+          "name" => "get",
+          "outputs" => [%{"name" => "", "type" => "uint256", "value" => 0}],
+          "payable" => false,
+          "stateMutability" => "view",
+          "type" => "function"
+        },
+        %{
+          "constant" => true,
+          "inputs" => [%{"name" => "x", "type" => "uint256"}],
+          "name" => "with_arguments",
+          "outputs" => [%{"name" => "", "type" => "bool", "value" => ""}],
+          "payable" => false,
+          "stateMutability" => "view",
+          "type" => "function"
+        }
+      ]
   """
   @spec read_only_functions(%Explorer.Chain.Hash{}) :: [%{}]
   def read_only_functions(contract_address_hash) do
@@ -140,7 +140,7 @@ defmodule Explorer.SmartContract.Reader do
 
   defp fetch_from_blockchain(contract_address_hash, %{name: name, args: args, outputs: outputs}) do
     contract_address_hash
-    |> query_contract(%{name => args})
+    |> query_contract(%{name => normalize_args(args)})
     |> link_outputs_and_values(outputs, name)
   end
 

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -5,35 +5,37 @@ defmodule Explorer.SmartContract.ReaderTest do
   doctest Explorer.SmartContract.Reader
 
   alias Explorer.SmartContract.Reader
+
   alias Plug.Conn
-  alias Explorer.Chain.Hash
 
   @ethereum_jsonrpc_original Application.get_env(:ethereum_jsonrpc, :url)
 
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(:ethereum_jsonrpc, :url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.put_env(:ethereum_jsonrpc, :url, @ethereum_jsonrpc_original)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
   describe "query_contract/2" do
-    setup do
-      bypass = Bypass.open()
-
-      Application.put_env(:ethereum_jsonrpc, :url, "http://localhost:#{bypass.port}")
-
-      on_exit(fn ->
-        Application.put_env(:ethereum_jsonrpc, :url, @ethereum_jsonrpc_original)
+    test "correctly returns the results of the smart contract functions", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        Conn.resp(
+          conn,
+          200,
+          ~s[{"jsonrpc":"2.0","result":"0x0000000000000000000000000000000000000000000000000000000000000000","id":"get"}]
+        )
       end)
-
-      {:ok, bypass: bypass}
-    end
-
-    test "correctly returns the result of a smart contract function", %{bypass: bypass} do
-      blockchain_resp =
-        "[{\"jsonrpc\":\"2.0\",\"result\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"id\":\"get\"}]\n"
-
-      Bypass.expect(bypass, fn conn -> Conn.resp(conn, 200, blockchain_resp) end)
 
       hash =
         :smart_contract
         |> insert()
         |> Map.get(:address_hash)
-        |> Hash.to_string()
 
       assert Reader.query_contract(hash, %{"get" => []}) == %{"get" => [0]}
     end
@@ -49,6 +51,141 @@ defmodule Explorer.SmartContract.ReaderTest do
                {function_name, data},
                contract_address
              ) == %{contract_address: "0x123789abc", data: "0x6d4ce63c", id: "get"}
+    end
+  end
+
+  describe "read_only_functions/1" do
+    test "fetches the smart contract read only functions with the blockchain value", %{bypass: bypass} do
+      smart_contract =
+        insert(
+          :smart_contract,
+          abi: [
+            %{
+              "constant" => true,
+              "inputs" => [],
+              "name" => "get",
+              "outputs" => [%{"name" => "", "type" => "uint256"}],
+              "payable" => false,
+              "stateMutability" => "view",
+              "type" => "function"
+            },
+            %{
+              "constant" => true,
+              "inputs" => [%{"name" => "x", "type" => "uint256"}],
+              "name" => "with_arguments",
+              "outputs" => [%{"name" => "", "type" => "bool"}],
+              "payable" => false,
+              "stateMutability" => "view",
+              "type" => "function"
+            }
+          ]
+        )
+
+      Bypass.expect(bypass, fn conn ->
+        Conn.resp(
+          conn,
+          200,
+          ~s[{"jsonrpc":"2.0","result":"0x0000000000000000000000000000000000000000000000000000000000000000","id":"get"}]
+        )
+      end)
+
+      response = Reader.read_only_functions(smart_contract.address_hash)
+
+      assert [
+               %{
+                 "constant" => true,
+                 "inputs" => [],
+                 "name" => "get",
+                 "outputs" => [%{"name" => "", "type" => "uint256", "value" => 0}],
+                 "payable" => _,
+                 "stateMutability" => _,
+                 "type" => _
+               },
+               %{
+                 "constant" => true,
+                 "inputs" => [%{"name" => "x", "type" => "uint256"}],
+                 "name" => "with_arguments",
+                 "outputs" => [%{"name" => "", "type" => "bool", "value" => ""}],
+                 "payable" => _,
+                 "stateMutability" => _,
+                 "type" => _
+               }
+             ] = response
+    end
+  end
+
+  describe "query_function/2" do
+    test "given the arguments, fetches the function value from the blockchain", %{bypass: bypass} do
+      smart_contract = insert(:smart_contract)
+
+      Bypass.expect(bypass, fn conn ->
+        Conn.resp(
+          conn,
+          200,
+          ~s[{"jsonrpc":"2.0","result":"0x0000000000000000000000000000000000000000000000000000000000000000","id":"get"}]
+        )
+      end)
+
+      assert [
+               %{
+                 "name" => "",
+                 "type" => "uint256",
+                 "value" => 0
+               }
+             ] = Reader.query_function(smart_contract.address_hash, %{name: "get", args: []})
+    end
+  end
+
+  describe "normalize_args/1" do
+    test "converts argument when is a number" do
+      assert [0] = Reader.normalize_args(["0"])
+
+      assert ["0x798465571ae21a184a272f044f991ad1d5f87a3f"] =
+               Reader.normalize_args(["0x798465571ae21a184a272f044f991ad1d5f87a3f"])
+    end
+
+    test "converts argument when is a boolean" do
+      assert [true] = Reader.normalize_args(["true"])
+      assert [false] = Reader.normalize_args(["false"])
+
+      assert ["some string"] = Reader.normalize_args(["some string"])
+    end
+  end
+
+  describe "link_outputs_and_values/2" do
+    test "links the ABI outputs with the values retrieved from the blockchain" do
+      blockchain_values = %{
+        "getOwner" => [
+          <<105, 55, 203, 37, 235, 84, 188, 1, 59, 156, 19, 196, 122, 179, 142, 182, 62, 221, 20, 147>>
+        ]
+      }
+
+      outputs = [%{"name" => "", "type" => "address"}]
+
+      function_name = "getOwner"
+
+      assert [%{"name" => "", "type" => "address", "value" => "0x6937cb25eb54bc013b9c13c47ab38eb63edd1493"}] =
+               Reader.link_outputs_and_values(blockchain_values, outputs, function_name)
+    end
+
+    test "correctly shows returns of 'bytes' type" do
+      blockchain_values = %{
+        "get" => [
+          <<0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+        ]
+      }
+
+      outputs = [%{"name" => "", "type" => "bytes32"}]
+
+      function_name = "get"
+
+      assert [
+               %{
+                 "name" => "",
+                 "type" => "bytes32",
+                 "value" => "0x000a000000000000000000000000000000000000000000000000000000000000"
+               }
+             ] = Reader.link_outputs_and_values(blockchain_values, outputs, function_name)
     end
   end
 end

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -1,5 +1,5 @@
 defmodule Explorer.SmartContract.ReaderTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Explorer.DataCase
 
   doctest Explorer.SmartContract.Reader
@@ -38,6 +38,34 @@ defmodule Explorer.SmartContract.ReaderTest do
         |> Map.get(:address_hash)
 
       assert Reader.query_contract(hash, %{"get" => []}) == %{"get" => [0]}
+    end
+
+    test "won't raise error when there is a problem with the params to consult the blockchain" do
+      smart_contract =
+        insert(
+          :smart_contract,
+          abi: [
+            %{
+              "constant" => true,
+              "inputs" => [
+                %{"name" => "a", "type" => "int256"},
+                %{"name" => "b", "type" => "int256"},
+                %{"name" => "c", "type" => "int256"},
+                %{"name" => "d", "type" => "int256"}
+              ],
+              "name" => "sum",
+              "outputs" => [%{"name" => "", "type" => "int256"}],
+              "payable" => false,
+              "stateMutability" => "pure",
+              "type" => "function"
+            }
+          ]
+        )
+
+      wrong_args = %{"sum" => [1, 1, 1, "abc"]}
+
+      assert %{"sum" => ["Data overflow encoding int, data `abc` cannot fit in 256 bits"]} =
+               Reader.query_contract(smart_contract.address_hash, wrong_args)
     end
   end
 

--- a/apps/explorer_web/assets/css/app.scss
+++ b/apps/explorer_web/assets/css/app.scss
@@ -32,6 +32,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "node_modules/bootstrap/scss/utilities/text";
 @import "node_modules/bootstrap/scss/utilities/background";
 @import "node_modules/bootstrap/scss/utilities/position";
+@import "node_modules/bootstrap/scss/utilities/borders";
 
 // Bootstrap Components
 @import "node_modules/bootstrap/scss/dropdown";

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -25,5 +25,6 @@ import './lib/market_history_chart'
 import './lib/reload_button'
 import './lib/sidebar'
 import './lib/tooltip'
+import './lib/smart_contract/read_function'
 
 import './pages/address'

--- a/apps/explorer_web/assets/js/lib/smart_contract/read_function.js
+++ b/apps/explorer_web/assets/js/lib/smart_contract/read_function.js
@@ -1,0 +1,31 @@
+import $ from 'jquery'
+
+const readFunction = (element) => {
+  const $element = $(element);
+  const $form = $element.find("[data-function-form]");
+
+  const $responseContainer = $element.find("[data-function-response]");
+
+  $form.on('submit', (event) => {
+    event.preventDefault();
+
+    const url = $form.data('url');
+    const $function_name  = $form.find("input[name=function_name]");
+    const $function_inputs = $form.find("input[name=function_input]");
+
+    const args = $.map($function_inputs, element => {
+      return $(element).val();
+    });
+
+    const data = {
+      function_name: $function_name.val(),
+      args
+    }
+
+    $.get(url, data, response => $responseContainer.html(response));
+  })
+}
+
+$("[data-function]").each((_, element) => {
+  readFunction(element);
+});

--- a/apps/explorer_web/assets/package-lock.json
+++ b/apps/explorer_web/assets/package-lock.json
@@ -11627,7 +11627,7 @@
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",

--- a/apps/explorer_web/config/test.exs
+++ b/apps/explorer_web/config/test.exs
@@ -10,4 +10,4 @@ config :explorer_web, ExplorerWeb.Endpoint,
   server: true
 
 # Configure wallaby
-config :wallaby, screenshot_on_failure: true, js_errors: false
+config :wallaby, screenshot_on_failure: true

--- a/apps/explorer_web/config/test.exs
+++ b/apps/explorer_web/config/test.exs
@@ -10,4 +10,4 @@ config :explorer_web, ExplorerWeb.Endpoint,
   server: true
 
 # Configure wallaby
-config :wallaby, screenshot_on_failure: true
+config :wallaby, screenshot_on_failure: true, js_errors: false

--- a/apps/explorer_web/lib/explorer_web/controllers/address_read_contract_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_read_contract_controller.ex
@@ -1,0 +1,60 @@
+defmodule ExplorerWeb.AddressReadContractController do
+  use ExplorerWeb, :controller
+
+  alias Explorer.{Chain, Market}
+  alias Explorer.ExchangeRates.Token
+  alias Explorer.SmartContract.Reader
+
+  import ExplorerWeb.AddressController, only: [transaction_count: 1]
+
+  def index(conn, %{"address_id" => address_hash_string}) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, address} <- Chain.find_contract_address(address_hash) do
+      read_only_functions = Reader.read_only_functions(address_hash)
+
+      render(
+        conn,
+        "index.html",
+        read_only_functions: read_only_functions,
+        address: address,
+        exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+        transaction_count: transaction_count(address)
+      )
+    else
+      :error ->
+        not_found(conn)
+
+      {:error, :not_found} ->
+        not_found(conn)
+    end
+  end
+
+  def show(conn, params) do
+    with true <- ajax?(conn),
+         {:ok, address_hash} <- Chain.string_to_address_hash(params["address_id"]),
+         outputs =
+           Reader.query_function(
+             address_hash,
+             %{name: params["function_name"], args: params["args"]}
+           ) do
+      conn
+      |> put_status(200)
+      |> put_layout(false)
+      |> render(
+        "_function_response.html",
+        function_name: params["function_name"],
+        outputs: outputs
+      )
+    else
+      _ ->
+        not_found(conn)
+    end
+  end
+
+  defp ajax?(conn) do
+    case get_req_header(conn, "x-requested-with") do
+      [value] -> value in ["XMLHttpRequest", "xmlhttprequest"]
+      [] -> false
+    end
+  end
+end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -94,6 +94,13 @@ defmodule ExplorerWeb.Router do
         only: [:new, :create],
         as: :verify_contract
       )
+
+      resources(
+        "/read_contract",
+        AddressReadContractController,
+        only: [:index, :show],
+        as: :read_contract
+      )
     end
 
     get("/search", ChainController, :search)

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -31,6 +31,14 @@
             <% end %>
           <% end %>
         </li>
+        <%= if smart_contract_with_read_only_functions?(@address) do %>
+          <li class="nav-item">
+            <%= link(
+                gettext("Read Contract"),
+                to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                class: "nav-link")%>
+          </li>
+        <% end %>
       </ul>
     </div>
 

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -34,6 +34,14 @@
               <% end %>
             </li>
           <% end %>
+          <%= if smart_contract_with_read_only_functions?(@address) do %>
+            <li class="nav-item">
+              <%= link(
+                  gettext("Read Contract"),
+                  to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  class: "nav-link")%>
+            </li>
+          <% end %>
         </ul>
       </div>
       <div class="card-body">

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/_function_response.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/_function_response.html.eex
@@ -1,0 +1,7 @@
+<span>
+  [ <%= @function_name %> method Response ] <br />
+
+  <%= for item <- @outputs do %>
+    <i class="fa fa-angle-double-right"></i> <%= item["type"] %> : <%= item["value"] %>
+  <% end %>
+</span>

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
@@ -1,0 +1,99 @@
+<section class="container-fluid">
+
+  <%= render ExplorerWeb.AddressView, "overview.html", assigns %>
+
+  <div class="card">
+    <div class="card-header">
+      <ul class="nav nav-tabs card-header-tabs">
+        <li class="nav-item">
+          <%= link(
+                gettext("Transactions"),
+                class: "nav-link",
+                to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+              ) %>
+        </li>
+        <li class="nav-item">
+          <%= link(
+                gettext("Internal Transactions"),
+                class: "nav-link",
+                "data-test": "internal_transactions_tab_link",
+                to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+              ) %>
+        </li>
+        <li class="nav-item">
+          <%= link(
+              to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              class: "nav-link") do %>
+            <%= gettext("Code") %>
+
+            <%= if smart_contract_verified?(@address) do %>
+              <i class="far fa-check-circle"></i>
+            <% end %>
+          <% end %>
+        </li>
+        <li class="nav-item">
+          <%= link(
+              gettext("Read Contract"),
+              to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              class: "nav-link active")%>
+        </li>
+      </ul>
+    </div>
+
+    <div class="card-body">
+      <h2>
+        <i class="fas fa-book"></i>
+        <%= gettext("Read Contract Information") %>
+      </h2>
+
+      <%= for {function, counter} <- Enum.with_index(@read_only_functions, 1) do %>
+        <div class="d-flex py-2 flex-wrap border-bottom" data-function>
+          <div class="py-2 pr-2">
+            <%= counter %>.
+
+            <%= function["name"] %>
+
+            &#8594;
+          </div>
+
+          <%= if queryable?(function["inputs"]) do %>
+            <form class="form-inline" data-function-form data-url="<%= address_read_contract_path(@conn, :show, :en, @address, @address.hash) %>">
+              <input type="hidden" name="function_name" value='<%= function["name"] %>' />
+
+              <%= for input <- function["inputs"] do %>
+                <div class="form-group pr-2">
+                  <input type="text" name="function_input" class="form-control form-control-sm mb-1" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
+                </div>
+              <% end %>
+
+              <input type="submit" value='<%= gettext("Query")%>' class="button button--secondary button--xsmall py-0" />
+            </form>
+          <% else %>
+            <span class="py-2">
+              <%= for output <- function["outputs"] do %>
+                <%= if address?(output["type"]) do %>
+                  <%= link(
+                     output["value"],
+                     to: address_path(@conn, :show, @conn.assigns.locale, output["value"])
+                   ) %>
+                <% else %>
+                  <%= output["value"] %>
+                <% end %>
+              <% end %>
+            </span>
+          <% end %>
+
+          <div class='p-2 text-muted <%= if (queryable?(function["inputs"]) == true), do: "w-100" %>'>
+            <%= if (queryable?(function["inputs"])), do: raw "&#8627;" %>
+
+            <%= for output <- function["outputs"] do %>
+              <%= output["type"] %>
+            <% end %>
+          </div>
+
+          <div data-function-response></div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -34,6 +34,14 @@
               <% end %>
             </li>
           <% end %>
+          <%= if smart_contract_with_read_only_functions?(@address) do %>
+            <li class="nav-item">
+              <%= link(
+                  gettext("Read Contract"),
+                  to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  class: "nav-link")%>
+            </li>
+          <% end %>
         </ul>
       </div>
       <div class="card-body">

--- a/apps/explorer_web/lib/explorer_web/views/address_contract_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_contract_view.ex
@@ -1,7 +1,7 @@
 defmodule ExplorerWeb.AddressContractView do
   use ExplorerWeb, :view
 
-  import ExplorerWeb.AddressView, only: [smart_contract_verified?: 1]
+  import ExplorerWeb.AddressView, only: [smart_contract_verified?: 1, smart_contract_with_read_only_functions?: 1]
 
   def format_smart_contract_abi(abi), do: Poison.encode!(abi, pretty: true)
 

--- a/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_internal_transaction_view.ex
@@ -1,7 +1,8 @@
 defmodule ExplorerWeb.AddressInternalTransactionView do
   use ExplorerWeb, :view
 
-  import ExplorerWeb.AddressView, only: [contract?: 1, smart_contract_verified?: 1]
+  import ExplorerWeb.AddressView,
+    only: [contract?: 1, smart_contract_verified?: 1, smart_contract_with_read_only_functions?: 1]
 
   def format_current_filter(filter) do
     case filter do

--- a/apps/explorer_web/lib/explorer_web/views/address_read_contract_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_read_contract_view.ex
@@ -1,0 +1,9 @@
+defmodule ExplorerWeb.AddressReadContractView do
+  use ExplorerWeb, :view
+
+  import ExplorerWeb.AddressView, only: [smart_contract_verified?: 1]
+
+  def queryable?(inputs), do: Enum.any?(inputs)
+
+  def address?(type), do: type == "address"
+end

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -1,7 +1,8 @@
 defmodule ExplorerWeb.AddressTransactionView do
   use ExplorerWeb, :view
 
-  import ExplorerWeb.AddressView, only: [contract?: 1, smart_contract_verified?: 1]
+  import ExplorerWeb.AddressView,
+    only: [contract?: 1, smart_contract_verified?: 1, smart_contract_with_read_only_functions?: 1]
 
   alias ExplorerWeb.TransactionView
 

--- a/apps/explorer_web/lib/explorer_web/views/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_view.ex
@@ -62,4 +62,10 @@ defmodule ExplorerWeb.AddressView do
 
   def smart_contract_verified?(%Address{smart_contract: %SmartContract{}}), do: true
   def smart_contract_verified?(%Address{smart_contract: nil}), do: false
+
+  def smart_contract_with_read_only_functions?(%Address{smart_contract: %SmartContract{}} = address) do
+    Enum.any?(address.smart_contract.abi, & &1["constant"])
+  end
+
+  def smart_contract_with_read_only_functions?(%Address{smart_contract: nil}), do: false
 end

--- a/apps/explorer_web/package-lock.json
+++ b/apps/explorer_web/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,5 +1,5 @@
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
-#: lib/explorer_web/templates/address_transaction/index.html.eex:97
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_transaction/index.html.eex:105
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -9,8 +9,8 @@
 msgid "Age"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
-#: lib/explorer_web/templates/address_transaction/index.html.eex:96
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:90
+#: lib/explorer_web/templates/address_transaction/index.html.eex:104
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:95
+#: lib/explorer_web/templates/address_transaction/index.html.eex:103
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -41,212 +41,170 @@ msgstr ""
 msgid "Hash"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:17
-#: lib/explorer_web/templates/chain/_blocks.html.eex:7
-msgid "Height"
-msgstr ""
-
-#: lib/explorer_web/templates/layout/app.html.eex:7
-msgid "POA Network Explorer"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:10
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/address_transaction/index.html.eex:11
-#: lib/explorer_web/templates/block/index.html.eex:19
-#: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/chain/_transactions.html.eex:4
-#: lib/explorer_web/templates/layout/_topnav.html.eex:18
-msgid "Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:101
-#: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/chain/_transactions.html.eex:10
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:61
-#: lib/explorer_web/templates/transaction/overview.html.eex:69
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-msgid "Value"
-msgstr ""
-
-#: lib/explorer_web/templates/block/show.html.eex:3
-msgid "Block #%{number} Details"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:58
-msgid "Difficulty"
-msgstr ""
-
-#: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:138
-msgid "Gas Limit"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:50
-msgid "Miner"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:112
-msgid "Nonce"
-msgstr ""
-
-#: lib/explorer_web/templates/block/show.html.eex:26
-msgid "Number"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:38
-msgid "Parent Hash"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:80
-msgid "Size"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:14
-msgid "Timestamp"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:72
-msgid "Total Difficulty"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
-msgid "Block Number"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:11
-msgid "Transaction Details"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:104
-msgid "Cumulative Gas Used"
-msgstr ""
-
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/chain/_blocks.html.eex:10
-msgid "Gas"
-msgstr ""
-
-#: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:146
-msgid "Gas Price"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:179
-msgid "Input"
-msgstr ""
-
+#, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:44
 msgid "%{confirmations} block confirmations"
 msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:39
+msgid "%{count} transactions"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
 msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:43
+msgid "24h Volume"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
 #: lib/explorer_web/views/address_view.ex:18
 msgid "Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:65
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:75
-#: lib/explorer_web/templates/address_transaction/index.html.eex:98
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:17
+msgid "Avg Block Time"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:12
+msgid "Balance"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:3
+msgid "Block Details"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:33
+msgid "Block Number"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
+msgid "Code"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/address_view.ex:16
+msgid "Contract Address"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
+msgid "Contract Source Code"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:58
+msgid "Difficulty"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
+msgid "Facebook"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/transaction_view.ex:93
+msgid "Failed"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:126
+msgid "First Seen"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:73
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:92
+#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:106
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/overview.html.eex:77
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
-#: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "From"
 msgstr ""
 
-#: lib/explorer_web/templates/block/show.html.eex:9
-#: lib/explorer_web/templates/block_transaction/index.html.eex:21
-msgid "Overview"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/chain/_blocks.html.eex:10
+msgid "Gas"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:96
-msgid "Success"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:53
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
-#: lib/explorer_web/templates/address_transaction/index.html.eex:63
-#: lib/explorer_web/templates/address_transaction/index.html.eex:100
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:93
+#: lib/explorer_web/templates/address_transaction/index.html.eex:71
+#: lib/explorer_web/templates/address_transaction/index.html.eex:108
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/overview.html.eex:89
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
-#: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
+#: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "To"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:10
-#: lib/explorer_web/templates/transaction/overview.html.eex:10
-msgid "Transaction Hash"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/transaction/overview.html.eex:138
+msgid "Gas Limit"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:24
-msgid "Transaction Status"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/transaction/overview.html.eex:146
+msgid "Gas Price"
 msgstr ""
 
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:12
-msgid "Balance"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:17
+#: lib/explorer_web/templates/chain/_blocks.html.eex:7
+msgid "Height"
 msgstr ""
 
-#: lib/explorer_web/templates/address/show.html.eex:15
-#: lib/explorer_web/templates/address_transaction/index.html.eex:43
-#: lib/explorer_web/templates/block_transaction/index.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:103
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:45
-#: lib/explorer_web/templates/transaction/index.html.eex:43
-#: lib/explorer_web/templates/transaction/show.html.eex:44
-msgid "POA"
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:179
+msgid "Input"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:39
-msgid "%{count} transactions"
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
+msgid "Instagram"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:5
-msgid "Showing #%{start_block} to #%{end_block}"
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:12
+msgid "Last Block"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:5
-msgid "Showing %{count} Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:55
-#: lib/explorer_web/views/transaction_view.ex:18
-#: lib/explorer_web/views/transaction_view.ex:95
-msgid "Pending"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:126
-msgid "First Seen"
-msgstr ""
-
+#, elixir-format
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
 #: lib/explorer_web/templates/transaction/overview.html.eex:132
 msgid "Last Seen"
 msgstr ""
 
+#, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
@@ -280,10 +238,6 @@ msgstr ""
 msgid "Lag"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:12
-msgid "Last Block"
-msgstr ""
-
 #: lib/explorer_web/templates/chain/show.html.eex:6
 msgid "Skipped"
 msgstr ""
@@ -296,15 +250,11 @@ msgstr ""
 msgid "Next Page"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:93
-msgid "Failed"
-msgstr ""
-
 #: lib/explorer_web/views/transaction_view.ex:94
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:93
+#: lib/explorer_web/templates/address_transaction/index.html.eex:101
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -320,8 +270,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:101
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:94
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -339,83 +289,116 @@ msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:17
 #: lib/explorer_web/templates/address_transaction/index.html.eex:18
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_topnav.html.eex:39
-msgid "Search by address, transaction hash, or block number"
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:46
+msgid "Mainnet"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:123
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
-msgid "There are no Internal Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction_log/index.html.eex:67
-msgid "There are no logs currently."
-msgstr ""
-
-#: lib/explorer_web/templates/address/show.html.eex:20
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:37
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:36
-msgid "Transactions From"
-msgstr ""
-
-#: lib/explorer_web/templates/address/show.html.eex:16
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:30
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:29
-msgid "Transactions To"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-msgid "Type"
-msgstr ""
-
-#: lib/explorer_web/views/wei_helpers.ex:69
-msgid "Wei"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
-#: lib/explorer_web/templates/address_transaction/index.html.eex:57
-#: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
-msgid "All"
-msgstr ""
-
-#: lib/explorer_web/templates/address_transaction/index.html.eex:102
-msgid "Fee"
-msgstr ""
-
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/transaction/index.html.eex:14
-msgid "Validated"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:3
-msgid "Block Details"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:81
-msgid "Parent Tx Hash"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/show.html.eex:43
-msgid "24h Volume"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/show.html.eex:17
-msgid "Avg Block Time"
-msgstr ""
-
+#, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:39
 msgid "Market Cap"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
+msgid "There are no Internal Transactions"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:50
+msgid "Miner"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction_log/index.html.eex:73
+msgid "Newer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/transaction/overview.html.eex:112
+msgid "Nonce"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:137
+#: lib/explorer_web/templates/address_transaction/index.html.eex:126
+#: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:69
+#: lib/explorer_web/templates/transaction/index.html.eex:88
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+msgid "Older"
+msgstr ""
+
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
+#: lib/explorer_web/views/address_internal_transaction_view.ex:11
+#: lib/explorer_web/views/address_transaction_view.ex:13
+msgid "All"
+msgstr ""
+
+#: lib/explorer_web/templates/address_transaction/index.html.eex:110
+msgid "Fee"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:50
+msgid "POA Core"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/app.html.eex:7
+msgid "POA Network Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:49
+msgid "POA Sokol"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:38
+msgid "Parent Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:89
+msgid "Parent Tx Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/overview.html.eex:55
+#: lib/explorer_web/views/transaction_view.ex:18
+#: lib/explorer_web/views/transaction_view.ex:95
+msgid "Pending"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:34
 msgid "Price"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:69
+msgid "Query"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:37
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:40
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:36
+#: lib/explorer_web/templates/address_transaction/index.html.eex:40
+msgid "Read Contract"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
@@ -429,120 +412,24 @@ msgstr ""
 msgid "Number of Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_sidebar.html.eex:24
-msgid "Dashboard"
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:39
+msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:5
+msgid "Showing #%{start_block} to #%{end_block}"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/transaction/index.html.eex:6
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_topnav.html.eex:48
-msgid "Smart Contract"
-msgstr ""
-
-#: lib/explorer_web/templates/layout/_sidebar.html.eex:12
-msgid "Switch Network "
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_transactions.html.eex:7
-msgid "TX Hash"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:9
-msgid "TXNs"
-msgstr ""
-
-#: lib/explorer_web/templates/layout/_topnav.html.eex:29
-msgid "Tokens"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:145
-msgid "Total Gas Used"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:22
-msgid "Transaction"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:11
-msgid "Validator"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:3
-#: lib/explorer_web/templates/chain/_transactions.html.eex:3
-msgid "View All"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:155
-#: lib/explorer_web/templates/transaction/overview.html.eex:163
-msgid "TX Fee"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:27
-#: lib/explorer_web/templates/address_transaction/index.html.eex:27
-msgid "Contract"
-msgstr ""
-
-#: lib/explorer_web/views/address_view.ex:16
-msgid "Contract Address"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:39
-msgid "Contract bytecode"
-msgstr ""
-
-#: lib/explorer_web/templates/address_transaction/index.html.eex:112
-#: lib/explorer_web/templates/block_transaction/index.html.eex:192
-msgid "There are no Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:129
-#: lib/explorer_web/templates/address_transaction/index.html.eex:118
-#: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-msgid "Older"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
-msgid "Contract Source Code"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:44
-msgid "Verify and Publish"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
-#: lib/explorer_web/templates/address_transaction/index.html.eex:29
-msgid "Code"
-msgstr ""
-
-#: lib/explorer_web/views/address_contract_view.ex:9
-msgid "false"
-msgstr ""
-
-#: lib/explorer_web/views/address_contract_view.ex:8
-msgid "true"
-msgstr ""
-
-#: lib/explorer_web/templates/address/_values.html.eex:28
-msgid "Last Updated In Block"
-msgstr ""
-
 #, elixir-format
-#: lib/explorer_web/templates/transaction_log/index.html.eex:73
-msgid "Newer"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:107
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:24
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-msgid "Contract Creation"
+#: lib/explorer_web/templates/block_transaction/index.html.eex:80
+msgid "Size"
 msgstr ""
 
 #, elixir-format
@@ -551,28 +438,24 @@ msgid "Smart Contracts"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:46
-msgid "Mainnet"
+#: lib/explorer_web/views/transaction_view.ex:96
+msgid "Success"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:50
-msgid "POA Core"
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
+msgid "TX Fee"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:49
-msgid "POA Sokol"
+#: lib/explorer_web/templates/chain/_transactions.html.eex:7
+msgid "TX Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
-msgid "Facebook"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
-msgid "Instagram"
+#: lib/explorer_web/templates/chain/_blocks.html.eex:9
+msgid "TXNs"
 msgstr ""
 
 #, elixir-format
@@ -581,16 +464,138 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/transaction_log/index.html.eex:67
+msgid "There are no logs currently."
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:14
+msgid "Timestamp"
+msgstr ""
+
+#: lib/explorer_web/templates/address_transaction/index.html.eex:120
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
+msgid "There are no Transactions"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:29
+msgid "Tokens"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:72
+msgid "Total Difficulty"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:22
+msgid "Transaction"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:11
+msgid "Transaction Details"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:24
+msgid "Transaction Status"
+msgstr ""
+
+#: lib/explorer_web/templates/address/_values.html.eex:28
+msgid "Last Updated In Block"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:10
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:10
+#: lib/explorer_web/templates/address_transaction/index.html.eex:11
+#: lib/explorer_web/templates/block/index.html.eex:19
+#: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/chain/_transactions.html.eex:4
+#: lib/explorer_web/templates/layout/_topnav.html.eex:18
+msgid "Transactions"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:115
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:24
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+msgid "Contract Creation"
+msgstr ""
+
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
+msgid "Type"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/transaction/index.html.eex:14
+msgid "Validated"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:11
+msgid "Validator"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:94
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
+#: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/chain/_transactions.html.eex:10
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+msgid "Value"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:52
+msgid "Verify and Publish"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:3
+#: lib/explorer_web/templates/chain/_transactions.html.eex:3
+msgid "View All"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/wei_helpers.ex:69
+msgid "Wei"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/address_contract_view.ex:9
+msgid "false"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/address_contract_view.ex:8
+msgid "true"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_transaction/index.html.eex:55
 msgid "connection lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:42
+#: lib/explorer_web/templates/address_transaction/index.html.eex:50
 msgid "more messages have come in"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:46
+msgid "Read Contract Information"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
-#: lib/explorer_web/templates/address_transaction/index.html.eex:97
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_transaction/index.html.eex:105
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -19,33 +19,33 @@ msgstr ""
 #: lib/explorer_web/templates/transaction/index.html.eex:36
 #: lib/explorer_web/templates/transaction/overview.html.eex:49
 msgid "Age"
-msgstr "Age"
+msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
-#: lib/explorer_web/templates/address_transaction/index.html.eex:96
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:90
+#: lib/explorer_web/templates/address_transaction/index.html.eex:104
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
 msgid "Block"
-msgstr "Block"
+msgstr ""
 
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
 #: lib/explorer_web/templates/layout/_topnav.html.eex:13
 msgid "Blocks"
-msgstr "Blocks"
+msgstr ""
 
 #: lib/explorer_web/templates/layout/_footer.html.eex:18
 msgid "Copyright %{year} POA"
-msgstr "%{year} POA Network Ltd. All rights reserved"
+msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:171
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
-msgstr "Gas Used"
+msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:95
+#: lib/explorer_web/templates/address_transaction/index.html.eex:103
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -53,212 +53,170 @@ msgstr "Gas Used"
 msgid "Hash"
 msgstr "Hash"
 
-#: lib/explorer_web/templates/block/index.html.eex:17
-#: lib/explorer_web/templates/chain/_blocks.html.eex:7
-msgid "Height"
-msgstr "Height"
-
-#: lib/explorer_web/templates/layout/app.html.eex:7
-msgid "POA Network Explorer"
-msgstr "POA Network Explorer"
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:10
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/address_transaction/index.html.eex:11
-#: lib/explorer_web/templates/block/index.html.eex:19
-#: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/chain/_transactions.html.eex:4
-#: lib/explorer_web/templates/layout/_topnav.html.eex:18
-msgid "Transactions"
-msgstr "Transactions"
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:101
-#: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/chain/_transactions.html.eex:10
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:61
-#: lib/explorer_web/templates/transaction/overview.html.eex:69
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-msgid "Value"
-msgstr "Value"
-
-#: lib/explorer_web/templates/block/show.html.eex:3
-msgid "Block #%{number} Details"
-msgstr "Block #%{number} Details"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:58
-msgid "Difficulty"
-msgstr "Difficulty"
-
-#: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:138
-msgid "Gas Limit"
-msgstr "Gas Limit"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:50
-msgid "Miner"
-msgstr "Validator"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:112
-msgid "Nonce"
-msgstr "Nonce"
-
-#: lib/explorer_web/templates/block/show.html.eex:26
-msgid "Number"
-msgstr "Height"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:38
-msgid "Parent Hash"
-msgstr "Parent Hash"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:80
-msgid "Size"
-msgstr "Size"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:14
-msgid "Timestamp"
-msgstr "Timestamp"
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:72
-msgid "Total Difficulty"
-msgstr "Total Difficulty"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
-msgid "Block Number"
-msgstr "Block Height"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:11
-msgid "Transaction Details"
-msgstr "Transaction Details"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:104
-msgid "Cumulative Gas Used"
-msgstr "Cumulative Gas Used"
-
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/chain/_blocks.html.eex:10
-msgid "Gas"
-msgstr "Gas"
-
-#: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:146
-msgid "Gas Price"
-msgstr "Gas Price"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:179
-msgid "Input"
-msgstr "Input"
-
+#, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:44
 msgid "%{confirmations} block confirmations"
-msgstr "%{confirmations} block confirmations"
+msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:39
+msgid "%{count} transactions"
+msgstr "%{count} transactions"
+
+#, elixir-format
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
-msgstr "%{count} transactions in this block"
+msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:43
+msgid "24h Volume"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
 #: lib/explorer_web/views/address_view.ex:18
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:65
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:75
-#: lib/explorer_web/templates/address_transaction/index.html.eex:98
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:17
+msgid "Avg Block Time"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:12
+msgid "Balance"
+msgstr "Balance"
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:3
+msgid "Block Details"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:33
+msgid "Block Number"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_transaction/index.html.eex:29
+msgid "Code"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/address_view.ex:16
+msgid "Contract Address"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
+msgid "Contract Source Code"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:58
+msgid "Difficulty"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
+msgid "Facebook"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/transaction_view.ex:93
+msgid "Failed"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:126
+msgid "First Seen"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:73
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:92
+#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:106
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/overview.html.eex:77
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
-#: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "From"
 msgstr "From"
 
-#: lib/explorer_web/templates/block/show.html.eex:9
-#: lib/explorer_web/templates/block_transaction/index.html.eex:21
-msgid "Overview"
-msgstr "Overview"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/chain/_blocks.html.eex:10
+msgid "Gas"
+msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:96
-msgid "Success"
-msgstr "Success"
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:53
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
-#: lib/explorer_web/templates/address_transaction/index.html.eex:63
-#: lib/explorer_web/templates/address_transaction/index.html.eex:100
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:93
+#: lib/explorer_web/templates/address_transaction/index.html.eex:71
+#: lib/explorer_web/templates/address_transaction/index.html.eex:108
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/overview.html.eex:89
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
-#: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
+#: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "To"
 msgstr "To"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:10
-#: lib/explorer_web/templates/transaction/overview.html.eex:10
-msgid "Transaction Hash"
-msgstr "Transaction Hash"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:24
-msgid "Transaction Status"
-msgstr "Transaction Status"
-
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:12
-msgid "Balance"
-msgstr "Balance"
-
-#: lib/explorer_web/templates/address/show.html.eex:15
-#: lib/explorer_web/templates/address_transaction/index.html.eex:43
-#: lib/explorer_web/templates/block_transaction/index.html.eex:43
-#: lib/explorer_web/templates/chain/show.html.eex:103
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:45
-#: lib/explorer_web/templates/transaction/index.html.eex:43
-#: lib/explorer_web/templates/transaction/show.html.eex:44
-msgid "POA"
-msgstr "POA"
-
-#: lib/explorer_web/templates/block/index.html.eex:39
-msgid "%{count} transactions"
-msgstr "%{count} transactions"
-
-#: lib/explorer_web/templates/block/index.html.eex:5
-msgid "Showing #%{start_block} to #%{end_block}"
-msgstr "Showing #%{start_block} to #%{end_block}"
-
-#: lib/explorer_web/templates/transaction/index.html.eex:5
-msgid "Showing %{count} Transactions"
-msgstr "Showing %{count} Transactions"
-
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/index.html.eex:21
-#: lib/explorer_web/templates/transaction/overview.html.eex:55
-#: lib/explorer_web/views/transaction_view.ex:18
-#: lib/explorer_web/views/transaction_view.ex:95
-msgid "Pending"
-msgstr "Pending"
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:126
-msgid "First Seen"
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/transaction/overview.html.eex:138
+msgid "Gas Limit"
 msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/transaction/overview.html.eex:146
+msgid "Gas Price"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:17
+#: lib/explorer_web/templates/chain/_blocks.html.eex:7
+msgid "Height"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:179
+msgid "Input"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
+msgid "Instagram"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:12
+msgid "Last Block"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
 #: lib/explorer_web/templates/transaction/overview.html.eex:132
 msgid "Last Seen"
 msgstr ""
 
+#, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
@@ -274,7 +232,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/transaction_log/index.html.eex:3
 msgid "Transaction Logs"
-msgstr ""
+msgstr "Transaction Hash"
 
 #: lib/explorer_web/templates/chain/show.html.eex:47
 msgid "%{count} per day"
@@ -292,10 +250,6 @@ msgstr ""
 msgid "Lag"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:12
-msgid "Last Block"
-msgstr ""
-
 #: lib/explorer_web/templates/chain/show.html.eex:6
 msgid "Skipped"
 msgstr ""
@@ -308,15 +262,11 @@ msgstr ""
 msgid "Next Page"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:93
-msgid "Failed"
-msgstr ""
-
 #: lib/explorer_web/views/transaction_view.ex:94
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:93
+#: lib/explorer_web/templates/address_transaction/index.html.eex:101
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -332,8 +282,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:101
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:94
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -351,83 +301,116 @@ msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:17
 #: lib/explorer_web/templates/address_transaction/index.html.eex:18
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_topnav.html.eex:39
-msgid "Search by address, transaction hash, or block number"
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:46
+msgid "Mainnet"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:123
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
-msgid "There are no Internal Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction_log/index.html.eex:67
-msgid "There are no logs currently."
-msgstr ""
-
-#: lib/explorer_web/templates/address/show.html.eex:20
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:37
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:36
-msgid "Transactions From"
-msgstr ""
-
-#: lib/explorer_web/templates/address/show.html.eex:16
-#: lib/explorer_web/templates/address_transaction_from/index.html.eex:30
-#: lib/explorer_web/templates/address_transaction_to/index.html.eex:29
-msgid "Transactions To"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-msgid "Type"
-msgstr ""
-
-#: lib/explorer_web/views/wei_helpers.ex:69
-msgid "Wei"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
-#: lib/explorer_web/templates/address_transaction/index.html.eex:57
-#: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
-msgid "All"
-msgstr ""
-
-#: lib/explorer_web/templates/address_transaction/index.html.eex:102
-msgid "Fee"
-msgstr ""
-
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/transaction/index.html.eex:14
-msgid "Validated"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:3
-msgid "Block Details"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:81
-msgid "Parent Tx Hash"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/show.html.eex:43
-msgid "24h Volume"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/show.html.eex:17
-msgid "Avg Block Time"
-msgstr ""
-
+#, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:39
 msgid "Market Cap"
 msgstr ""
 
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
+msgid "There are no Internal Transactions"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:50
+msgid "Miner"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction_log/index.html.eex:73
+msgid "Newer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/transaction/overview.html.eex:112
+msgid "Nonce"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:137
+#: lib/explorer_web/templates/address_transaction/index.html.eex:126
+#: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:69
+#: lib/explorer_web/templates/transaction/index.html.eex:88
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+msgid "Older"
+msgstr ""
+
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/explorer_web/templates/address_transaction/index.html.eex:65
+#: lib/explorer_web/views/address_internal_transaction_view.ex:11
+#: lib/explorer_web/views/address_transaction_view.ex:13
+msgid "All"
+msgstr ""
+
+#: lib/explorer_web/templates/address_transaction/index.html.eex:110
+msgid "Fee"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:50
+msgid "POA Core"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/app.html.eex:7
+msgid "POA Network Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:49
+msgid "POA Sokol"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:38
+msgid "Parent Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:89
+msgid "Parent Tx Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/overview.html.eex:55
+#: lib/explorer_web/views/transaction_view.ex:18
+#: lib/explorer_web/views/transaction_view.ex:95
+msgid "Pending"
+msgstr "Pending"
+
+#, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:34
 msgid "Price"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:69
+msgid "Query"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:37
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:40
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:36
+#: lib/explorer_web/templates/address_transaction/index.html.eex:40
+msgid "Read Contract"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
@@ -441,120 +424,24 @@ msgstr ""
 msgid "Number of Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_sidebar.html.eex:24
-msgid "Dashboard"
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:39
+msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
+#, elixir-format
+#: lib/explorer_web/templates/block/index.html.eex:5
+msgid "Showing #%{start_block} to #%{end_block}"
+msgstr "Showing #%{start_block} to #%{end_block}"
+
+#, elixir-format
 #: lib/explorer_web/templates/transaction/index.html.eex:6
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_topnav.html.eex:48
-msgid "Smart Contract"
-msgstr ""
-
-#: lib/explorer_web/templates/layout/_sidebar.html.eex:12
-msgid "Switch Network "
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_transactions.html.eex:7
-msgid "TX Hash"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:9
-msgid "TXNs"
-msgstr ""
-
-#: lib/explorer_web/templates/layout/_topnav.html.eex:29
-msgid "Tokens"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:145
-msgid "Total Gas Used"
-msgstr ""
-
-#: lib/explorer_web/templates/block_transaction/index.html.eex:22
-msgid "Transaction"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:11
-msgid "Validator"
-msgstr ""
-
-#: lib/explorer_web/templates/chain/_blocks.html.eex:3
-#: lib/explorer_web/templates/chain/_transactions.html.eex:3
-msgid "View All"
-msgstr ""
-
-#: lib/explorer_web/templates/transaction/overview.html.eex:155
-#: lib/explorer_web/templates/transaction/overview.html.eex:163
-msgid "TX Fee"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:27
-#: lib/explorer_web/templates/address_transaction/index.html.eex:27
-msgid "Contract"
-msgstr ""
-
-#: lib/explorer_web/views/address_view.ex:16
-msgid "Contract Address"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:39
-msgid "Contract bytecode"
-msgstr ""
-
-#: lib/explorer_web/templates/address_transaction/index.html.eex:112
-#: lib/explorer_web/templates/block_transaction/index.html.eex:192
-msgid "There are no Transactions"
-msgstr ""
-
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:129
-#: lib/explorer_web/templates/address_transaction/index.html.eex:118
-#: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-msgid "Older"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
-msgid "Contract Source Code"
-msgstr "Contract Source Code"
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:44
-msgid "Verify and Publish"
-msgstr ""
-
-#: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:29
-#: lib/explorer_web/templates/address_transaction/index.html.eex:29
-msgid "Code"
-msgstr ""
-
-#: lib/explorer_web/views/address_contract_view.ex:9
-msgid "false"
-msgstr "No"
-
-#: lib/explorer_web/views/address_contract_view.ex:8
-msgid "true"
-msgstr "Yes"
-
-#: lib/explorer_web/templates/address/_values.html.eex:28
-msgid "Last Updated In Block"
-msgstr ""
-
 #, elixir-format
-#: lib/explorer_web/templates/transaction_log/index.html.eex:73
-msgid "Newer"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:107
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:24
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-msgid "Contract Creation"
+#: lib/explorer_web/templates/block_transaction/index.html.eex:80
+msgid "Size"
 msgstr ""
 
 #, elixir-format
@@ -563,28 +450,24 @@ msgid "Smart Contracts"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:46
-msgid "Mainnet"
+#: lib/explorer_web/views/transaction_view.ex:96
+msgid "Success"
+msgstr "Success"
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
+msgid "TX Fee"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:50
-msgid "POA Core"
+#: lib/explorer_web/templates/chain/_transactions.html.eex:7
+msgid "TX Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:49
-msgid "POA Sokol"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
-msgid "Facebook"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
-msgid "Instagram"
+#: lib/explorer_web/templates/chain/_blocks.html.eex:9
+msgid "TXNs"
 msgstr ""
 
 #, elixir-format
@@ -593,16 +476,138 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/transaction_log/index.html.eex:67
+msgid "There are no logs currently."
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:14
+msgid "Timestamp"
+msgstr ""
+
+#: lib/explorer_web/templates/address_transaction/index.html.eex:120
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
+msgid "There are no Transactions"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:29
+msgid "Tokens"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:72
+msgid "Total Difficulty"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/block_transaction/index.html.eex:22
+msgid "Transaction"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:11
+msgid "Transaction Details"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/transaction/overview.html.eex:24
+msgid "Transaction Status"
+msgstr "Transaction Status"
+
+#: lib/explorer_web/templates/address/_values.html.eex:28
+msgid "Last Updated In Block"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:10
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:10
+#: lib/explorer_web/templates/address_transaction/index.html.eex:11
+#: lib/explorer_web/templates/block/index.html.eex:19
+#: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/chain/_transactions.html.eex:4
+#: lib/explorer_web/templates/layout/_topnav.html.eex:18
+msgid "Transactions"
+msgstr ""
+
+#, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:115
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:24
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+msgid "Contract Creation"
+msgstr ""
+
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
+msgid "Type"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/transaction/index.html.eex:14
+msgid "Validated"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:11
+msgid "Validator"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:94
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
+#: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/chain/_transactions.html.eex:10
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/index.html.eex:39
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+msgid "Value"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_contract/index.html.eex:52
+msgid "Verify and Publish"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:3
+#: lib/explorer_web/templates/chain/_transactions.html.eex:3
+msgid "View All"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/wei_helpers.ex:69
+msgid "Wei"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/views/address_contract_view.ex:9
+msgid "false"
+msgstr "No"
+
+#, elixir-format
+#: lib/explorer_web/views/address_contract_view.ex:8
+msgid "true"
+msgstr "Yes"
+
+#, elixir-format
+#: lib/explorer_web/templates/address_transaction/index.html.eex:55
 msgid "connection lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:42
+#: lib/explorer_web/templates/address_transaction/index.html.eex:50
 msgid "more messages have come in"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:46
+msgid "Read Contract Information"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_read_contract_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_read_contract_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule ExplorerWeb.AddressReadContractControllerTest do
+  use ExplorerWeb.ConnCase
+
+  describe "GET show/3" do
+    test "only responds to ajax requests", %{conn: conn} do
+      smart_contract = insert(:smart_contract)
+
+      path =
+        address_read_contract_path(
+          ExplorerWeb.Endpoint,
+          :show,
+          :en,
+          smart_contract.address_hash,
+          smart_contract.address_hash,
+          function_name: "get",
+          args: []
+        )
+
+      conn = get(conn, path)
+
+      assert conn.status == 404
+    end
+  end
+end

--- a/apps/explorer_web/test/explorer_web/features/address_read_contract_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_read_contract_test.exs
@@ -1,0 +1,59 @@
+defmodule ExplorerWeb.AddressReadContractTest do
+  use ExplorerWeb.FeatureCase, async: true
+
+  import Wallaby.Query
+
+  alias Plug.Conn
+
+  @ethereum_jsonrpc_original Application.get_env(:ethereum_jsonrpc, :url)
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(:ethereum_jsonrpc, :url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.put_env(:ethereum_jsonrpc, :url, @ethereum_jsonrpc_original)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  test "user can query a function from the smart contract", %{session: session, bypass: bypass} do
+    smart_contract_bytecode =
+      "0x608060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b11461005c5780636d4ce63c14610089578063acbe7b79146100b4575b600080fd5b34801561006857600080fd5b50610087600480360381019080803590602001909291905050506100f9565b005b34801561009557600080fd5b5061009e610103565b6040518082815260200191505060405180910390f35b3480156100c057600080fd5b506100df6004803603810190808035906020019092919050505061010c565b604051808215151515815260200191505060405180910390f35b8060008190555050565b60008054905090565b60008054821490509190505600a165627a7a723058201b7ca1dc6f88d76a0aa8279bc79a934469d7b90a4af3be3d2b7490f34db10fe10029"
+
+    created_contract_address = insert(:address, contract_code: smart_contract_bytecode)
+
+    smart_contract =
+      insert(
+        :smart_contract,
+        address_hash: created_contract_address.hash,
+        abi: [
+          %{
+            "constant" => true,
+            "inputs" => [%{"name" => "x", "type" => "uint256"}],
+            "name" => "with_arguments",
+            "outputs" => [%{"name" => "", "type" => "bool"}],
+            "payable" => false,
+            "stateMutability" => "view",
+            "type" => "function"
+          }
+        ]
+      )
+
+    Bypass.expect(bypass, fn conn ->
+      Conn.resp(
+        conn,
+        200,
+        ~s[{"jsonrpc":"2.0","result":"0x0000000000000000000000000000000000000000000000000000000000000000","id":"with_arguments"}]
+      )
+    end)
+
+    session
+    |> visit("/en/addresses/#{smart_contract.address_hash}/read_contract")
+    |> fill_in(text_field("function_input"), with: 0)
+    |> click(button("Query"))
+    |> assert_has(css("[data-function-response]", text: "[ with_arguments method Response ]"))
+  end
+end

--- a/apps/explorer_web/test/explorer_web/views/address_read_contract_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/address_read_contract_view_test.exs
@@ -1,0 +1,19 @@
+defmodule ExplorerWeb.AddressReadContractViewTest do
+  use ExplorerWeb.ConnCase, async: true
+
+  alias ExplorerWeb.AddressReadContractView
+
+  describe "queryable?/1" do
+    test "returns true if list of inputs is not empty" do
+      assert AddressReadContractView.queryable?([%{"name" => "argument_name", "type" => "uint256"}]) == true
+      assert AddressReadContractView.queryable?([]) == false
+    end
+  end
+
+  describe "address?/1" do
+    test "returns true if type equals `address`" do
+      assert AddressReadContractView.address?("address") == true
+      assert AddressReadContractView.address?("uint256") == false
+    end
+  end
+end

--- a/apps/explorer_web/test/explorer_web/views/address_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/address_view_test.exs
@@ -44,4 +44,71 @@ defmodule ExplorerWeb.AddressViewTest do
       assert {:ok, _} = Base.decode64(AddressView.qr_code(address))
     end
   end
+
+  describe "smart_contract_verified?/1" do
+    test "returns true when smart contract is verified" do
+      smart_contract = insert(:smart_contract)
+      address = insert(:address, smart_contract: smart_contract)
+
+      assert AddressView.smart_contract_verified?(address)
+    end
+
+    test "returns false when smart contract is not verified" do
+      address = insert(:address, smart_contract: nil)
+
+      refute AddressView.smart_contract_verified?(address)
+    end
+  end
+
+  describe "smart_contract_with_read_only_functions?/1" do
+    test "returns true when abi has read only functions" do
+      smart_contract =
+        insert(
+          :smart_contract,
+          abi: [
+            %{
+              "constant" => true,
+              "inputs" => [],
+              "name" => "get",
+              "outputs" => [%{"name" => "", "type" => "uint256"}],
+              "payable" => false,
+              "stateMutability" => "view",
+              "type" => "function"
+            }
+          ]
+        )
+
+      address = insert(:address, smart_contract: smart_contract)
+
+      assert AddressView.smart_contract_with_read_only_functions?(address)
+    end
+
+    test "returns false when there is no read only functions" do
+      smart_contract =
+        insert(
+          :smart_contract,
+          abi: [
+            %{
+              "constant" => false,
+              "inputs" => [%{"name" => "x", "type" => "uint256"}],
+              "name" => "set",
+              "outputs" => [],
+              "payable" => false,
+              "stateMutability" => "nonpayable",
+              "type" => "function"
+            }
+          ]
+        )
+
+      address = insert(:address, smart_contract: smart_contract)
+
+      refute AddressView.smart_contract_with_read_only_functions?(address)
+    end
+
+    test "returns false when smart contract is not verified" do
+      address = insert(:address, smart_contract: nil)
+
+      refute AddressView.smart_contract_with_read_only_functions?(address)
+    end
+  end
 end


### PR DESCRIPTION
This PR is part of the #70 issue, it adds a page to read the smart contract functions.

![screen shot 2018-07-02 at 18 51 03](https://user-images.githubusercontent.com/840531/42188132-0bfda4f2-7e29-11e8-9b65-27ad216ccb37.png)

**TODO**
- [x] Create a page to list contract read-only functions;
- [x] Send query values to interact with the blockchain;
- [x] Show response from the blockchain;
- [x] Integrate with `Reader.query_contract/3`;