### PR TITLE
Bug fix transactions not populating #297

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -37,7 +37,6 @@
         </ul>
       </div>
       <div class="card-body">
-
         <%= if Enum.count(@internal_transactions) > 0 do %>
           <div class="dropdown u-float-right u-push-sm">
             <button data-test="filter_dropdown" class="button button--secondary button--xsmall dropdown-toggle" type="button"

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -37,44 +37,45 @@
         </ul>
       </div>
       <div class="card-body">
-        <div class="dropdown u-float-right u-push-sm">
-          <button data-test="filter_dropdown" class="button button--secondary button--xsmall dropdown-toggle" type="button"
-                  id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Filter: <%= format_current_filter(@filter) %>
-          </button>
-          <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
-            <%= link(
-                  gettext("All"),
-                  to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
-                  class: "address__link address__link--active dropdown-item",
-                  "data-test": "filter_option"
-                ) %>
-            <%= link(
-                  gettext("To"),
-                  to: address_transaction_path(
-                    @conn,
-                    :index,
-                    @conn.assigns.locale,
-                    @conn.params["address_id"],
-                    filter: "to"
-                  ),
-                  class: "address__link address__link--active dropdown-item",
-                  "data-test": "filter_option"
-                ) %>
-            <%= link(
-                  gettext("From"),
-                  to: address_transaction_path(
-                    @conn,
-                    :index,
-                    @conn.assigns.locale,
-                    @conn.params["address_id"],
-                    filter: "from"
-                  ),
-                  class: "address__link address__link--active dropdown-item",
-                  "data-test": "filter_option"
-                ) %>
+        <%= if Enum.count(@transactions) > 0 do %>
+          <div class="dropdown u-float-right u-push-sm">
+            <button data-test="filter_dropdown" class="button button--secondary button--xsmall dropdown-toggle" type="button"
+                    id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Filter: <%= format_current_filter(@filter) %>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
+              <%= link(
+                    gettext("All"),
+                    to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                    class: "address__link address__link--active dropdown-item",
+                    "data-test": "filter_option"
+                  ) %>
+              <%= link(
+                    gettext("To"),
+                    to: address_transaction_path(
+                      @conn,
+                      :index,
+                      @conn.assigns.locale,
+                      @conn.params["address_id"],
+                      filter: "to"
+                    ),
+                    class: "address__link address__link--active dropdown-item",
+                    "data-test": "filter_option"
+                  ) %>
+              <%= link(
+                    gettext("From"),
+                    to: address_transaction_path(
+                      @conn,
+                      :index,
+                      @conn.assigns.locale,
+                      @conn.params["address_id"],
+                      filter: "from"
+                    ),
+                    class: "address__link address__link--active dropdown-item",
+                    "data-test": "filter_option"
+                  ) %>
+            </div>
           </div>
-        </div>
 
         <table class="table table-responsive-sm table-font">
           <thead>
@@ -132,6 +133,9 @@
             <% end %>
           </tbody>
         </table>
+        <% else %>
+          <p><%= gettext "There are no Transactions" %></p>
+        <% end %>
       </div>
     </div>
     <%= if @next_page_params do %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_log/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_log/index.html.eex
@@ -64,7 +64,7 @@
             <% end %>
           </table>
         <% else %>
-        <p><%= gettext "There are no logs currently." %></p>
+          <p><%= gettext "There are no logs currently." %></p>
         <% end %>
       </div>
     </div>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,5 +1,5 @@
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -9,8 +9,8 @@
 msgid "Age"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:87
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Gas Used"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:86
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -61,8 +61,8 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
@@ -158,10 +158,10 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:65
-#: lib/explorer_web/templates/address_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_transaction/index.html.eex:89
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
@@ -182,10 +182,10 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
-#: lib/explorer_web/templates/address_transaction/index.html.eex:53
-#: lib/explorer_web/templates/address_transaction/index.html.eex:90
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:54
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:54
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -310,7 +310,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:84
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -326,8 +326,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:24
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:124
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -384,14 +384,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:49
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction/index.html.eex:48
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:92
+#: lib/explorer_web/templates/address_transaction/index.html.eex:93
 msgid "Fee"
 msgstr ""
 
@@ -406,7 +406,7 @@ msgstr ""
 msgid "Block Details"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
 msgid "Parent Tx Hash"
 msgstr ""
 
@@ -500,12 +500,13 @@ msgstr ""
 msgid "Contract bytecode"
 msgstr ""
 
+#: lib/explorer_web/templates/address_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:194
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
-#: lib/explorer_web/templates/address_transaction/index.html.eex:139
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:130
+#: lib/explorer_web/templates/address_transaction/index.html.eex:143
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:200
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
@@ -546,7 +547,7 @@ msgid "Newer"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:109
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:108
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
 msgid "Contract Creation"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
-#: lib/explorer_web/templates/address_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
+#: lib/explorer_web/templates/address_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
 #: lib/explorer_web/templates/chain/_blocks.html.eex:8
@@ -21,8 +21,8 @@ msgstr ""
 msgid "Age"
 msgstr "Age"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:84
-#: lib/explorer_web/templates/address_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:87
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
 #: lib/explorer_web/templates/chain/show.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:35
@@ -45,7 +45,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 msgid "Gas Used"
 msgstr "Gas Used"
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:86
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:35
@@ -73,8 +73,8 @@ msgstr "POA Network Explorer"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
@@ -170,10 +170,10 @@ msgstr "%{count} transactions in this block"
 msgid "Address"
 msgstr "Address"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:67
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:65
-#: lib/explorer_web/templates/address_transaction/index.html.eex:88
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:85
+#: lib/explorer_web/templates/address_transaction/index.html.eex:66
+#: lib/explorer_web/templates/address_transaction/index.html.eex:89
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
@@ -194,10 +194,10 @@ msgstr "Overview"
 msgid "Success"
 msgstr "Success"
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:55
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
-#: lib/explorer_web/templates/address_transaction/index.html.eex:53
-#: lib/explorer_web/templates/address_transaction/index.html.eex:90
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:54
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:54
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_transaction/index.html.eex:84
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction/index.html.eex:33
@@ -338,8 +338,8 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:24
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:88
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:87
+#: lib/explorer_web/templates/address_transaction/index.html.eex:92
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
@@ -367,7 +367,7 @@ msgstr ""
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:124
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
@@ -396,14 +396,14 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:49
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction/index.html.eex:48
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:92
+#: lib/explorer_web/templates/address_transaction/index.html.eex:93
 msgid "Fee"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Block Details"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:82
 msgid "Parent Tx Hash"
 msgstr ""
 
@@ -512,12 +512,13 @@ msgstr ""
 msgid "Contract bytecode"
 msgstr ""
 
+#: lib/explorer_web/templates/address_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:194
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:131
-#: lib/explorer_web/templates/address_transaction/index.html.eex:139
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:130
+#: lib/explorer_web/templates/address_transaction/index.html.eex:143
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:200
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
@@ -558,7 +559,7 @@ msgid "Newer"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:109
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:108
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
 msgid "Contract Creation"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_internal_transaction_controller_test.exs
@@ -179,5 +179,28 @@ defmodule ExplorerWeb.AddressInternalTransactionControllerTest do
 
       refute conn.assigns.next_page_params
     end
+
+    test "returns parent transaction for a contract address", %{conn: conn} do
+      address = insert(:address, contract_code: data(:address_contract_code))
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert(to_address: nil)
+        |> with_block(block)
+
+      internal_transaction =
+        insert(
+          :internal_transaction_create,
+          index: 0,
+          created_contract_address: address,
+          to_address: nil,
+          transaction: transaction
+        )
+
+      conn = get(conn, address_internal_transaction_path(conn, :index, :en, address))
+
+      assert internal_transaction.id == hd(conn.assigns.internal_transactions).id
+    end
   end
 end

--- a/apps/explorer_web/test/explorer_web/controllers/address_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_transaction_controller_test.exs
@@ -119,5 +119,27 @@ defmodule ExplorerWeb.AddressTransactionControllerTest do
 
       refute conn.assigns.next_page_params
     end
+
+    test "returns parent transaction for a contract address", %{conn: conn} do
+      address = insert(:address, contract_code: data(:address_contract_code))
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert(to_address: nil, created_contract_address_hash: address.hash)
+        |> with_block(block)
+
+      insert(
+        :internal_transaction_create,
+        index: 0,
+        created_contract_address: address,
+        to_address: nil,
+        transaction: transaction
+      )
+
+      conn = get(conn, address_transaction_path(conn, :index, :en, address))
+
+      assert [transaction] == conn.assigns.transactions
+    end
   end
 end


### PR DESCRIPTION
Resolves #297 

## Changelog

### Bug Fixes
* Display parent transaction/internal transaction on contract address page
* Don't display table headers when no transactions exist on address page
* Ensure transaction count includes contract creation transactions