### PR TITLE
`AddressBalanceFetcher` uses max `block_quantity` for `hash_data` in batches

### DIFF
--- a/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
@@ -2,4 +2,81 @@ defmodule EthereumJSONRPCTest do
   use ExUnit.Case, async: true
 
   doctest EthereumJSONRPC
+
+  describe "fetch_balances/1" do
+    test "with all valid hash_data returns {:ok, addresses_params}" do
+      assert EthereumJSONRPC.fetch_balances([
+               %{block_quantity: "0x1", hash_data: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"}
+             ]) ==
+               {:ok,
+                [
+                  %{
+                    fetched_balance: 1,
+                    fetched_balance_block_number: 1,
+                    hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+                  }
+                ]}
+    end
+
+    test "with all invalid hash_data returns {:error, reasons}" do
+      assert EthereumJSONRPC.fetch_balances([%{block_quantity: "0x1", hash_data: "0x0"}]) ==
+               {:error,
+                [
+                  %{
+                    "blockNumber" => "0x1",
+                    "code" => -32602,
+                    "hash" => "0x0",
+                    "message" =>
+                      "Invalid params: invalid length 1, expected a 0x-prefixed, padded, hex-encoded hash with length 40."
+                  }
+                ]}
+    end
+
+    test "with a mix of valid and invalid hash_data returns {:error, reasons}" do
+      assert EthereumJSONRPC.fetch_balances([
+               # start with :ok
+               %{
+                 block_quantity: "0x1",
+                 hash_data: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+               },
+               # :ok, :ok clause
+               %{
+                 block_quantity: "0x34",
+                 hash_data: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+               },
+               # :ok, :error clause
+               %{
+                 block_quantity: "0x2",
+                 hash_data: "0x3"
+               },
+               # :error, :ok clause
+               %{
+                 block_quantity: "0x35",
+                 hash_data: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+               },
+               # :error, :error clause
+               %{
+                 block_quantity: "0x4",
+                 hash_data: "0x5"
+               }
+             ]) ==
+               {:error,
+                [
+                  %{
+                    "blockNumber" => "0x2",
+                    "code" => -32602,
+                    "hash" => "0x3",
+                    "message" =>
+                      "Invalid params: invalid length 1, expected a 0x-prefixed, padded, hex-encoded hash with length 40."
+                  },
+                  %{
+                    "blockNumber" => "0x4",
+                    "code" => -32602,
+                    "hash" => "0x5",
+                    "message" =>
+                      "Invalid params: invalid length 1, expected a 0x-prefixed, padded, hex-encoded hash with length 40."
+                  }
+                ]}
+    end
+  end
 end

--- a/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
@@ -86,8 +86,27 @@ defmodule Explorer.Indexer.AddressBalanceFetcherTest do
 
       fetched_address = Repo.one!(from(address in Address, where: address.hash == ^hash_data))
 
-      assert fetched_address.fetched_balance == %Explorer.Chain.Wei{value: Decimal.new(252460802000000000000000000)}
+      assert fetched_address.fetched_balance == %Explorer.Chain.Wei{
+               value: Decimal.new(252_460_802_000_000_000_000_000_000)
+             }
+
       assert fetched_address.fetched_balance_block_number == 2
+    end
+
+    test "duplicate address hashes only retry max block_quantity" do
+      hash_data = "0x000000000000000000000000000000000"
+
+      assert AddressBalanceFetcher.run(
+               [%{block_quantity: "0x1", hash_data: hash_data}, %{block_quantity: "0x2", hash_data: hash_data}],
+               0
+             ) ==
+               {:retry,
+                [
+                  %{
+                    block_quantity: "0x2",
+                    hash_data: "0x000000000000000000000000000000000"
+                  }
+                ]}
     end
   end
 

--- a/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
+++ b/apps/explorer/test/explorer/indexer/address_balance_fetcher_test.exs
@@ -75,6 +75,22 @@ defmodule Explorer.Indexer.AddressBalanceFetcherTest do
     end
   end
 
+  describe "run/2" do
+    test "duplicate address hashes the max block_quantity" do
+      hash_data = "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+
+      assert AddressBalanceFetcher.run(
+               [%{block_quantity: "0x1", hash_data: hash_data}, %{block_quantity: "0x2", hash_data: hash_data}],
+               0
+             ) == :ok
+
+      fetched_address = Repo.one!(from(address in Address, where: address.hash == ^hash_data))
+
+      assert fetched_address.fetched_balance == %Explorer.Chain.Wei{value: Decimal.new(252460802000000000000000000)}
+      assert fetched_address.fetched_balance_block_number == 2
+    end
+  end
+
   defp wait(producer) do
     producer.()
   rescue

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 93.1
+    "minimum_coverage": 93.9
   },
   "terminal_options": {
     "file_column_width": 120


### PR DESCRIPTION
Fixes #309

## Blockers

- [x] Merge #308 to `master`

## Changelog

### Enhancements
* Regression test for #309

### Bug Fixes
* `AddressBalanceFetcher` uses max `block_quantity` for `hash_data` in batches passed to `run/2` to eliminate duplicate address hashes in one `ON CONFLICT DO UPDATE`.
*  Convert `eth_getBalance` error responses to `:error` tuple.
