### PR TITLE
Fix homepage timeout #330

### DIFF
--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -13,10 +13,9 @@ defmodule Explorer.Chain.Statistics do
   @average_time_query """
     SELECT coalesce(avg(difference), interval '0 seconds')
     FROM (
-      SELECT timestamp - lag(timestamp) over (order by timestamp) as difference
-      FROM blocks
-      ORDER BY number DESC
-      LIMIT 100
+      SELECT b.timestamp - lag(b.timestamp) over (order by b.timestamp) as difference
+      FROM (SELECT * FROM blocks ORDER BY number DESC LIMIT 101) b
+      LIMIT 100 OFFSET 1
     ) t
   """
 

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -20,13 +20,6 @@ defmodule Explorer.Chain.Statistics do
     ) t
   """
 
-  @transaction_count_query """
-    SELECT count(transactions.hash)
-      FROM transactions
-      JOIN blocks ON blocks.hash = transactions.block_hash
-      WHERE blocks.timestamp > NOW() - interval '1 day'
-  """
-
   @lag_query """
     SELECT coalesce(avg(lag), interval '0 seconds')
     FROM (
@@ -69,7 +62,6 @@ defmodule Explorer.Chain.Statistics do
    * `number` - the latest `t:Explorer.Chain.Block.t/0` `number`
      `t:Explorer.Chain.Block.t/0`
    * `timestamp` - when the last `t:Explorer.Chain.Block.t/0` was mined/validated
-   * `transaction_count` - the number of transactions confirmed in blocks that were mined/validated in the last day
    * `transaction_velocity` - the number of `t:Explorer.Chain.Block.t/0` mined/validated in the last minute
    * `transactions` - the last <= 5 `t:Explorer.Chain.Transaction.t/0`
   """
@@ -80,7 +72,6 @@ defmodule Explorer.Chain.Statistics do
           lag: Duration.t(),
           number: Block.block_number(),
           timestamp: :calendar.datetime(),
-          transaction_count: non_neg_integer(),
           transaction_velocity: transactions_per_minute(),
           transactions: [Transaction.t()]
         }
@@ -91,7 +82,6 @@ defmodule Explorer.Chain.Statistics do
             lag: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             number: -1,
             timestamp: nil,
-            transaction_count: 0,
             transaction_velocity: 0,
             transactions: []
 
@@ -119,7 +109,6 @@ defmodule Explorer.Chain.Statistics do
       block_velocity: query_value(@block_velocity_query),
       blocks: Repo.all(blocks),
       lag: query_duration(@lag_query),
-      transaction_count: query_value(@transaction_count_query),
       transaction_velocity: query_value(@transaction_velocity_query),
       transactions: transactions
     }

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -27,13 +27,6 @@ defmodule Explorer.Chain.Statistics do
       WHERE blocks.timestamp > NOW() - interval '1 day'
   """
 
-  @skipped_blocks_query """
-    SELECT COUNT(missing_number)
-      FROM generate_series(0, $1, 1) AS missing_number
-      LEFT JOIN blocks ON missing_number = blocks.number
-      WHERE blocks.hash IS NULL
-  """
-
   @lag_query """
     SELECT coalesce(avg(lag), interval '0 seconds')
     FROM (
@@ -74,7 +67,6 @@ defmodule Explorer.Chain.Statistics do
      (`t:Explorer.Chain.Block.t/0` `timestamp`) and when it was inserted into the databasse
      (`t:Explorer.Chain.Block.t/0` `inserted_at`)
    * `number` - the latest `t:Explorer.Chain.Block.t/0` `number`
-   * `skipped_blocks` - the number of blocks that were mined/validated, but do not exist as
      `t:Explorer.Chain.Block.t/0`
    * `timestamp` - when the last `t:Explorer.Chain.Block.t/0` was mined/validated
    * `transaction_count` - the number of transactions confirmed in blocks that were mined/validated in the last day
@@ -87,7 +79,6 @@ defmodule Explorer.Chain.Statistics do
           blocks: [Block.t()],
           lag: Duration.t(),
           number: Block.block_number(),
-          skipped_blocks: non_neg_integer(),
           timestamp: :calendar.datetime(),
           transaction_count: non_neg_integer(),
           transaction_velocity: transactions_per_minute(),
@@ -99,7 +90,6 @@ defmodule Explorer.Chain.Statistics do
             blocks: [],
             lag: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             number: -1,
-            skipped_blocks: 0,
             timestamp: nil,
             transaction_count: 0,
             transaction_velocity: 0,
@@ -142,7 +132,6 @@ defmodule Explorer.Chain.Statistics do
         %__MODULE__{
           state
           | number: number,
-            skipped_blocks: query_value(@skipped_blocks_query, [number]),
             timestamp: timestamp
         }
 

--- a/apps/explorer/priv/repo/migrations/20180626143840_add_inserted_at_index_to_blocks.exs
+++ b/apps/explorer/priv/repo/migrations/20180626143840_add_inserted_at_index_to_blocks.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddInsertedAtIndexToBlocks do
+  use Ecto.Migration
+
+  def change do
+    create(index(:blocks, :inserted_at))
+  end
+end

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -60,15 +60,6 @@ defmodule Explorer.Chain.StatisticsTest do
       assert %Statistics{transaction_count: 1} = Statistics.fetch()
     end
 
-    test "returns the number of skipped blocks" do
-      insert(:block, %{number: 0})
-      insert(:block, %{number: 2})
-
-      statistics = Statistics.fetch()
-
-      assert statistics.skipped_blocks == 1
-    end
-
     test "returns the lag between validation and insertion time" do
       validation_time = DateTime.utc_now()
       inserted_at = validation_time |> Timex.shift(seconds: 5)

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -27,11 +27,14 @@ defmodule Explorer.Chain.StatisticsTest do
       assert Timex.diff(statistics.timestamp, time, :seconds) == 0
     end
 
-    test "returns the average time between blocks" do
+    test "returns the average time between blocks for the last 100 blocks" do
       time = DateTime.utc_now()
-      next_time = Timex.shift(time, seconds: 5)
-      insert(:block, timestamp: time)
-      insert(:block, timestamp: next_time)
+
+      insert(:block, timestamp: Timex.shift(time, seconds: -1000))
+
+      for x <- 100..0 do
+        insert(:block, timestamp: Timex.shift(time, seconds: -5 * x))
+      end
 
       assert %Statistics{
                average_time: %Duration{

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -42,24 +42,6 @@ defmodule Explorer.Chain.StatisticsTest do
              } = Statistics.fetch()
     end
 
-    test "returns the count of transactions from blocks in the last day" do
-      time = DateTime.utc_now()
-      block = insert(:block, timestamp: time)
-
-      :transaction
-      |> insert()
-      |> with_block(block)
-
-      last_week = Timex.shift(time, days: -8)
-      old_block = insert(:block, timestamp: last_week)
-
-      :transaction
-      |> insert()
-      |> with_block(old_block)
-
-      assert %Statistics{transaction_count: 1} = Statistics.fetch()
-    end
-
     test "returns the lag between validation and insertion time" do
       validation_time = DateTime.utc_now()
       inserted_at = validation_time |> Timex.shift(seconds: 5)


### PR DESCRIPTION
Fixes #330 

Anecdotal performance change in development: page response time from > 15 seconds (timeout) to average response time < 20ms (see "Optimization Details" section for more specific information)

## Changelog

### Bug Fixes

* Removes unused queries in `Explorer.Chain.Statistics` that accounted for 17s (exceeding the timeout) of wall time 
* Optimizes slow average block time query by limiting result set that window function uses to calculate average block time
* Optimizes slow velocity query by indexing `inserted_at` on `blocks`


### Optimization Details

#### Average block time

Before: 

Query
```sql
SELECT timestamp - lag(timestamp) over (order by timestamp) as difference
FROM blocks
ORDER BY number DESC
LIMIT 100
```

Query Plan
```
Limit  (cost=378073.38..378073.63 rows=100 width=32) (actual time=4071.147..4071.178 rows=100 loops=1)
  ->  Sort  (cost=378073.38..383706.97 rows=2253434 width=32) (actual time=4071.146..4071.157 rows=100 loops=1)
        Sort Key: number DESC
        Sort Method: top-N heapsort  Memory: 40kB
        ->  WindowAgg  (cost=0.43..291948.75 rows=2253434 width=32) (actual time=0.056..3187.384 rows=2253357 loops=1)
              ->  Index Scan using blocks_timestamp_index on blocks  (cost=0.43..252513.66 rows=2253434 width=16) (actual time=0.051..1394.942 rows=2253357 loops=1)
Planning time: 0.277 ms
Execution time: 4071.239 ms
```

After:

Query
```sql
SELECT b.timestamp - lag(b.timestamp) over (order by b.timestamp) as difference
FROM (SELECT * FROM blocks ORDER BY number DESC LIMIT 101) b -- LIMIT WINDOW TO SUBSET OF TABLE
LIMIT 100 OFFSET 1
```

Query Plan
```
Limit  (cost=16.14..18.14 rows=100 width=24) (actual time=0.182..0.233 rows=100 loops=1)
  ->  WindowAgg  (cost=16.12..18.14 rows=101 width=24) (actual time=0.180..0.222 rows=101 loops=1)
        ->  Sort  (cost=16.12..16.37 rows=101 width=8) (actual time=0.174..0.181 rows=101 loops=1)
              Sort Key: b."timestamp"
              Sort Method: quicksort  Memory: 29kB
              ->  Subquery Scan on b  (cost=0.43..12.76 rows=101 width=8) (actual time=0.080..0.153 rows=101 loops=1)
                    ->  Limit  (cost=0.43..11.75 rows=101 width=212) (actual time=0.079..0.139 rows=101 loops=1)
                          ->  Index Scan Backward using blocks_number_index on blocks  (cost=0.43..252465.66 rows=2253434 width=212) (actual time=0.079..0.126 rows=101 loops=1)
Planning time: 0.096 ms
Execution time: 0.266 ms
```

#### Block velocity query

Query
```sql
SELECT count(blocks.hash)
FROM blocks
WHERE blocks.inserted_at > NOW() - interval '1 minute'
```

Before `inserted_at` index Query Plan (Sequential Scan):
```
Aggregate  (cost=109818.80..109818.81 rows=1 width=8) (actual time=701.353..701.353 rows=1 loops=1)
  ->  Seq Scan on blocks  (cost=0.00..109818.24 rows=223 width=33) (actual time=701.351..701.351 rows=0 loops=1)
        Filter: (inserted_at > (now() - '00:01:00'::interval))
        Rows Removed by Filter: 2252058
Planning time: 0.095 ms
Execution time: 701.390 ms
```

After `inserted_at` index Query Plan (Index Scan):
```
Aggregate  (cost=6.11..6.12 rows=1 width=8) (actual time=0.640..0.641 rows=1 loops=1)
  ->  Index Scan using blocks_inserted_at_index on blocks  (cost=0.43..6.10 rows=1 width=33) (actual time=0.041..0.461 rows=1299 loops=1)
        Index Cond: (inserted_at > (now() - '00:01:00'::interval))
Planning time: 0.143 ms
Execution time: 0.673 ms
```