### PR TITLE
Fix multiple results in Repo.One with multiple create type internal transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2106,7 +2106,7 @@ defmodule Explorer.Chain do
     |> where_transaction_has_multiple_internal_transactions()
     |> page_internal_transaction(paging_options)
     |> limit(^paging_options.page_size)
-    |> order_by([internal_transaction], desc: internal_transaction.index)
+    |> order_by([internal_transaction], asc: internal_transaction.index)
     |> Repo.all()
   end
 
@@ -2538,7 +2538,7 @@ defmodule Explorer.Chain do
   end
 
   defp page_internal_transaction(query, %PagingOptions{key: {index}}) do
-    where(query, [internal_transaction], internal_transaction.index < ^index)
+    where(query, [internal_transaction], internal_transaction.index > ^index)
   end
 
   defp page_logs(query, %PagingOptions{key: nil}), do: query

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -701,7 +701,7 @@ defmodule Explorer.ChainTest do
       assert actual.id == expected.id
     end
 
-    test "returns the internal transactions in descending index order" do
+    test "returns the internal transactions in ascending index order" do
       transaction =
         :transaction
         |> insert()
@@ -715,7 +715,7 @@ defmodule Explorer.ChainTest do
         |> Chain.transaction_to_internal_transactions()
         |> Enum.map(& &1.id)
 
-      assert [second_id, first_id] == result
+      assert [first_id, second_id] == result
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -335,6 +335,22 @@ defmodule Explorer.ChainTest do
                  necessity_by_association: %{block: :required}
                )
     end
+
+    test "transaction with multiple create internal transactions is returned" do
+      transaction =
+        %Transaction{hash: hash_with_block} =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction, transaction: transaction, index: 0)
+
+      Enum.each(1..3, fn index ->
+        insert(:internal_transaction_create, transaction: transaction, index: index)
+      end)
+
+      assert {:ok, %Transaction{hash: ^hash_with_block}} = Chain.hash_to_transaction(hash_with_block)
+    end
   end
 
   describe "list_blocks/2" do

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/index.html.eex
@@ -68,7 +68,7 @@
 
     <%= if @next_page_params do %>
       <%= link(
-        gettext("Older"),
+        gettext("Newer"),
         class: "button button--secondary button--sm u-float-right mt-3",
         to: transaction_internal_transaction_path(
           @conn,

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -494,7 +494,6 @@ msgstr ""
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:73
 #: lib/explorer_web/templates/transaction/index.html.eex:90
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""
 
@@ -525,6 +524,7 @@ msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -506,7 +506,6 @@ msgstr ""
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:73
 #: lib/explorer_web/templates/transaction/index.html.eex:90
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 msgid "Older"
 msgstr ""
 
@@ -537,6 +536,7 @@ msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -88,12 +88,12 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
         |> insert()
         |> with_block()
 
+      %InternalTransaction{index: index} = insert(:internal_transaction, transaction: transaction, index: 0)
+
       second_page_indexes =
         1..50
         |> Enum.map(fn index -> insert(:internal_transaction, transaction: transaction, index: index) end)
         |> Enum.map(& &1.index)
-
-      %InternalTransaction{index: index} = insert(:internal_transaction, transaction: transaction, index: 51)
 
       conn =
         get(conn, transaction_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, transaction.hash), %{
@@ -103,7 +103,6 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
       actual_indexes =
         conn.assigns.internal_transactions
         |> Enum.map(& &1.index)
-        |> Enum.reverse()
 
       assert second_page_indexes == actual_indexes
     end
@@ -128,7 +127,7 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
 
       conn = get(conn, transaction_internal_transaction_path(ExplorerWeb.Endpoint, :index, :en, transaction.hash))
 
-      assert %{"block_number" => ^number, "index" => 11, "transaction_index" => ^transaction_index} =
+      assert %{"block_number" => ^number, "index" => 50, "transaction_index" => ^transaction_index} =
                conn.assigns.next_page_params
     end
 


### PR DESCRIPTION
Fixes #367
Fixes #383

## Changelog

### Bug Fixes
* Fixes the transaction details page when a transaction has multiple internal transactions of type create
* Fixes contract address page showing parent transaction with non-matching to and from addresses