### PR TITLE
Add contract creator on Account details page

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -622,7 +622,7 @@ defmodule Explorer.Chain do
     query =
       from(
         address in Address,
-        preload: [:smart_contract],
+        preload: [:smart_contract, :contracts_creation_internal_transaction],
         where: address.hash == ^hash
       )
 
@@ -638,7 +638,7 @@ defmodule Explorer.Chain do
     query =
       from(
         address in Address,
-        preload: [:smart_contract],
+        preload: [:smart_contract, :contracts_creation_internal_transaction],
         where: address.hash == ^hash and not is_nil(address.contract_code)
       )
 

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Address do
   use Explorer.Schema
 
   alias Ecto.Changeset
-  alias Explorer.Chain.{Block, Data, Hash, Wei, SmartContract}
+  alias Explorer.Chain.{Block, Data, Hash, Wei, SmartContract, InternalTransaction}
 
   @optional_attrs ~w(contract_code)a
   @required_attrs ~w(hash)a
@@ -42,6 +42,12 @@ defmodule Explorer.Chain.Address do
     field(:contract_code, Data)
 
     has_one(:smart_contract, SmartContract)
+
+    has_one(
+      :contracts_creation_internal_transaction,
+      InternalTransaction,
+      foreign_key: :created_contract_address_hash
+    )
 
     timestamps()
   end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -832,7 +832,9 @@ defmodule Explorer.ChainTest do
     end
 
     test "finds an contract address" do
-      address = insert(:address, contract_code: Factory.data("contract_code"), smart_contract: nil)
+      address =
+        insert(:address, contract_code: Factory.data("contract_code"), smart_contract: nil)
+        |> Repo.preload(:contracts_creation_internal_transaction)
 
       response = Chain.find_contract_address(address.hash)
 

--- a/apps/explorer_web/lib/explorer_web/controllers/address_transaction_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/address_transaction_controller.ex
@@ -26,7 +26,6 @@ defmodule ExplorerWeb.AddressTransactionController do
         |> Keyword.merge(current_filter(params))
 
       transactions_plus_one = Chain.address_to_transactions(address, full_options)
-
       {transactions, next_page} = split_list_by_page(transactions_plus_one)
 
       render(

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -19,6 +19,35 @@
           <h3 class="<%= if ExplorerWeb.AddressView.contract?(@address) do %>contract-address<% end %>" data-test="address_detail_hash"><%= @address %></h3>
           <div class="d-flex flex-row justify-content-start text-muted">
             <span class="mr-4" data-test="transaction_count"><%= Cldr.Number.to_string!(@transaction_count) %> <%= gettext "Transactions" %></span>
+
+            <%= if contract?(@address) do %>
+              <span class="mr-4" data-test="address_contract_creator">
+                <%= gettext "Contract created by" %>
+                <%= link(
+                      trimmed_hash(@address.contracts_creation_internal_transaction.from_address_hash),
+                      to: address_path(
+                        ExplorerWeb.Endpoint,
+                        :show,
+                        @locale,
+                        @address.contracts_creation_internal_transaction.from_address_hash
+                      )
+                    ) %>
+
+                <%= gettext "at" %>
+
+                <%= link(
+                      trimmed_hash(@address.contracts_creation_internal_transaction.transaction_hash),
+                      to: transaction_path(
+                        ExplorerWeb.Endpoint,
+                        :show,
+                        @locale,
+                        @address.contracts_creation_internal_transaction.transaction_hash
+                      ),
+                      "data-test": "transaction_hash_link",
+                      "class": "tile-title"
+                    ) %>
+              </span>
+            <% end %>
           </div>
         </div>
       </div>
@@ -37,7 +66,6 @@
     </div>
   </div>
 </section>
-
 
 <!-- Modal -->
 <div class="modal fade" id="qrModal" tabindex="-1" role="dialog" aria-labelledby="qrModalLabel" aria-hidden="true">

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -633,3 +633,13 @@ msgstr ""
 #: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:25
+msgid "Contract created by"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:36
+msgid "at"
+msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -645,3 +645,13 @@ msgstr ""
 #: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:25
+msgid "Contract created by"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:36
+msgid "at"
+msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/address_contract_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/address_contract_controller_test.exs
@@ -24,7 +24,7 @@ defmodule ExplorerWeb.AddressContractControllerTest do
       assert html_response(conn, 404)
     end
 
-    test "returns not found when the address doesn't have a contract", %{conn: conn} do
+    test "returns not found when the address isn't a contract", %{conn: conn} do
       address = insert(:address)
 
       conn = get(conn, address_contract_path(ExplorerWeb.Endpoint, :index, :en, address))
@@ -32,13 +32,22 @@ defmodule ExplorerWeb.AddressContractControllerTest do
       assert html_response(conn, 404)
     end
 
-    test "suscefully renders the page", %{conn: conn} do
+    test "successfully renders the page when the address is a contract", %{conn: conn} do
       address = insert(:address, contract_code: Factory.data("contract_code"), smart_contract: nil)
+
+      transaction = insert(:transaction, from_address: address)
+
+      insert(
+        :internal_transaction_create,
+        index: 0,
+        transaction: transaction,
+        created_contract_address: address
+      )
 
       conn = get(conn, address_contract_path(ExplorerWeb.Endpoint, :index, :en, address))
 
       assert html_response(conn, 200)
-      assert address == conn.assigns.address
+      assert address.hash == conn.assigns.address.hash
       assert %Token{} = conn.assigns.exchange_rate
       assert conn.assigns.transaction_count
     end

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -15,6 +15,10 @@ defmodule ExplorerWeb.AddressPage do
     css("[data-test='address_balance']")
   end
 
+  def contract_creator do
+    css("[data-test='address_contract_creator']")
+  end
+
   def click_internal_transactions(session) do
     click(session, css("[data-test='internal_transactions_tab_link']"))
   end


### PR DESCRIPTION
This PR is about https://github.com/poanetwork/poa-explorer/issues/303

It adds a link that shows who created the contract and a link to the transaction id, though these links will be shown just when the account details page is a smart contract.

## Screenshots

- A contract created by some user.
![image](https://user-images.githubusercontent.com/27698968/42707259-02b7c0be-86b0-11e8-850c-f1bf128cd138.png)

- A contract created by another contract, in this case, the creator link will send the user to contract creator and the transaction that created the contract.*
![image](https://user-images.githubusercontent.com/27698968/42707275-0e9ef262-86b0-11e8-9013-f8819e09dbde.png)


## TODO
- [x] Docs 
- [x] Tests
- [x] Truncate links