### PR TITLE
Show correct internal transaction type and contract link

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -103,7 +103,18 @@
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
                   </td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <%= if ExplorerWeb.InternalTransactionView.contract?(internal_transaction) do %>
+                      <i class="fas fa-plus-square"></i>
+                      <%= link(
+                        gettext("Contract Creation"),
+                        class: "transaction__link",
+                        "data-address-hash": internal_transaction.created_contract_address_hash,
+                        to: address_path(ExplorerWeb.Endpoint, :show, @locale, internal_transaction.created_contract_address_hash),
+                        title: internal_transaction.created_contract_address_hash
+                      ) %>
+                    <% else %>
+                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <% end %>
                   </td>
                   <td><%= ExplorerWeb.TransactionView.value(internal_transaction, include_label: false) %></td>
                 </tr>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -103,7 +103,7 @@
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
                   </td>
                   <td>
-                    <%= if ExplorerWeb.InternalTransactionView.contract?(internal_transaction) do %>
+                    <%= if ExplorerWeb.InternalTransactionView.create?(internal_transaction) do %>
                       <i class="fas fa-plus-square"></i>
                       <%= link(
                         gettext("Contract Creation"),

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
@@ -41,7 +41,7 @@
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
                   </td>
                   <td>
-                    <%= if ExplorerWeb.InternalTransactionView.contract?(internal_transaction) do %>
+                    <%= if ExplorerWeb.InternalTransactionView.create?(internal_transaction) do %>
                       <i class="fas fa-plus-square"></i>
                       <%= link(
                         gettext("Contract Creation"),

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
@@ -41,7 +41,18 @@
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
                   </td>
                   <td>
-                    <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <%= if ExplorerWeb.InternalTransactionView.contract?(internal_transaction) do %>
+                      <i class="fas fa-plus-square"></i>
+                      <%= link(
+                        gettext("Contract Creation"),
+                        class: "transaction__link",
+                        "data-address-hash": internal_transaction.created_contract_address_hash,
+                        to: address_path(ExplorerWeb.Endpoint, :show, @locale, internal_transaction.created_contract_address_hash),
+                        title: internal_transaction.created_contract_address_hash
+                      ) %>
+                    <% else %>
+                      <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.to_address %>
+                    <% end %>
                   </td>
                   <td><%= ExplorerWeb.TransactionView.value(internal_transaction, include_label: false) %></td>
                   <td><%= ExplorerWeb.TransactionView.gas(internal_transaction) %></td>

--- a/apps/explorer_web/lib/explorer_web/views/internal_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/internal_transaction_view.ex
@@ -4,6 +4,6 @@ defmodule ExplorerWeb.InternalTransactionView do
 
   alias Explorer.Chain.InternalTransaction
 
-  def contract?(%InternalTransaction{type: :create}), do: true
-  def contract?(_), do: false
+  def create?(%InternalTransaction{type: :create}), do: true
+  def create?(_), do: false
 end

--- a/apps/explorer_web/lib/explorer_web/views/internal_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/internal_transaction_view.ex
@@ -1,4 +1,9 @@
 defmodule ExplorerWeb.InternalTransactionView do
   use ExplorerWeb, :view
   @dialyzer :no_match
+
+  alias Explorer.Chain.InternalTransaction
+
+  def contract?(%InternalTransaction{type: :create}), do: true
+  def contract?(_), do: false
 end

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -355,8 +355,8 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:114
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:53
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
@@ -504,13 +504,13 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:120
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
 #: lib/explorer_web/templates/address_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:200
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
 #: lib/explorer_web/templates/transaction/index.html.eex:90
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:60
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""
 
@@ -543,4 +543,10 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:109
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+msgid "Contract Creation"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -367,8 +367,8 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:114
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:53
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
@@ -516,13 +516,13 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:120
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
 #: lib/explorer_web/templates/address_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:200
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
 #: lib/explorer_web/templates/transaction/index.html.eex:90
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:60
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""
 
@@ -555,4 +555,10 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:109
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+msgid "Contract Creation"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/views/internal_transaction_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/internal_transaction_view_test.exs
@@ -1,0 +1,19 @@
+defmodule ExplorerWeb.InternalTransactionViewTest do
+  use ExplorerWeb.ConnCase, async: true
+
+  alias ExplorerWeb.InternalTransactionView
+
+  describe "contract?/1" do
+    test "with internal transaction of type create returns true" do
+      internal_transaction = build(:internal_transaction_create)
+
+      assert InternalTransactionView.contract?(internal_transaction)
+    end
+
+    test "with non-create type internal transaction returns false" do
+      internal_transaction = build(:internal_transaction)
+
+      refute InternalTransactionView.contract?(internal_transaction)
+    end
+  end
+end

--- a/apps/explorer_web/test/explorer_web/views/internal_transaction_view_test.exs
+++ b/apps/explorer_web/test/explorer_web/views/internal_transaction_view_test.exs
@@ -3,17 +3,17 @@ defmodule ExplorerWeb.InternalTransactionViewTest do
 
   alias ExplorerWeb.InternalTransactionView
 
-  describe "contract?/1" do
+  describe "create?/1" do
     test "with internal transaction of type create returns true" do
       internal_transaction = build(:internal_transaction_create)
 
-      assert InternalTransactionView.contract?(internal_transaction)
+      assert InternalTransactionView.create?(internal_transaction)
     end
 
     test "with non-create type internal transaction returns false" do
       internal_transaction = build(:internal_transaction)
 
-      refute InternalTransactionView.contract?(internal_transaction)
+      refute InternalTransactionView.create?(internal_transaction)
     end
   end
 end


### PR DESCRIPTION
Fixes #296


## Changelog

### Bug Fixes
* Displays internal transaction `type` correctly on transaction page
* Displays Contract Creation link correctly on transaction->internal transactions and address->internal transactions pages
