### PR TITLE
Rechunk batch JSONRPC request when 413 is returned

### DIFF
--- a/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/etheream_jsonrpc_test.exs
@@ -79,4 +79,52 @@ defmodule EthereumJSONRPCTest do
                 ]}
     end
   end
+
+  describe "json_rpc/2" do
+    # regression test for https://github.com/poanetwork/poa-explorer/issues/254
+    test "transparently splits batch payloads that would trigger a 413 Request Entity Too Large" do
+      block_numbers = 0..13000
+
+      payload =
+        block_numbers
+        |> Stream.with_index()
+        |> Enum.map(&get_block_by_number_request/1)
+
+      assert_payload_too_large(payload)
+
+      url = EthereumJSONRPC.config(:url)
+
+      assert {:ok, responses} = EthereumJSONRPC.json_rpc(payload, url)
+      assert Enum.count(responses) == Enum.count(block_numbers)
+
+      block_number_set = MapSet.new(block_numbers)
+
+      response_block_number_set =
+        Enum.into(responses, MapSet.new(), fn %{"result" => %{"number" => quantity}} ->
+          EthereumJSONRPC.quantity_to_integer(quantity)
+        end)
+
+      assert MapSet.equal?(response_block_number_set, block_number_set)
+    end
+  end
+
+  defp assert_payload_too_large(payload) do
+    json = Jason.encode_to_iodata!(payload)
+    headers = [{"Content-Type", "application/json"}]
+    url = EthereumJSONRPC.config(:url)
+
+    assert {:ok, %HTTPoison.Response{body: body, status_code: 413}} =
+             HTTPoison.post(url, json, headers, EthereumJSONRPC.config(:http))
+
+    assert body =~ "413 Request Entity Too Large"
+  end
+
+  defp get_block_by_number_request({block_number, id}) do
+    %{
+      "id" => id,
+      "jsonrpc" => "2.0",
+      "method" => "eth_getBlockByNumber",
+      "params" => [EthereumJSONRPC.integer_to_quantity(block_number), true]
+    }
+  end
 end

--- a/apps/explorer/test/explorer/chain/statistics/server_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics/server_test.exs
@@ -4,6 +4,9 @@ defmodule Explorer.Chain.Statistics.ServerTest do
   alias Explorer.Chain.Statistics
   alias Explorer.Chain.Statistics.Server
 
+  # shutdown: "owner exited with: shutdown" error from polluting logs when tests are successful
+  @moduletag :capture_log
+
   describe "child_spec/1" do
     test "it defines a child_spec/1 that works with supervisors" do
       assert {:ok, _} = start_supervised(Server)

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,7 +1,7 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 93.9
+    "minimum_coverage": 93.7
   },
   "terminal_options": {
     "file_column_width": 120


### PR DESCRIPTION
Fixes #254

## Changelog

### Bug Fixes
* When status 413 Request Entity Too Large is returned from JSONRPC, we can split the batch in half and try again.  Continuing to break up the chunks of the batch until we succeed or hit 1 request in the chunk, in which case we still need to error.
* Use `:capture_log` `@moduletag` to quiet `Statistics.Server` shutdown during tests.
