### PR TITLE
Update Readme fix LGPLv3 to GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and pull request protoco
 
 ## License
 
-[![License: LGPL v3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+[![License: GPL v3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-This project is licensed under the GNU Lesser General Public License v3.0. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
### Bug Fixes
Change `LGPLv3` to `GPLv3` in README.md to reflect the correct license. 