### PR TITLE
Update ages in real-time

### DIFF
--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -100,7 +100,7 @@ defmodule Explorer.Chain.Statistics do
             lag: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             number: -1,
             skipped_blocks: 0,
-            timestamp: :calendar.universal_time(),
+            timestamp: nil,
             transaction_count: 0,
             transaction_velocity: 0,
             transactions: []

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -19,8 +19,9 @@ import 'bootstrap'
 // paths "./socket" or full ones "web/static/js/socket".
 
 // import socket from "./socket"
-import './lib/sidebar'
-import './lib/market_history_chart'
 import './lib/card_flip'
-import './lib/tooltip'
 import './lib/clipboard_buttons'
+import './lib/from_now'
+import './lib/market_history_chart'
+import './lib/sidebar'
+import './lib/tooltip'

--- a/apps/explorer_web/assets/js/lib/from_now.js
+++ b/apps/explorer_web/assets/js/lib/from_now.js
@@ -1,0 +1,26 @@
+import $ from 'jquery'
+import moment from 'moment'
+
+moment.relativeTimeThreshold('M', 12)
+moment.relativeTimeThreshold('d', 30)
+moment.relativeTimeThreshold('h', 24)
+moment.relativeTimeThreshold('m', 60)
+moment.relativeTimeThreshold('s', 60)
+moment.relativeTimeThreshold('ss', 1)
+
+function updateAllAges () {
+  $('[data-from-now]').each((i, el) => tryUpdateAge(el))
+}
+function tryUpdateAge (el) {
+  if (!el.dataset.fromNow) return
+
+  const timestamp = moment(el.dataset.fromNow)
+  if (timestamp.isValid()) updateAge(el, timestamp)
+}
+function updateAge (el, timestamp) {
+  const fromNow = timestamp.fromNow()
+  if (fromNow !== el.innerHTML) el.innerHTML = fromNow
+}
+updateAllAges()
+
+setInterval(updateAllAges, 1000)

--- a/apps/explorer_web/assets/js/lib/from_now.js
+++ b/apps/explorer_web/assets/js/lib/from_now.js
@@ -1,6 +1,8 @@
 import $ from 'jquery'
 import moment from 'moment'
 
+moment.locale(window.locale)
+
 moment.relativeTimeThreshold('M', 12)
 moment.relativeTimeThreshold('d', 30)
 moment.relativeTimeThreshold('h', 24)

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/index.html.eex
@@ -97,7 +97,7 @@
                       to: block_path(@conn, :show, @conn.assigns.locale, internal_transaction.transaction.block)
                       ) %>
                   </td>
-                  <td><%= ExplorerWeb.BlockView.age(internal_transaction.transaction.block) %></td>
+                  <td data-from-now="<%= internal_transaction.transaction.block.timestamp %>"></td>
                   <td>
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: internal_transaction.from_address %>
                   </td>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/index.html.eex
@@ -106,7 +106,7 @@
                         to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
                       ) %>
                 </td>
-                <td><%= transaction.block.timestamp |> Timex.from_now %></td>
+                <td data-from-now="<%= transaction.block.timestamp %>"></td>
                 <td class="address-cell">
                   <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
                 </td>

--- a/apps/explorer_web/lib/explorer_web/templates/block/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block/index.html.eex
@@ -34,7 +34,7 @@
                       "data-block-number": to_string(block.number)
                     ) %>
               </td>
-              <td><%= block.timestamp |> Timex.from_now  %></td>
+              <td data-from-now="<%= block.timestamp %>"></td>
               <td>
                 <%= gettext("%{count} transactions", count: block.transactions |> Enum.count) %>
               </td>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -14,7 +14,7 @@
                     <%= gettext "Timestamp" %>
                   </th>
                   <td>
-                    <%= age(@block) %> (<%= formatted_timestamp(@block) %>)
+                    <span data-from-now="<%= @block.timestamp %>"></span> (<%= formatted_timestamp(@block) %>)
                   </td>
                 </tr>
                 <tr>
@@ -160,9 +160,7 @@
                           to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
                         ) %>
                   </td>
-                  <td>
-                    <%= transaction.block.timestamp |> Timex.from_now %>
-                  </td>
+                  <td data-from-now="<%= transaction.block.timestamp %>"></td>
                   <td class="address-cell">
                     <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
                   </td>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_blocks.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_blocks.html.eex
@@ -17,7 +17,7 @@
             <img src="<%= static_path(@conn, "/images/block.svg") %>" />
             <%= link(block, to: block_path(@conn, :show, @conn.assigns.locale, block)) %>
           </td>
-          <td><%= block.timestamp |> Timex.from_now %></td>
+          <td data-from-now="<%= block.timestamp %>"></td>
           <td><%= block.transactions |> Enum.count %></td>
           <td><%= block.gas_used |> Cldr.Number.to_string! %></td>
           <td>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -36,7 +36,7 @@
             <% end %>
           </td>
           <td><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> </td>
-          <td><%= transaction.block.timestamp |> Timex.from_now() %></td>
+          <td data-from-now="<%= transaction.block.timestamp %>"></td>
         </tr>
         <% end %>
       </tbody>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/show.html.eex
@@ -10,7 +10,7 @@
         <div class="d-flex flex-column justify-content-center align-items-center">
           <%= render ExplorerWeb.IconsView, "_hourglass_icon.html", assigns %>
           <div> <%= gettext("Last Block") %></div>
-          <div> <%= @chain.timestamp |> Timex.from_now() %></div>
+          <div data-from-now="<%= @chain.timestamp %>"></div>
         </div>
         <div class="d-flex flex-column justify-content-center align-items-center">
           <div class="stroke"> <%= render ExplorerWeb.IconsView, "_guage_icon.html", assigns %> </div>

--- a/apps/explorer_web/lib/explorer_web/templates/layout/app.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/layout/app.html.eex
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= gettext "POA Network Explorer" %></title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <script>
+     window.locale = '<%= @conn.assigns.locale %>'
+    </script>
   </head>
 
   <body>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -48,7 +48,7 @@
               <td>
               <%= render ExplorerWeb.TransactionView, "_link.html", conn: @conn, transaction: transaction %>
               </td>
-              <td><%= last_seen(transaction) %></td>
+              <td data-from-now="<%= transaction.updated_at %>"></td>
               <td>
                 <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
               </td>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -55,9 +55,7 @@
                       to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
                     ) %>
               </td>
-              <td>
-                <%= transaction.block.timestamp %>
-              </td>
+              <td data-from-now="<%= transaction.block.timestamp %>"></td>
               <td>
                 <%= render ExplorerWeb.AddressView, "_link.html", conn: @conn, address: transaction.from_address %>
               </td>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -48,8 +48,12 @@
                 <th scope="row">
                   <%= gettext "Age" %>
                 </th>
-                <td title="<%= formatted_timestamp(@transaction) %>">
-                  <%= formatted_age(@transaction) %>
+                <td>
+                  <%= if block do %>
+                    <span data-from-now="<%= @transaction.block.timestamp %>"></span> (<%= formatted_timestamp(@transaction.block) %>)
+                  <% else %>
+                    <%= gettext "Pending" %>
+                  <% end %>
                 </td>
               </tr>
               <tr>
@@ -121,19 +125,13 @@
                 <th scope="row">
                   <%= gettext "First Seen" %>
                 </th>
-                <% first_seen = first_seen(@transaction) %>
-                <td title="<%= first_seen %>">
-                  <%= first_seen %>
-                </td>
+                <td data-from-now="<%= @transaction.inserted_at %>"></td>
               </tr>
               <tr>
                 <th scope="row">
                   <%= gettext "Last Seen" %>
                 </th>
-                <% last_seen = last_seen(@transaction) %>
-                <td title="<%= last_seen %>">
-                  <%= last_seen %>
-                </td>
+                <td data-from-now="<%= @transaction.updated_at %>"></td>
               </tr>
               <tr>
                 <th scope="row">

--- a/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
@@ -3,7 +3,6 @@ defmodule ExplorerWeb.BlockTransactionView do
 
   alias ExplorerWeb.{BlockView, TransactionView}
 
-  defdelegate age(block), to: BlockView
   defdelegate formatted_timestamp(block), to: BlockView
   defdelegate status(transacton), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/block_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/block_view.ex
@@ -7,10 +7,6 @@ defmodule ExplorerWeb.BlockView do
 
   @dialyzer :no_match
 
-  def age(%Block{timestamp: timestamp}) do
-    Timex.from_now(timestamp)
-  end
-
   def average_gas_price(%Block{transactions: transactions}) do
     average =
       transactions

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -1,9 +1,5 @@
 defmodule ExplorerWeb.PendingTransactionView do
   use ExplorerWeb, :view
 
-  alias ExplorerWeb.TransactionView
-
   @dialyzer :no_match
-
-  defdelegate last_seen(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/transaction_view.ex
@@ -53,10 +53,6 @@ defmodule ExplorerWeb.TransactionView do
     {fee_type, formatted}
   end
 
-  def first_seen(%Transaction{inserted_at: inserted_at}) do
-    Timex.from_now(inserted_at)
-  end
-
   def format_gas_limit(gas) do
     Number.to_string!(gas)
   end
@@ -67,19 +63,7 @@ defmodule ExplorerWeb.TransactionView do
     format_usd_value(USD.from(value, token))
   end
 
-  def formatted_age(%Transaction{block: block}) do
-    case block do
-      nil -> gettext("Pending")
-      _ -> "#{BlockView.age(block)} (#{BlockView.formatted_timestamp(block)})"
-    end
-  end
-
-  def formatted_timestamp(%Transaction{block: block}) do
-    case block do
-      nil -> gettext("Pending")
-      _ -> BlockView.formatted_timestamp(block)
-    end
-  end
+  defdelegate formatted_timestamp(block), to: BlockView
 
   defguardp is_transaction_type(mod) when mod in [InternalTransaction, Transaction]
 
@@ -96,10 +80,6 @@ defmodule ExplorerWeb.TransactionView do
 
   def hash(%Transaction{hash: hash}) do
     to_string(hash)
-  end
-
-  def last_seen(%Transaction{updated_at: updated_at}) do
-    Timex.from_now(updated_at)
   end
 
   def status(transaction) do

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -29,7 +29,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction/overview.html.eex:173
+#: lib/explorer_web/templates/transaction/overview.html.eex:171
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr ""
@@ -68,8 +68,8 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:65
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:140
+#: lib/explorer_web/templates/transaction/overview.html.eex:138
 msgid "Gas Limit"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgid "Miner"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:108
+#: lib/explorer_web/templates/transaction/overview.html.eex:112
 msgid "Nonce"
 msgstr ""
 
@@ -136,11 +136,11 @@ msgid "Gas"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:148
+#: lib/explorer_web/templates/transaction/overview.html.eex:146
 msgid "Gas Price"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:181
+#: lib/explorer_web/templates/transaction/overview.html.eex:179
 msgid "Input"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:37
-#: lib/explorer_web/templates/transaction/overview.html.eex:73
+#: lib/explorer_web/templates/transaction/overview.html.eex:77
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
 #: lib/explorer_web/views/address_transaction_view.ex:11
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:116
+#: lib/explorer_web/views/transaction_view.ex:96
 msgid "Success"
 msgstr ""
 
@@ -189,7 +189,7 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
-#: lib/explorer_web/templates/transaction/overview.html.eex:85
+#: lib/explorer_web/templates/transaction/overview.html.eex:89
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
 #: lib/explorer_web/views/address_transaction_view.ex:10
@@ -236,19 +236,18 @@ msgstr ""
 #: lib/explorer_web/templates/layout/_topnav.html.eex:31
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:21
 #: lib/explorer_web/templates/transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/overview.html.eex:55
 #: lib/explorer_web/views/transaction_view.ex:18
-#: lib/explorer_web/views/transaction_view.ex:72
-#: lib/explorer_web/views/transaction_view.ex:79
-#: lib/explorer_web/views/transaction_view.ex:115
+#: lib/explorer_web/views/transaction_view.ex:95
 msgid "Pending"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:122
+#: lib/explorer_web/templates/transaction/overview.html.eex:126
 msgid "First Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/transaction/overview.html.eex:131
+#: lib/explorer_web/templates/transaction/overview.html.eex:132
 msgid "Last Seen"
 msgstr ""
 
@@ -301,11 +300,11 @@ msgstr ""
 msgid "Next Page"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:113
+#: lib/explorer_web/views/transaction_view.ex:93
 msgid "Failed"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:114
+#: lib/explorer_web/views/transaction_view.ex:94
 msgid "Out of Gas"
 msgstr ""
 
@@ -330,14 +329,14 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:157
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr ""
 
-#: lib/explorer_web/views/block_view.ex:22
+#: lib/explorer_web/views/block_view.ex:18
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
@@ -426,8 +425,8 @@ msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:32
-#: lib/explorer_web/templates/transaction/overview.html.eex:65
-#: lib/explorer_web/templates/transaction/overview.html.eex:165
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
@@ -481,8 +480,8 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:157
-#: lib/explorer_web/templates/transaction/overview.html.eex:165
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
 msgid "TX Fee"
 msgstr ""
 
@@ -500,16 +499,16 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/address_transaction/index.html.eex:137
-#: lib/explorer_web/templates/block_transaction/index.html.eex:194
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:130
 #: lib/explorer_web/templates/address_transaction/index.html.eex:143
 #: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:200
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:90
+#: lib/explorer_web/templates/transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -41,7 +41,7 @@ msgstr "%{year} POA Network Ltd. All rights reserved"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
-#: lib/explorer_web/templates/transaction/overview.html.eex:173
+#: lib/explorer_web/templates/transaction/overview.html.eex:171
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr "Gas Used"
@@ -80,8 +80,8 @@ msgstr "Transactions"
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:65
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr "Value"
@@ -96,7 +96,7 @@ msgstr "Difficulty"
 
 #: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:140
+#: lib/explorer_web/templates/transaction/overview.html.eex:138
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
@@ -105,7 +105,7 @@ msgid "Miner"
 msgstr "Validator"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:108
+#: lib/explorer_web/templates/transaction/overview.html.eex:112
 msgid "Nonce"
 msgstr "Nonce"
 
@@ -148,11 +148,11 @@ msgid "Gas"
 msgstr "Gas"
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:148
+#: lib/explorer_web/templates/transaction/overview.html.eex:146
 msgid "Gas Price"
 msgstr "Gas Price"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:181
+#: lib/explorer_web/templates/transaction/overview.html.eex:179
 msgid "Input"
 msgstr "Input"
 
@@ -177,7 +177,7 @@ msgstr "Address"
 #: lib/explorer_web/templates/chain/_transactions.html.eex:8
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:37
 #: lib/explorer_web/templates/transaction/index.html.eex:37
-#: lib/explorer_web/templates/transaction/overview.html.eex:73
+#: lib/explorer_web/templates/transaction/overview.html.eex:77
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
 #: lib/explorer_web/views/address_transaction_view.ex:11
@@ -189,7 +189,7 @@ msgstr "From"
 msgid "Overview"
 msgstr "Overview"
 
-#: lib/explorer_web/views/transaction_view.ex:116
+#: lib/explorer_web/views/transaction_view.ex:96
 msgid "Success"
 msgstr "Success"
 
@@ -201,7 +201,7 @@ msgstr "Success"
 #: lib/explorer_web/templates/chain/_transactions.html.eex:9
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:38
 #: lib/explorer_web/templates/transaction/index.html.eex:38
-#: lib/explorer_web/templates/transaction/overview.html.eex:85
+#: lib/explorer_web/templates/transaction/overview.html.eex:89
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
 #: lib/explorer_web/views/address_transaction_view.ex:10
@@ -248,19 +248,18 @@ msgstr "Showing %{count} Transactions"
 #: lib/explorer_web/templates/layout/_topnav.html.eex:31
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:21
 #: lib/explorer_web/templates/transaction/index.html.eex:21
+#: lib/explorer_web/templates/transaction/overview.html.eex:55
 #: lib/explorer_web/views/transaction_view.ex:18
-#: lib/explorer_web/views/transaction_view.ex:72
-#: lib/explorer_web/views/transaction_view.ex:79
-#: lib/explorer_web/views/transaction_view.ex:115
+#: lib/explorer_web/views/transaction_view.ex:95
 msgid "Pending"
 msgstr "Pending"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:122
+#: lib/explorer_web/templates/transaction/overview.html.eex:126
 msgid "First Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:36
-#: lib/explorer_web/templates/transaction/overview.html.eex:131
+#: lib/explorer_web/templates/transaction/overview.html.eex:132
 msgid "Last Seen"
 msgstr ""
 
@@ -313,11 +312,11 @@ msgstr ""
 msgid "Next Page"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:113
+#: lib/explorer_web/views/transaction_view.ex:93
 msgid "Failed"
 msgstr ""
 
-#: lib/explorer_web/views/transaction_view.ex:114
+#: lib/explorer_web/views/transaction_view.ex:94
 msgid "Out of Gas"
 msgstr ""
 
@@ -342,14 +341,14 @@ msgstr ""
 #: lib/explorer_web/templates/chain/_transactions.html.eex:10
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:39
 #: lib/explorer_web/templates/transaction/index.html.eex:39
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:157
+#: lib/explorer_web/templates/transaction/overview.html.eex:61
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr "POA"
 
-#: lib/explorer_web/views/block_view.ex:22
+#: lib/explorer_web/views/block_view.ex:18
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
@@ -438,8 +437,8 @@ msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:32
-#: lib/explorer_web/templates/transaction/overview.html.eex:65
-#: lib/explorer_web/templates/transaction/overview.html.eex:165
+#: lib/explorer_web/templates/transaction/overview.html.eex:69
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
@@ -493,8 +492,8 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:157
-#: lib/explorer_web/templates/transaction/overview.html.eex:165
+#: lib/explorer_web/templates/transaction/overview.html.eex:155
+#: lib/explorer_web/templates/transaction/overview.html.eex:163
 msgid "TX Fee"
 msgstr ""
 
@@ -512,16 +511,16 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/address_transaction/index.html.eex:137
-#: lib/explorer_web/templates/block_transaction/index.html.eex:194
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:130
 #: lib/explorer_web/templates/address_transaction/index.html.eex:143
 #: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:200
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:69
-#: lib/explorer_web/templates/transaction/index.html.eex:90
+#: lib/explorer_web/templates/transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""


### PR DESCRIPTION
Resolves: #313

## Motivation

This will make sure as we live-update lists across the app we don't let ages get stale, which would result in full pages of `1 second ago`s that were live inserted.

## Changelog

### Enhancements
- Calculate ages using Javascript every 1000ms and update the DOM accordingly.

### Bug Fixes
- We were using `Timex.from_now` which does not get localized. The moment equivalent this PR transitions to does get localized.

## Notes
- I've done the most basic of performance optimizations and tested with a page size of 10k. Everything seems to be fine.