### PR TITLE
Real-time indexing starting from the last indexed Block

### DIFF
--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -294,7 +294,7 @@ defmodule Indexer.BlockFetcher do
   end
 
   defp realtime_task(%{} = state) do
-    {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest")
+    {:ok, latest_block_number} = Chain.max_block_number()
     {:ok, seq} = Sequence.start_link([], latest_block_number, 2)
     stream_import(state, seq, max_concurrency: 1)
   end


### PR DESCRIPTION
Fixes #332

Getting the last indexed block number seems to solve the problem. 

I have a few suspects of what has caused the bug but I lack comprehension from the Indexer most particular rules (mostly the Sequence).

I'd like to understand better what caused it before merging, but we can move on since this is a critical bug. 

After this, I'll start exploring #341 and I believe I would be more capable of explaining what happened here and write a few tests for this behavior.