### PR TITLE
Enhance API account balance endpoint

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -634,6 +634,23 @@ defmodule Explorer.Chain do
     end
   end
 
+  @doc """
+  Converts list of `t:Explorer.Chain.Address.t/0` `hash` to the `t:Explorer.Chain.Address.t/0` with that `hash`.
+
+  Returns `[%Explorer.Chain.Address{}]}` if found
+
+  """
+  @spec hashes_to_addresses([Hash.Address.t()]) :: [Address.t()]
+  def hashes_to_addresses(hashes) when is_list(hashes) do
+    query =
+      from(
+        address in Address,
+        where: address.hash in ^hashes
+      )
+
+    Repo.all(query)
+  end
+
   def find_contract_address(%Hash{byte_count: unquote(Hash.Address.byte_count())} = hash) do
     query =
       from(

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -316,6 +316,32 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "hashes_to_addresses/1" do
+    test "with existing addresses" do
+      address1_attrs = %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
+      address2_attrs = %{hash: "0x6aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
+      address1 = insert(:address, address1_attrs)
+      address2 = insert(:address, address2_attrs)
+      hashes = [address1.hash, address2.hash]
+
+      [found_address1, found_address2] = Explorer.Chain.hashes_to_addresses(hashes)
+
+      %Explorer.Chain.Address{hash: found_hash1} = found_address1
+      %Explorer.Chain.Address{hash: found_hash2} = found_address2
+
+      assert found_hash1 == address1.hash
+      assert found_hash2 == address2.hash
+    end
+
+    test "with nonexistent addresses" do
+      hash1 = "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"
+      hash2 = "0x6aaeb6053f3e94c9b9a09f33669435e7ef1beaed"
+      hashes = [hash1, hash2]
+
+      assert Explorer.Chain.hashes_to_addresses(hashes) == []
+    end
+  end
+
   describe "hash_to_transaction/2" do
     test "with transaction with block required without block returns {:error, :not_found}" do
       %Transaction{hash: hash_with_block} =

--- a/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
@@ -5,10 +5,10 @@ defmodule ExplorerWeb.API.RPC.AddressController do
   alias Explorer.Chain.{Address, Wei}
 
   def balance(conn, params) do
-    with {:address_param, {:ok, address_hash_string}} <- fetch_address(params),
-         {:format, {:ok, address_hash}} <- to_address_hash(address_hash_string),
-         {:ok, address} <- hash_to_address(address_hash) do
-      render(conn, :balance, %{address: address})
+    with {:address_param, {:ok, address_param}} <- fetch_address(params),
+         {:format, {:ok, address_hashes}} <- to_address_hashes(address_param) do
+      addresses = hashes_to_addresses(address_hashes)
+      render(conn, :balance, %{addresses: addresses})
     else
       {:address_param, :error} ->
         conn
@@ -26,17 +26,58 @@ defmodule ExplorerWeb.API.RPC.AddressController do
     {:address_param, Map.fetch(params, "address")}
   end
 
-  defp to_address_hash(address_hash_string) do
-    {:format, Chain.string_to_address_hash(address_hash_string)}
+  defp to_address_hashes(address_param) when is_binary(address_param) do
+    address_param
+    |> String.split(",")
+    |> Enum.take(20)
+    |> to_address_hashes()
   end
 
-  defp hash_to_address(address_hash) do
-    address =
-      case Chain.hash_to_address(address_hash) do
-        {:ok, address} -> address
-        {:error, :not_found} -> %Address{fetched_balance: %Wei{value: 0}}
-      end
+  defp to_address_hashes(address_param) when is_list(address_param) do
+    address_hashes = address_param_to_address_hashes(address_param)
 
-    {:ok, address}
+    if any_errors?(address_hashes) do
+      {:format, :error}
+    else
+      {:format, {:ok, address_hashes}}
+    end
+  end
+
+  defp address_param_to_address_hashes(address_param) do
+    Enum.map(address_param, fn single_address ->
+      case Chain.string_to_address_hash(single_address) do
+        {:ok, address_hash} -> address_hash
+        :error -> :error
+      end
+    end)
+  end
+
+  defp any_errors?(address_hashes) do
+    Enum.any?(address_hashes, &(&1 == :error))
+  end
+
+  defp hashes_to_addresses(address_hashes) do
+    address_hashes
+    |> Chain.hashes_to_addresses()
+    |> add_not_found_addresses(address_hashes)
+  end
+
+  defp add_not_found_addresses(addresses, hashes) do
+    found_hashes = MapSet.new(addresses, & &1.hash)
+
+    hashes
+    |> MapSet.new()
+    |> MapSet.difference(found_hashes)
+    |> hashes_to_addresses(:not_found)
+    |> Enum.concat(addresses)
+  end
+
+  defp hashes_to_addresses(hashes, :not_found) do
+    Enum.map(hashes, fn hash ->
+      %Address{
+        hash: hash,
+        fetched_balance: %Wei{value: 0}
+      }
+    end)
   end
 end

--- a/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
@@ -3,13 +3,28 @@ defmodule ExplorerWeb.API.RPC.AddressView do
 
   alias ExplorerWeb.API.RPC.RPCView
 
-  def render("balance.json", %{address: address}) do
-    ether_balance = format_wei_value(address.fetched_balance, :ether, include_unit_label: false)
-    data = ether_balance
+  def render("balance.json", %{addresses: [address]}) do
+    ether_balance = wei_to_ether(address.fetched_balance)
+    RPCView.render("show.json", data: ether_balance)
+  end
+
+  def render("balance.json", %{addresses: addresses}) do
+    data =
+      Enum.map(addresses, fn address ->
+        %{
+          "account" => "#{address.hash}",
+          "balance" => wei_to_ether(address.fetched_balance)
+        }
+      end)
+
     RPCView.render("show.json", data: data)
   end
 
   def render("error.json", %{error: error}) do
     RPCView.render("error.json", error: error)
+  end
+
+  defp wei_to_ether(wei) do
+    format_wei_value(wei, :ether, include_unit_label: false)
   end
 end

--- a/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
@@ -79,5 +79,142 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end
+
+    test "with an invalid and a valid address hash", %{conn: conn} do
+      address1 = "invalidhash"
+      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
+
+      params = %{
+        "module" => "account",
+        "action" => "balance",
+        "address" => "#{address1},#{address2}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(400)
+
+      assert response["message"] =~ "Invalid address hash"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with multiple addresses that don't exist", %{conn: conn} do
+      address1 = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
+
+      params = %{
+        "module" => "account",
+        "action" => "balance",
+        "address" => "#{address1},#{address2}"
+      }
+
+      expected_result = [
+        %{"account" => address1, "balance" => "0"},
+        %{"account" => address2, "balance" => "0"}
+      ]
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with multiple valid addresses", %{conn: conn} do
+      addresses =
+        for _ <- 1..4 do
+          insert(:address, fetched_balance: Enum.random(1..1_000))
+        end
+
+      address_param =
+        addresses
+        |> Enum.map(&"#{&1.hash}")
+        |> Enum.join(",")
+
+      params = %{
+        "module" => "account",
+        "action" => "balance",
+        "address" => address_param
+      }
+
+      expected_result =
+        Enum.map(addresses, fn address ->
+          expected_balance =
+            address.fetched_balance
+            |> Wei.to(:ether)
+            |> Decimal.to_string(:normal)
+
+          %{"account" => "#{address.hash}", "balance" => expected_balance}
+        end)
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with an address that exists and one that doesn't", %{conn: conn} do
+      address1 = insert(:address, fetched_balance: 100)
+      address2_hash = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
+
+      params = %{
+        "module" => "account",
+        "action" => "balance",
+        "address" => "#{address1.hash},#{address2_hash}"
+      }
+
+      expected_balance1 =
+        address1.fetched_balance
+        |> Wei.to(:ether)
+        |> Decimal.to_string(:normal)
+
+      expected_result = [
+        %{"account" => address2_hash, "balance" => "0"},
+        %{"account" => "#{address1.hash}", "balance" => expected_balance1}
+      ]
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "up to a maximum of 20 addresses in a single request", %{conn: conn} do
+      addresses = insert_list(25, :address, fetched_balance: 0)
+
+      address_param =
+        addresses
+        |> Enum.map(&"#{&1.hash}")
+        |> Enum.join(",")
+
+      params = %{
+        "module" => "account",
+        "action" => "balance",
+        "address" => address_param
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert length(response["result"]) == 20
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
   end
 end


### PR DESCRIPTION
## Motivation

* Currently, the API account balance endpoint allows users to get the
ether balance for a single address. This commit introduces support for
getting the ether balance for multiple addresses (maximum of 20) in a
single batch.
* Issue link: https://github.com/poanetwork/poa-explorer/issues/138

## Changelog

### Enhancements
* Adding `Chain.hashes_to_addresses/1` to get multiple addresses from
the DB, given a list of hashes.
* Editing `balance/2` in `API.RPC.AddressController` to support multiple
addresses. Previously it only supported a single address.
* Editing `API.RPC.AddressView` to handle a single address differently than
multiple addresses. This is to mimic Etherscan's API.

### Bug Fixes
* n/a

### Incompatible Changes
* n/a

## Upgrading
* n/a 