### PR TITLE
Fix Indexer Supervisor tree

### DIFF
--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -15,7 +15,8 @@ defmodule Indexer.Application do
       {Task.Supervisor, name: Indexer.TaskSupervisor},
       {AddressBalanceFetcher, name: AddressBalanceFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
       {PendingTransactionFetcher, name: PendingTransactionFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
-      {InternalTransactionFetcher, name: InternalTransactionFetcher},
+      {InternalTransactionFetcher,
+       name: InternalTransactionFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
       {BlockFetcher, []}
     ]
 


### PR DESCRIPTION
### Bug

We are facing this error when starting the `Indexer`:
```
    ** (EXIT) an exception was raised:
        ** (ArgumentError) :json_rpc_named_arguments must be provided to `Elixir.Indexer.InternalTransactionFetcher.child_spec to allow for json_rpc calls when running.
```

### Fix
It was missing the `json_rpc_named_arguments` to `InternalTransactionFetcher` children.

Original PR https://github.com/poanetwork/poa-explorer/pull/384