### PR TITLE
Set realtime interval to 5 seconds

### DIFF
--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -73,7 +73,7 @@ defmodule Indexer.BlockFetcher do
     state = %{
       genesis_task: nil,
       realtime_task: nil,
-      realtime_interval: (opts[:block_rate] || @block_rate) * 2,
+      realtime_interval: opts[:block_rate] || @block_rate,
       starting_block_number: nil,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),


### PR DESCRIPTION
We're defining the real-time interval to 5 seconds instead of 10 seconds. 👍 
