### PR TITLE
Pass through removed flag for logs

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -106,7 +106,8 @@ defmodule EthereumJSONRPC.Log do
     Enum.into(log, %{}, &entry_to_elixir/1)
   end
 
-  defp entry_to_elixir({key, _} = entry) when key in ~w(address blockHash data topics transactionHash type), do: entry
+  defp entry_to_elixir({key, _} = entry) when key in ~w(address blockHash data removed topics transactionHash type),
+    do: entry
 
   defp entry_to_elixir({key, quantity}) when key in ~w(blockNumber logIndex transactionIndex transactionLogIndex) do
     {key, quantity_to_integer(quantity)}


### PR DESCRIPTION
Fixes #314

## Changelog

### Bug Fixes
* Parity 1.11.4 sends a `removed` flag of whether a transaction was removed or not in the transaction receipt that was not sent in 1.10.6. As the flag value is already `true` or `false`, no conversion is
necessary when converting to Elixir.

## Upgrading

You MUST upgrade to this version to maintain compatibility with the Sokol nodes currently on `sokol.poa.network`, which have been upgraded to Parity 1.11.4 to fix a bug in Parity itself.