### PR TITLE
Convert Indexer.Sequence to GenServer to trap exits to ensure self-cleanup

### DIFF
--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -188,7 +188,9 @@ defmodule Indexer.BlockFetcher do
 
     debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
 
-    {:ok, seq} = Sequence.start_link(missing_ranges, latest_block_number, -1 * state.blocks_batch_size)
+    {:ok, seq} =
+      Sequence.start_link(prefix: missing_ranges, first: latest_block_number, step: -1 * state.blocks_batch_size)
+
     stream_import(state, seq, max_concurrency: state.blocks_concurrency)
   end
 
@@ -294,7 +296,7 @@ defmodule Indexer.BlockFetcher do
 
   defp realtime_task(%{} = state) do
     {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest")
-    {:ok, seq} = Sequence.start_link([], latest_block_number, 2)
+    {:ok, seq} = Sequence.start_link(first: latest_block_number, step: 2)
     stream_import(state, seq, max_concurrency: 1)
   end
 

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -293,7 +293,7 @@ defmodule Indexer.BlockFetcher do
   end
 
   defp realtime_task(%{} = state) do
-    {:ok, latest_block_number} = Chain.max_block_number()
+    {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest")
     {:ok, seq} = Sequence.start_link([], latest_block_number, 2)
     stream_import(state, seq, max_concurrency: 1)
   end

--- a/apps/indexer/lib/indexer/sequence.ex
+++ b/apps/indexer/lib/indexer/sequence.ex
@@ -1,9 +1,55 @@
 defmodule Indexer.Sequence do
   @moduledoc false
 
-  use Agent
+  use GenServer
 
-  defstruct ~w(current mode queue step)a
+  @enforce_keys ~w(current queue step)a
+  defstruct current: nil,
+            queue: nil,
+            step: nil,
+            mode: :infinite
+
+  @typedoc """
+  The initial ranges to stream from the `t:Stream.t/` returned from `build_stream/1`
+  """
+  @type prefix :: [Range.t()]
+
+  @typep prefix_option :: {:prefix, prefix}
+
+  @typedoc """
+  The first number in the sequence to start at once the `t:prefix/0` ranges and any `t:Range.t/0`s injected with
+  `inject_range/2` are all consumed.
+  """
+  @type first :: pos_integer()
+
+  @typep first_named_argument :: {:first, pos_integer()}
+
+  @type mode :: :infinite | :finite
+
+  @typedoc """
+  The size of `t:Range.t/0` to construct based on the `t:first_named_argument/0` or its current value when all
+  `t:prefix/0` ranges and any `t:Range.t/0`s injected with `inject_range/2` are consumed.
+  """
+  @type step :: neg_integer() | pos_integer()
+
+  @typep step_named_argument :: {:step, step}
+
+  @type options :: [prefix_option | first_named_argument | step_named_argument]
+
+  @typep t :: %__MODULE__{
+           current: pos_integer(),
+           queue: :queue.queue(Range.t()),
+           step: step(),
+           mode: mode()
+         }
+
+  @doc """
+  Starts a process for managing a block sequence.
+  """
+  @spec start_link(options) :: GenServer.on_start()
+  def start_link(options) when is_list(options) do
+    GenServer.start_link(__MODULE__, options)
+  end
 
   @doc """
   Builds an enumerable stream using a sequencer agent.
@@ -24,67 +70,83 @@ defmodule Indexer.Sequence do
 
   @doc """
   Changes the mode for the sequencer to signal continuous streaming mode.
+
+  Returns the previous `t:mode/0`.
   """
-  @spec cap(pid()) :: :ok
-  def cap(sequencer) when is_pid(sequencer) do
-    Agent.update(sequencer, fn state ->
-      %__MODULE__{state | mode: :finite}
-    end)
+  @spec cap(pid()) :: mode
+  def cap(sequence) when is_pid(sequence) do
+    GenServer.call(sequence, :cap)
   end
 
   @doc """
   Adds a range of block numbers to the sequence.
   """
   @spec inject_range(pid(), Range.t()) :: :ok
-  def inject_range(sequencer, _first.._last = range) when is_pid(sequencer) do
-    Agent.update(sequencer, fn state ->
-      %__MODULE__{state | queue: :queue.in(range, state.queue)}
-    end)
+  def inject_range(sequence, _first.._last = range) when is_pid(sequence) do
+    GenServer.call(sequence, {:inject_range, range})
   end
 
   @doc """
   Pops the next block range from the sequence.
   """
   @spec pop(pid()) :: Range.t() | :halt
-  def pop(sequencer) when is_pid(sequencer) do
-    Agent.get_and_update(sequencer, &pop_state/1)
+  def pop(sequence) when is_pid(sequence) do
+    GenServer.call(sequence, :pop)
   end
 
-  @doc """
-  Stars a process for managing a block sequence.
-  """
-  @spec start_link([Range.t()], pos_integer(), neg_integer() | pos_integer()) :: Agent.on_start()
-  def start_link(initial_ranges, range_start, step) do
-    Agent.start_link(fn ->
-      %__MODULE__{
-        current: range_start,
-        step: step,
-        mode: :infinite,
-        queue: :queue.from_list(initial_ranges)
-      }
-    end)
+  @impl GenServer
+  @spec init(options) :: {:ok, t}
+  def init(named_arguments) when is_list(named_arguments) do
+    {:ok,
+     %__MODULE__{
+       queue:
+         named_arguments
+         |> Keyword.get(:prefix, [])
+         |> :queue.from_list(),
+       current: Keyword.fetch!(named_arguments, :first),
+       step: Keyword.fetch!(named_arguments, :step)
+     }}
   end
 
-  defp pop_state(%__MODULE__{current: current, step: step} = state) do
-    case {state.mode, :queue.out(state.queue)} do
-      {_, {{:value, range}, new_queue}} ->
-        {range, %__MODULE__{state | queue: new_queue}}
+  @impl GenServer
 
-      {:infinite, {:empty, new_queue}} ->
-        case current + step do
-          negative when negative < 0 ->
-            {current..0, %__MODULE__{state | current: 0, mode: :finite, queue: new_queue}}
-
-          new_current ->
-            last = new_current - sign(step)
-            {current..last, %__MODULE__{state | current: new_current, queue: new_queue}}
-        end
-
-      {:finite, {:empty, new_queue}} ->
-        {:halt, %__MODULE__{state | queue: new_queue}}
-    end
+  @spec handle_call(:cap, GenServer.from(), t()) :: {:reply, mode(), %__MODULE__{mode: :infinite}}
+  def handle_call(:cap, _from, %__MODULE__{mode: mode} = state) do
+    {:reply, mode, %__MODULE__{state | mode: :finite}}
   end
 
+  @spec handle_call({:inject_range, Range.t()}, GenServer.from(), t()) :: {:reply, mode(), t()}
+  def handle_call({:inject_range, _first.._last = range}, _from, %__MODULE__{queue: queue} = state) do
+    {:reply, :ok, %__MODULE__{state | queue: :queue.in(range, queue)}}
+  end
+
+  @spec handle_call(:pop, GenServer.from(), t()) :: {:reply, Range.t() | :halt, t()}
+  def handle_call(:pop, _from, %__MODULE__{mode: mode, queue: queue, current: current, step: step} = state) do
+    {reply, new_state} =
+      case {mode, :queue.out(queue)} do
+        {_, {{:value, range}, new_queue}} ->
+          {range, %__MODULE__{state | queue: new_queue}}
+
+        {:infinite, {:empty, new_queue}} ->
+          case current + step do
+            negative when negative < 0 ->
+              {current..0, %__MODULE__{state | current: 0, mode: :finite, queue: new_queue}}
+
+            new_current ->
+              last = new_current - sign(step)
+              {current..last, %__MODULE__{state | current: new_current, queue: new_queue}}
+          end
+
+        {:finite, {:empty, new_queue}} ->
+          {:halt, %__MODULE__{state | queue: new_queue}}
+      end
+
+    {:reply, reply, new_state}
+  end
+
+  @spec sign(neg_integer()) :: -1
   defp sign(integer) when integer < 0, do: -1
+
+  @spec sign(non_neg_integer()) :: 1
   defp sign(_), do: 1
 end

--- a/apps/indexer/lib/indexer/sequence.ex
+++ b/apps/indexer/lib/indexer/sequence.ex
@@ -97,6 +97,8 @@ defmodule Indexer.Sequence do
   @impl GenServer
   @spec init(options) :: {:ok, t}
   def init(named_arguments) when is_list(named_arguments) do
+    Process.flag(:trap_exit, true)
+
     {:ok,
      %__MODULE__{
        queue:

--- a/apps/indexer/test/indexer/block_fetcher_test.exs
+++ b/apps/indexer/test/indexer/block_fetcher_test.exs
@@ -143,7 +143,7 @@ defmodule Indexer.BlockFetcherTest do
     end
 
     test "with single element range that is valid imports one block", %{state: state, variant: variant} do
-      {:ok, sequence} = Sequence.start_link([], 0, 1)
+      {:ok, sequence} = Sequence.start_link(first: 0, step: 1)
 
       %{address_hash: address_hash, block_hash: block_hash} =
         case variant do
@@ -205,7 +205,7 @@ defmodule Indexer.BlockFetcherTest do
     end
 
     test "can import range with all synchronous imported schemas", %{state: state, variant: variant} do
-      {:ok, sequence} = Sequence.start_link([], 0, 1)
+      {:ok, sequence} = Sequence.start_link(first: 0, step: 1)
 
       case variant do
         EthereumJSONRPC.Geth ->

--- a/apps/indexer/test/indexer/sequence_test.exs
+++ b/apps/indexer/test/indexer/sequence_test.exs
@@ -26,7 +26,8 @@ defmodule Indexer.SequenceTest do
 
       sequence_ref = Process.monitor(sequence_pid)
 
-      assert_receive {:DOWN, ^sequence_ref, :process, ^sequence_pid, :normal}
+      # noproc when the sequence has already died by the time monitor is called
+      assert_receive {:DOWN, ^sequence_ref, :process, ^sequence_pid, status} when status in [:normal, :noproc]
     end
   end
 


### PR DESCRIPTION
Fixes #387

## Changelog

### Enhancements
* The previous `mode` is returned when you `Indexer.Sequence.cap` a sequence, so you can tell what mode you were in before without having to make a separate call to the sequence.

### Bug Fixes
* `Indexer.Sequence.start_link` spawned processes now clean up themselves even when the calling process exits `:normal` in addition to the previous cleanup on crashes. 
* The change in #357 was broken because it did not work when the database was empty, so it has been reverted as it prevented testing this PR.  The realtime indexer will not fill holes.  The genesis task will be rewritten to fill holes in a later PR.

### Incompatible Changes
* `Indexer.Sequence.cap` returns the previous `mode` (`:infinite` or `:finite`) instead of `:ok`.
