### PR TITLE
Fix chunking issues with BlockFetcher and Sequence

### DIFF
--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -274,7 +274,8 @@ defmodule Indexer.BlockFetcher do
     |> chunk_ranges(blocks_batch_size)
   end
 
-  defp chunk_ranges(ranges, size) do
+  @doc false
+  def chunk_ranges(ranges, size) do
     Enum.flat_map(ranges, fn
       first..last = range when last - first <= size ->
         [range]

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -188,8 +188,8 @@ defmodule Indexer.BlockFetcher do
 
     debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
 
-    {:ok, seq} =
-      Sequence.start_link(prefix: missing_ranges, first: 0, step: -1 * state.blocks_batch_size)
+    {:ok, seq} = Sequence.start_link(prefix: missing_ranges, first: 0, step: -1 * state.blocks_batch_size)
+    Sequence.cap(seq)
 
     stream_import(state, seq, max_concurrency: state.blocks_concurrency)
   end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -189,7 +189,7 @@ defmodule Indexer.BlockFetcher do
     debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
 
     {:ok, seq} =
-      Sequence.start_link(prefix: missing_ranges, first: latest_block_number, step: -1 * state.blocks_batch_size)
+      Sequence.start_link(prefix: missing_ranges, first: 0, step: -1 * state.blocks_batch_size)
 
     stream_import(state, seq, max_concurrency: state.blocks_concurrency)
   end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -188,7 +188,7 @@ defmodule Indexer.BlockFetcher do
 
     debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
 
-    {:ok, seq} = Sequence.start_link(prefix: missing_ranges, first: 0, step: -1 * state.blocks_batch_size)
+    {:ok, seq} = Sequence.start_link(ranges: missing_ranges, step: -1 * state.blocks_batch_size)
     Sequence.cap(seq)
 
     stream_import(state, seq, max_concurrency: state.blocks_concurrency)
@@ -214,7 +214,7 @@ defmodule Indexer.BlockFetcher do
           "failed to insert blocks during #{step} #{inspect(range)}: #{inspect(failed_value)}. Retrying"
         end)
 
-        :ok = Sequence.inject_range(seq, range)
+        :ok = Sequence.queue(seq, range)
 
         error
     end
@@ -319,7 +319,7 @@ defmodule Indexer.BlockFetcher do
           "failed to fetch #{step} for blocks #{first} - #{last}: #{inspect(reason)}. Retrying block range."
         end)
 
-        :ok = Sequence.inject_range(seq, range)
+        :ok = Sequence.queue(seq, range)
 
         {:error, step, reason}
     end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -281,28 +281,31 @@ defmodule Indexer.BlockFetcher do
 
   defp chunk_range(range, size) do
     count = Enum.count(range)
+    chunk_range(range, count, size)
+  end
 
-    if count <= size do
-      [range]
-    else
-      first..last = range
+  defp chunk_range(range, count, size) when count <= size do
+    [range]
+  end
 
-      first
-      |> Stream.iterate(&(&1 + size))
-      |> Enum.reduce_while([], fn chunk_first, acc ->
-        next_chunk_first = chunk_first + size
-        full_chunk_last = next_chunk_first - 1
+  defp chunk_range(range, _, size) do
+    first..last = range
 
-        {action, chunk_last} = if full_chunk_last >= last do
-          {:halt, last}
-        else
-          {:cont, full_chunk_last}
-        end
+    first
+    |> Stream.iterate(&(&1 + size))
+    |> Enum.reduce_while([], fn chunk_first, acc ->
+      next_chunk_first = chunk_first + size
+      full_chunk_last = next_chunk_first - 1
 
-        {action, [chunk_first..chunk_last | acc]}
-      end)
-      |> Enum.reverse()
-    end
+      {action, chunk_last} = if full_chunk_last >= last do
+        {:halt, last}
+      else
+        {:cont, full_chunk_last}
+      end
+
+      {action, [chunk_first..chunk_last | acc]}
+    end)
+    |> Enum.reverse()
   end
 
   defp realtime_task(%{json_rpc_named_arguments: json_rpc_named_arguments} = state) do

--- a/apps/indexer/lib/indexer/sequence.ex
+++ b/apps/indexer/lib/indexer/sequence.ex
@@ -6,25 +6,27 @@ defmodule Indexer.Sequence do
   @enforce_keys ~w(current queue step)a
   defstruct current: nil,
             queue: nil,
-            step: nil,
-            mode: :infinite
+            step: nil
 
   @typedoc """
-  The initial ranges to stream from the `t:Stream.t/` returned from `build_stream/1`
+  The ranges to stream from the `t:Stream.t/` returned from `build_stream/1`
   """
-  @type prefix :: [Range.t()]
+  @type ranges :: [Range.t()]
 
-  @typep prefix_option :: {:prefix, prefix}
+  @typep ranges_option :: {:ranges, ranges}
 
   @typedoc """
-  The first number in the sequence to start at once the `t:prefix/0` ranges and any `t:Range.t/0`s injected with
-  `inject_range/2` are all consumed.
+  The first number in the sequence to start for infinite sequences.
   """
-  @type first :: non_neg_integer()
+  @type first :: integer()
 
-  @typep first_named_argument :: {:first, first}
+  @typep first_option :: {:first, first}
 
-  @type mode :: :infinite | :finite
+  @typedoc """
+   * `:finite` - only popping ranges from `queue`.
+   * `:infinite` - generating new ranges from `current` and `step` when `queue` is empty.
+  """
+  @type mode :: :finite | :infinite
 
   @typedoc """
   The size of `t:Range.t/0` to construct based on the `t:first_named_argument/0` or its current value when all
@@ -34,17 +36,25 @@ defmodule Indexer.Sequence do
 
   @typep step_named_argument :: {:step, step}
 
-  @type options :: [prefix_option | first_named_argument | step_named_argument]
+  @type options :: [ranges_option | first_option | step_named_argument]
 
   @typep t :: %__MODULE__{
-           current: pos_integer(),
            queue: :queue.queue(Range.t()),
-           step: step(),
-           mode: mode()
+           current: nil | integer(),
+           step: step()
          }
 
   @doc """
   Starts a process for managing a block sequence.
+
+  Infinite sequence
+
+      Indexer.Sequence.start_link(first: 100, step: 10)
+
+  Finite sequence
+
+      Indexer.Sequence.start_link(ranges: [100..0])
+
   """
   @spec start_link(options) :: GenServer.on_start()
   def start_link(options) when is_list(options) do
@@ -69,9 +79,7 @@ defmodule Indexer.Sequence do
   end
 
   @doc """
-  Changes the mode for the sequencer to signal continuous streaming mode.
-
-  Returns the previous `t:mode/0`.
+  Changes the mode for the sequence to finite.
   """
   @spec cap(pid()) :: mode
   def cap(sequence) when is_pid(sequence) do
@@ -79,11 +87,11 @@ defmodule Indexer.Sequence do
   end
 
   @doc """
-  Adds a range of block numbers to the sequence.
+  Adds a range of block numbers to the end of sequence.
   """
-  @spec inject_range(pid(), Range.t()) :: :ok
-  def inject_range(sequence, _first.._last = range) when is_pid(sequence) do
-    GenServer.call(sequence, {:inject_range, range})
+  @spec queue(pid(), Range.t()) :: :ok
+  def queue(sequence, _first.._last = range) when is_pid(sequence) do
+    GenServer.call(sequence, {:queue, range})
   end
 
   @doc """
@@ -100,9 +108,9 @@ defmodule Indexer.Sequence do
     Process.flag(:trap_exit, true)
 
     case validate_options(options) do
-      {:ok, %{prefix: prefix, first: first, step: step}} ->
+      {:ok, %{ranges: ranges, first: first, step: step}} ->
         initial_queue = :queue.new()
-        queue = queue_chunked_ranges(initial_queue, step, prefix)
+        queue = queue_chunked_ranges(initial_queue, step, ranges)
 
         {:ok, %__MODULE__{queue: queue, current: first, step: step}}
 
@@ -113,35 +121,40 @@ defmodule Indexer.Sequence do
 
   @impl GenServer
 
-  @spec handle_call(:cap, GenServer.from(), t()) :: {:reply, mode(), %__MODULE__{mode: :infinite}}
-  def handle_call(:cap, _from, %__MODULE__{mode: mode} = state) do
-    {:reply, mode, %__MODULE__{state | mode: :finite}}
+  @spec handle_call(:cap, GenServer.from(), %__MODULE__{current: nil}) :: {:reply, :finite, %__MODULE__{current: nil}}
+  @spec handle_call(:cap, GenServer.from(), %__MODULE__{current: integer()}) ::
+          {:reply, :infinite, %__MODULE__{current: nil}}
+  def handle_call(:cap, _from, %__MODULE__{current: current} = state) do
+    mode =
+      case current do
+        nil -> :finite
+        _ -> :infinite
+      end
+
+    {:reply, mode, %__MODULE__{state | current: nil}}
   end
 
-  @spec handle_call({:inject_range, Range.t()}, GenServer.from(), t()) :: {:reply, mode(), t()}
-  def handle_call({:inject_range, _first.._last = range}, _from, %__MODULE__{queue: queue, step: step} = state) do
+  @spec handle_call({:queue, Range.t()}, GenServer.from(), t()) :: {:reply, :ok, t()}
+  def handle_call({:queue, _first.._last = range}, _from, %__MODULE__{queue: queue, step: step} = state) do
     {:reply, :ok, %__MODULE__{state | queue: queue_chunked_range(queue, step, range)}}
   end
 
   @spec handle_call(:pop, GenServer.from(), t()) :: {:reply, Range.t() | :halt, t()}
-  def handle_call(:pop, _from, %__MODULE__{mode: mode, queue: queue, current: current, step: step} = state) do
+  def handle_call(:pop, _from, %__MODULE__{queue: queue, current: current, step: step} = state) do
     {reply, new_state} =
-      case {mode, :queue.out(queue)} do
+      case {current, :queue.out(queue)} do
         {_, {{:value, range}, new_queue}} ->
           {range, %__MODULE__{state | queue: new_queue}}
 
-        {:infinite, {:empty, new_queue}} ->
-          case current + step do
-            negative when negative < 0 ->
-              {current..0, %__MODULE__{state | current: 0, mode: :finite, queue: new_queue}}
+        {nil, {:empty, new_queue}} ->
+          {:halt, %__MODULE__{state | queue: new_queue}}
 
+        {_, {:empty, new_queue}} ->
+          case current + step do
             new_current ->
               last = new_current - sign(step)
               {current..last, %__MODULE__{state | current: new_current, queue: new_queue}}
           end
-
-        {:finite, {:empty, new_queue}} ->
-          {:halt, %__MODULE__{state | queue: new_queue}}
       end
 
     {:reply, reply, new_state}
@@ -204,26 +217,20 @@ defmodule Indexer.Sequence do
 
   defp validate_options(options) do
     step = Keyword.fetch!(options, :step)
-    prefix = Keyword.get(options, :prefix, [])
-    first = Keyword.fetch!(options, :first)
 
-    validated_options = %{prefix: prefix, first: first, step: step}
+    case {Keyword.fetch(options, :ranges), Keyword.fetch(options, :first)} do
+      {:error, {:ok, first}} ->
+        {:ok, %{ranges: [], first: first, step: step}}
 
-    if step < 0 do
-      minimum_in_prefix =
-        prefix
-        |> Stream.map(&Enum.min/1)
-        |> Enum.min(fn -> first end)
+      {{:ok, ranges}, :error} ->
+        {:ok, %{ranges: ranges, first: nil, step: step}}
 
-      if first > minimum_in_prefix do
+      {{:ok, _}, {:ok, _}} ->
         {:error,
-         ":first (#{first}) is greater than the minimum in `:prefix` (#{minimum_in_prefix}), " <>
-           "which will cause retraversal."}
-      else
-        {:ok, validated_options}
-      end
-    else
-      {:ok, validated_options}
+         ":ranges and :first cannot be set at the same time as :ranges is for :finite mode while :first is for :infinite mode"}
+
+      {:error, :error} ->
+        {:error, "either :ranges or :first must be set"}
     end
   end
 end

--- a/apps/indexer/lib/indexer/sequence.ex
+++ b/apps/indexer/lib/indexer/sequence.ex
@@ -20,9 +20,9 @@ defmodule Indexer.Sequence do
   The first number in the sequence to start at once the `t:prefix/0` ranges and any `t:Range.t/0`s injected with
   `inject_range/2` are all consumed.
   """
-  @type first :: pos_integer()
+  @type first :: non_neg_integer()
 
-  @typep first_named_argument :: {:first, pos_integer()}
+  @typep first_named_argument :: {:first, first}
 
   @type mode :: :infinite | :finite
 

--- a/apps/indexer/lib/indexer/sequence.ex
+++ b/apps/indexer/lib/indexer/sequence.ex
@@ -152,7 +152,7 @@ defmodule Indexer.Sequence do
         {_, {:empty, new_queue}} ->
           case current + step do
             new_current ->
-              last = new_current - sign(step)
+              last = new_current - 1
               {current..last, %__MODULE__{state | current: new_current, queue: new_queue}}
           end
       end
@@ -209,18 +209,18 @@ defmodule Indexer.Sequence do
     end)
   end
 
-  @spec sign(neg_integer()) :: -1
-  defp sign(integer) when integer < 0, do: -1
-
-  @spec sign(non_neg_integer()) :: 1
-  defp sign(_), do: 1
-
   defp validate_options(options) do
     step = Keyword.fetch!(options, :step)
 
     case {Keyword.fetch(options, :ranges), Keyword.fetch(options, :first)} do
       {:error, {:ok, first}} ->
-        {:ok, %{ranges: [], first: first, step: step}}
+        case step do
+          pos_integer when is_integer(pos_integer) and pos_integer > 0 ->
+            {:ok, %{ranges: [], first: first, step: step}}
+
+          _ ->
+            {:error, ":step must be a positive integer for infinite sequences"}
+        end
 
       {{:ok, ranges}, :error} ->
         {:ok, %{ranges: ranges, first: nil, step: step}}

--- a/apps/indexer/test/indexer/block_fetcher_test.exs
+++ b/apps/indexer/test/indexer/block_fetcher_test.exs
@@ -829,68 +829,6 @@ defmodule Indexer.BlockFetcherTest do
     end
   end
 
-  describe "chunk_ranges/2" do
-    test "with first < last in one chunk" do
-      range = 0..1
-      size = 2
-
-      assert Enum.count(range) <= size
-      assert BlockFetcher.chunk_ranges([range], size) == [range]
-    end
-
-    test "with first < last with filled last chunk" do
-      range = 0..1
-      size = 1
-
-      assert Enum.count(range) > size
-      assert rem(Enum.count(range), size) == 0
-      assert BlockFetcher.chunk_ranges([range], size) == [0..0, 1..1]
-    end
-
-    test "with first < last with unfilled last chunk" do
-      range = 0..2
-      size = 2
-
-      assert Enum.count(range) > size
-      refute rem(Enum.count(range), size) == 0
-      assert BlockFetcher.chunk_ranges([range], size) == [0..1, 2..2]
-    end
-
-    test "with first == last" do
-      range = 0..0
-      size = 1
-
-      assert Enum.count(range) == size
-      assert BlockFetcher.chunk_ranges([range], size) == [range]
-    end
-
-    test "with first > last in one chunk" do
-      range = 1..0
-      size = 2
-
-      assert Enum.count(range) <= size
-      assert BlockFetcher.chunk_ranges([range], size) == [range]
-    end
-
-    test "with first > last with filled last chunk" do
-      range = 1..0
-      size = 1
-
-      assert Enum.count(range) > size
-      assert rem(Enum.count(range), size) == 0
-      assert BlockFetcher.chunk_ranges([range], size) == [1..1, 0..0]
-    end
-
-    test "with first > last with unfilled last chunk" do
-      range = 2..0
-      size = 2
-
-      assert Enum.count(range) > size
-      refute rem(Enum.count(range), size) == 0
-      assert BlockFetcher.chunk_ranges([range], size) == [2..1, 0..0]
-    end
-  end
-
   defp capture_log_at_level(level, block) do
     logger_level_transaction(fn ->
       Logger.configure(level: level)

--- a/apps/indexer/test/indexer/block_fetcher_test.exs
+++ b/apps/indexer/test/indexer/block_fetcher_test.exs
@@ -829,6 +829,68 @@ defmodule Indexer.BlockFetcherTest do
     end
   end
 
+  describe "chunk_ranges/2" do
+    test "with first < last in one chunk" do
+      range = 0..1
+      size = 2
+
+      assert Enum.count(range) <= size
+      assert BlockFetcher.chunk_ranges([range], size) == [range]
+    end
+
+    test "with first < last with filled last chunk" do
+      range = 0..1
+      size = 1
+
+      assert Enum.count(range) > size
+      assert rem(Enum.count(range), size) == 0
+      assert BlockFetcher.chunk_ranges([range], size) == [0..0, 1..1]
+    end
+
+    test "with first < last with unfilled last chunk" do
+      range = 0..2
+      size = 2
+
+      assert Enum.count(range) > size
+      refute rem(Enum.count(range), size) == 0
+      assert BlockFetcher.chunk_ranges([range], size) == [0..1, 2..2]
+    end
+
+    test "with first == last" do
+      range = 0..0
+      size = 1
+
+      assert Enum.count(range) == size
+      assert BlockFetcher.chunk_ranges([range], size) == [range]
+    end
+
+    test "with first > last in one chunk" do
+      range = 1..0
+      size = 2
+
+      assert Enum.count(range) <= size
+      assert BlockFetcher.chunk_ranges([range], size) == [range]
+    end
+
+    test "with first > last with filled last chunk" do
+      range = 1..0
+      size = 1
+
+      assert Enum.count(range) > size
+      assert rem(Enum.count(range), size) == 0
+      assert BlockFetcher.chunk_ranges([range], size) == [1..1, 0..0]
+    end
+
+    test "with first > last with unfilled last chunk" do
+      range = 2..0
+      size = 2
+
+      assert Enum.count(range) > size
+      refute rem(Enum.count(range), size) == 0
+      assert BlockFetcher.chunk_ranges([range], size) == [2..1, 0..0]
+    end
+  end
+
   defp capture_log_at_level(level, block) do
     logger_level_transaction(fn ->
       Logger.configure(level: level)

--- a/apps/indexer/test/indexer/sequence_test.exs
+++ b/apps/indexer/test/indexer/sequence_test.exs
@@ -29,6 +29,11 @@ defmodule Indexer.SequenceTest do
       # noproc when the sequence has already died by the time monitor is called
       assert_receive {:DOWN, ^sequence_ref, :process, ^sequence_pid, status} when status in [:normal, :noproc]
     end
+
+    test "with negative :step with :first greater than minimum in :prefix returns error" do
+      assert {:error, ":first (1) is greater than the minimum in `:prefix` (0), which will cause retraversal."} =
+               Sequence.start_link(prefix: [1..0], first: 1, step: -1)
+    end
   end
 
   test "inject_range" do


### PR DESCRIPTION
Resolves #340

## Changelog

### Enhancements
* Regression tests for #340.
* Move `chunk_ranges` from `BlockFetcher` to `Sequence` as this will guarantee that any caller of `Sequence.start_link` or `Sequence.inject_range` ends up queuing chunked ranges.
* Cap genesis sequence immediately, to indicate we don't really want infinite ranges after all the missing blocks are found, it will stop at `0` anyway.

### Bug Fixes
* Fix [off-by-one error](https://en.wikipedia.org/wiki/Off-by-one_error)s in `BlockFetcher.chunk_ranges`.
* Fix `chunk_ranges` for descending ranges.  
* Return error from `Sequence.start_link` if `:first` would cause a retraversal.  Retraversal occurs when `first` was set to the `latest_block_number` and the `step` was negative because the `prefix` of the missing block numbers which are all `<= latest_block_number` would be consumed, then the `Sequence` would start calculating infinite ranges starting `first`, which was back at `latest_block_number`.