### PR TITLE
Fix eslint in CircleCI which was not running on everything it should

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
 
       - run:
           name: ESLint
-          command: ./node_modules/.bin/eslint --format=junit --output-file="test/eslint/junit.xml" js/**/*.js
+          command: ./node_modules/.bin/eslint --format=junit --output-file="test/eslint/junit.xml" js/**
           working_directory: apps/explorer_web/assets
 
       - store_test_results:


### PR DESCRIPTION
`js/**/*.js` was not running eslint on files nested with extra nesting. `js/**` is what we have in `package.json` which works with everything so we should stick with that.