### PR TITLE
Rename Gas Limit to Gas Used on Internal Transactions

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
@@ -31,7 +31,7 @@
               <th><%= gettext "From" %></th>
               <th><%= gettext "To" %></th>
               <th><%= gettext "Value" %> (<%= gettext "Ether" %>)</th>
-              <th><%= gettext "Gas Limit" %> (<%= gettext "Gas" %>)</th>
+              <th><%= gettext "Gas Used" %></th>
             </thead>
             <%= for internal_transaction <- @internal_transactions do %>
               <tgroup>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -30,6 +30,7 @@ msgstr ""
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:173
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr ""
 
@@ -84,7 +85,6 @@ msgstr ""
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
 #: lib/explorer_web/templates/transaction/overview.html.eex:140
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Limit"
 msgstr ""
 
@@ -132,7 +132,6 @@ msgstr ""
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/chain/_blocks.html.eex:10
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -42,6 +42,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:173
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr "Gas Used"
 
@@ -96,7 +97,6 @@ msgstr "Difficulty"
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
 #: lib/explorer_web/templates/transaction/overview.html.eex:140
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
@@ -144,7 +144,6 @@ msgstr "Cumulative Gas Used"
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/chain/_blocks.html.eex:10
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas"
 msgstr "Gas"
 


### PR DESCRIPTION
Fixes #321 

## Motivation

Internal transactions on the transaction details page show how much gas was used by each event of the parent transaction. Right now we are displaying `gas limit` which is incorrect.

## Changelog

Changed the `gettext` to `Gas Used` from `Gas Limit`

