### PR TITLE
Change reference to Hash.Address

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2263,7 +2263,7 @@ defmodule Explorer.Chain do
               ],
             transaction.hash
           ),
-          Explorer.Chain.Hash.Truncated
+          Explorer.Chain.Hash.Address
         )
     })
     |> order_by([transaction], desc: transaction.block_number, desc: transaction.index)


### PR DESCRIPTION
Fixes #391 

## Changelog

### Bug Fixes
* Changes reference from `Explorer.Chain.Hash.Truncated` to `Explorer.Chain.Hash.Address`

