### PR TITLE
More home page query optimizations

### DIFF
--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -30,7 +30,7 @@ defmodule Explorer.Chain.Statistics do
   """
 
   @block_velocity_query """
-    SELECT count(blocks.hash)
+    SELECT count(blocks.inserted_at)
       FROM blocks
       WHERE blocks.inserted_at > NOW() - interval '1 minute'
   """

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -29,12 +29,6 @@ defmodule Explorer.Chain.Statistics do
     ) t
   """
 
-  @block_velocity_query """
-    SELECT count(blocks.inserted_at)
-      FROM blocks
-      WHERE blocks.inserted_at > NOW() - interval '1 minute'
-  """
-
   @transaction_velocity_query """
     SELECT count(transactions.inserted_at)
       FROM transactions
@@ -53,7 +47,6 @@ defmodule Explorer.Chain.Statistics do
 
   @typedoc """
    * `average_time` - the average time it took to mine/validate the last <= 100 `t:Explorer.Chain.Block.t/0`
-   * `block_velocity` - the number of `t:Explorer.Chain.Block.t/0` mined/validated in the last minute
    * `blocks` - the last <= 5 `t:Explorer.Chain.Block.t/0`
    * `lag` - the average time over the last hour between when the block was mined/validated
      (`t:Explorer.Chain.Block.t/0` `timestamp`) and when it was inserted into the databasse
@@ -66,7 +59,6 @@ defmodule Explorer.Chain.Statistics do
   """
   @type t :: %__MODULE__{
           average_time: Duration.t(),
-          block_velocity: blocks_per_minute(),
           blocks: [Block.t()],
           lag: Duration.t(),
           number: Block.block_number(),
@@ -76,7 +68,6 @@ defmodule Explorer.Chain.Statistics do
         }
 
   defstruct average_time: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
-            block_velocity: 0,
             blocks: [],
             lag: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             number: -1,
@@ -105,7 +96,6 @@ defmodule Explorer.Chain.Statistics do
 
     %__MODULE__{
       average_time: query_duration(@average_time_query),
-      block_velocity: query_value(@block_velocity_query),
       blocks: Repo.all(blocks),
       lag: query_duration(@lag_query),
       transaction_velocity: query_value(@transaction_velocity_query),

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -19,16 +19,6 @@ defmodule Explorer.Chain.Statistics do
     ) t
   """
 
-  @lag_query """
-    SELECT coalesce(avg(lag), interval '0 seconds')
-    FROM (
-      SELECT inserted_at - timestamp AS lag
-      FROM blocks
-      WHERE blocks.inserted_at > NOW() - interval '1 hour'
-        AND blocks.timestamp > NOW() - interval '1 hour'
-    ) t
-  """
-
   @transaction_velocity_query """
     SELECT count(transactions.inserted_at)
       FROM transactions
@@ -48,7 +38,6 @@ defmodule Explorer.Chain.Statistics do
   @typedoc """
    * `average_time` - the average time it took to mine/validate the last <= 100 `t:Explorer.Chain.Block.t/0`
    * `blocks` - the last <= 5 `t:Explorer.Chain.Block.t/0`
-   * `lag` - the average time over the last hour between when the block was mined/validated
      (`t:Explorer.Chain.Block.t/0` `timestamp`) and when it was inserted into the databasse
      (`t:Explorer.Chain.Block.t/0` `inserted_at`)
    * `number` - the latest `t:Explorer.Chain.Block.t/0` `number`
@@ -60,7 +49,6 @@ defmodule Explorer.Chain.Statistics do
   @type t :: %__MODULE__{
           average_time: Duration.t(),
           blocks: [Block.t()],
-          lag: Duration.t(),
           number: Block.block_number(),
           timestamp: :calendar.datetime(),
           transaction_velocity: transactions_per_minute(),
@@ -69,7 +57,6 @@ defmodule Explorer.Chain.Statistics do
 
   defstruct average_time: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             blocks: [],
-            lag: %Duration{seconds: 0, megaseconds: 0, microseconds: 0},
             number: -1,
             timestamp: nil,
             transaction_velocity: 0,
@@ -97,7 +84,6 @@ defmodule Explorer.Chain.Statistics do
     %__MODULE__{
       average_time: query_duration(@average_time_query),
       blocks: Repo.all(blocks),
-      lag: query_duration(@lag_query),
       transaction_velocity: query_value(@transaction_velocity_query),
       transactions: transactions
     }

--- a/apps/explorer/lib/explorer/chain/statistics.ex
+++ b/apps/explorer/lib/explorer/chain/statistics.ex
@@ -36,7 +36,7 @@ defmodule Explorer.Chain.Statistics do
   """
 
   @transaction_velocity_query """
-    SELECT count(transactions.hash)
+    SELECT count(transactions.inserted_at)
       FROM transactions
       WHERE transactions.inserted_at > NOW() - interval '1 minute'
   """

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -45,14 +45,6 @@ defmodule Explorer.Chain.StatisticsTest do
              } = Statistics.fetch()
     end
 
-    test "returns the lag between validation and insertion time" do
-      validation_time = DateTime.utc_now()
-      inserted_at = validation_time |> Timex.shift(seconds: 5)
-      insert(:block, timestamp: validation_time, inserted_at: inserted_at)
-
-      assert %Statistics{lag: %Duration{seconds: 5, megaseconds: 0, microseconds: 0}} = Statistics.fetch()
-    end
-
     test "returns the number of transactions inserted in the last minute" do
       old_inserted_at = Timex.shift(DateTime.utc_now(), days: -1)
       insert(:transaction, inserted_at: old_inserted_at)

--- a/apps/explorer/test/explorer/chain/statistics_test.exs
+++ b/apps/explorer/test/explorer/chain/statistics_test.exs
@@ -53,16 +53,6 @@ defmodule Explorer.Chain.StatisticsTest do
       assert %Statistics{lag: %Duration{seconds: 5, megaseconds: 0, microseconds: 0}} = Statistics.fetch()
     end
 
-    test "returns the number of blocks inserted in the last minute" do
-      old_inserted_at = Timex.shift(DateTime.utc_now(), days: -1)
-      insert(:block, inserted_at: old_inserted_at)
-      insert(:block)
-
-      statistics = Statistics.fetch()
-
-      assert statistics.block_velocity == 1
-    end
-
     test "returns the number of transactions inserted in the last minute" do
       old_inserted_at = Timex.shift(DateTime.utc_now(), days: -1)
       insert(:transaction, inserted_at: old_inserted_at)


### PR DESCRIPTION
Fixes #330 

## Changelog

### Bug Fixes

* Remove unused blocks per minute query
* Remove unused lag query
* Avoid table lookups for transactions per minute count query by selecting `inserted_at` column in index

### Optimization Details

#### Block velocity (BPM) query

Before:

Query
```sql
SELECT count(transactions.hash)
FROM transactions
WHERE transactions.inserted_at > NOW() - interval '1 minute'
```

Query Plan
```
Aggregate  (cost=138034.35..138034.36 rows=1 width=8) (actual time=221.715..221.715 rows=1 loops=1)
  ->  Bitmap Heap Scan on transactions  (cost=4053.99..137676.42 rows=143169 width=33) (actual time=27.196..200.698 rows=145075 loops=1)
        Recheck Cond: (inserted_at > (now() - '00:01:00'::interval))
        Heap Blocks: exact=22256
        ->  Bitmap Index Scan on transactions_inserted_at_index  (cost=0.00..4018.20 rows=143169 width=0) (actual time=23.933..23.933 rows=145075 loops=1)
              Index Cond: (inserted_at > (now() - '00:01:00'::interval))
Planning time: 0.474 ms
Execution time: 221.756 ms
```

After:

Query
```sql
SELECT count(transactions.inserted_at)
FROM transactions
WHERE transactions.inserted_at > NOW() - interval '1 minute'
```

Query Plan
```
Aggregate  (cost=5807.81..5807.82 rows=1 width=8) (actual time=46.037..46.038 rows=1 loops=1)
  ->  Index Only Scan using transactions_inserted_at_index on transactions  (cost=0.43..5449.89 rows=143169 width=8) (actual time=0.038..32.903 rows=145075 loops=1)
        Index Cond: (inserted_at > (now() - '00:01:00'::interval))
        Heap Fetches: 0
Planning time: 0.122 ms
Execution time: 46.064 ms
```