### PR TITLE
Add transaction status indicator

### DIFF
--- a/apps/explorer_web/assets/css/_typography.scss
+++ b/apps/explorer_web/assets/css/_typography.scss
@@ -52,6 +52,6 @@ a {
 }
 
 .contract-address {
-  text-decoration: underline;
-  text-decoration-style: dashed;
+  border-bottom: 1px dashed currentColor;
+  display: inline-block;
 }

--- a/apps/explorer_web/assets/css/components/_tile.scss
+++ b/apps/explorer_web/assets/css/components/_tile.scss
@@ -65,6 +65,15 @@
     }
   }
 
+  &-status {
+    &--failed {
+      border: 1px solid lighten($danger, 10%);
+    }
+    &--out_of_gas {
+      border: 1px solid lighten($warning, 10%);
+    }
+  }
+
   .tile-title {
     font-size: 14px;
     font-weight: 600;

--- a/apps/explorer_web/assets/css/components/_tile.scss
+++ b/apps/explorer_web/assets/css/components/_tile.scss
@@ -70,7 +70,6 @@
     font-weight: 600;
     color: $gray-700;
     margin-bottom: 0;
-    display: block;
   }
 }
 

--- a/apps/explorer_web/assets/css/components/_tile.scss
+++ b/apps/explorer_web/assets/css/components/_tile.scss
@@ -22,7 +22,7 @@
     &-transaction {
       border-left: 4px solid $blue;
 
-      .tile-label, .tile-text-highlight {
+      .tile-label {
         color: $blue;
       }
     }
@@ -51,7 +51,7 @@
     &-token {
       border-left: 4px solid $orange;
 
-      .tile-label, .tile-text-highlight {
+      .tile-label {
         color: $orange;
       }
     }
@@ -59,7 +59,7 @@
     &-internal-transaction {
       border-left: 4px solid $teal;
 
-      .tile-label, .tile-text-highlight {
+      .tile-label {
         color: $teal;
       }
     }
@@ -67,10 +67,22 @@
 
   &-status {
     &--failed {
-      border: 1px solid lighten($danger, 10%);
+      border-top: 1px solid lighten($danger, 10%);
+      border-right: 1px solid lighten($danger, 10%);
+      border-bottom: 1px solid lighten($danger, 10%);
+
+      .tile-status-label {
+        color: $danger;
+      }
     }
     &--out_of_gas {
-      border: 1px solid lighten($warning, 10%);
+      border-top: 1px solid lighten($warning, 10%);
+      border-right: 1px solid lighten($warning, 10%);
+      border-bottom: 1px solid lighten($warning, 10%);
+
+      .tile-status-label {
+        color: $warning;
+      }
     }
   }
 

--- a/apps/explorer_web/assets/css/theme/_poa_variables.scss
+++ b/apps/explorer_web/assets/css/theme/_poa_variables.scss
@@ -38,7 +38,7 @@ $blue:    #4786ff !default;
 $indigo:  #5b33a1 !default;
 $purple:  #9987fc !default;
 $pink:    #e83e8c !default;
-$red:     #dc3545 !default;
+$red:     #c74d39 !default;
 $orange:  #ef9a60 !default;
 $yellow:  #ffc107 !default;
 $green:   #20b760 !default;

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
@@ -17,15 +17,15 @@
         <% else %>
           <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: ExplorerWeb.AddressView.contract?(@internal_transaction.to_address), locale: @locale %>
         <% end %>
+        <%= if @address.hash == @internal_transaction.from_address_hash do %>
+          <span class="badge badge-danger tile-badge">OUT</span>
+        <% else %>
+          <span class="badge badge-success tile-badge">IN</span>
+        <% end %>
       </span>
-      <%= ExplorerWeb.TransactionView.value(@internal_transaction, include_label: false) %> POA
     </div>
     <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column align-items-end justify-content-center text-md-right">
-      <%= if @address.hash == @internal_transaction.from_address_hash do %>
-        <span class="badge badge-danger tile-badge">OUT</span>
-      <% else %>
-        <span class="badge badge-success tile-badge">IN</span>
-      <% end %>
+      <%= ExplorerWeb.TransactionView.value(@internal_transaction, include_label: false) %> <%= gettext "Ether" %>
     </div>
   </div>
 </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
@@ -17,15 +17,17 @@
         <% else %>
           <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: ExplorerWeb.AddressView.contract?(@internal_transaction.to_address), locale: @locale %>
         <% end %>
-        <%= if @address.hash == @internal_transaction.from_address_hash do %>
-          <span class="badge badge-danger tile-badge">OUT</span>
-        <% else %>
-          <span class="badge badge-success tile-badge">IN</span>
-        <% end %>
       </span>
+      <%= if @address.hash == @internal_transaction.from_address_hash do %>
+        <span class="badge badge-danger tile-badge"><%= gettext "OUT" %></span>
+      <% else %>
+        <span class="badge badge-success tile-badge"><%= gettext "IN" %></span>
+      <% end %>
     </div>
-    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column align-items-end justify-content-center text-md-right">
-      <%= ExplorerWeb.TransactionView.value(@internal_transaction, include_label: false) %> <%= gettext "Ether" %>
+    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right">
+      <span class="tile-title">
+        <%= ExplorerWeb.TransactionView.value(@internal_transaction, include_label: false) %> <%= gettext "Ether" %>
+      </span>
     </div>
   </div>
 </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -1,8 +1,10 @@
 <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in  tile-status--<%= status(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row">
-    <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
-      <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
-      <div data-test="transaction_status" class="text-muted"><%= formatted_status(@transaction) %></div>
+    <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
+      <span class="tile-label">
+        <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
+      </span>
+      <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(@transaction) %></div>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
       <div class="col-md-1" data-test="transaction_status">
-        <div class="transaction__dot transaction__dot--<%= status(@transaction) %>"></div>
+        <div class="transaction__dot transaction__dot--<%= status(@transaction) %>" data-toggle="tooltip" title="<%= formatted_status(@transaction) %>"></div>
       </div>
       <div class="col-md-11">
         <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -1,12 +1,8 @@
 <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row">
-    <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-      <div class="col-md-1" data-test="transaction_status">
-        <div class="transaction__dot transaction__dot--<%= status(@transaction) %>" data-toggle="tooltip" title="<%= formatted_status(@transaction) %>"></div>
-      </div>
-      <div class="col-md-11">
-        <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
-      </div>
+    <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+      <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
+      <div data-test="transaction_status" class="text-muted"><%= formatted_status(@transaction) %></div>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
@@ -16,6 +12,7 @@
         <% else %>
           <%= render ExplorerWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(@transaction.from_address), locale: @locale %>
         <% end %>
+
         &rarr;
         <%= if @address.hash == ExplorerWeb.TransactionView.to_address_hash(@transaction) do %>
           <%= render ExplorerWeb.AddressView, "_responsive_hash.html", address_hash: ExplorerWeb.TransactionView.to_address_hash(@transaction), contract: ExplorerWeb.AddressView.contract?(@transaction.to_address) %>
@@ -23,19 +20,26 @@
           <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.TransactionView.to_address_hash(@transaction), contract: ExplorerWeb.AddressView.contract?(@transaction.to_address), locale: @locale %>
         <% end %>
       </span>
-      <%= ExplorerWeb.TransactionView.value(@transaction, include_label: false) %> POA
+      <span>
+        <%= if @address.hash == @transaction.from_address_hash do %>
+          <span class="badge badge-danger tile-badge">Out</span>
+        <% else %>
+          <span class="badge badge-success tile-badge">In</span>
+        <% end %>
+        <span class="ml-1" data-from-now="<%= @transaction.block.timestamp %>"></span>
+        <span class="ml-1">
+          <%= link(
+            gettext("Block #") <> "#{@transaction.block.number}",
+            to: block_path(ExplorerWeb.Endpoint, :show, @locale, @transaction.block)
+          ) %>
+        </span>
+      </span>
     </div>
-    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start justify-content-md-end align-items-end text-md-right">
-      <%= if @address.hash == @transaction.from_address_hash do %>
-        <span class="badge badge-warning tile-badge  mr-2 mr-md-0">OUT</span>
-      <% else %>
-        <span class="badge badge-success tile-badge mr-2 mr-md-0">IN</span>
-      <% end %>
-      <span class="mr-2 mr-sm-0" data-from-now="<%= @transaction.block.timestamp %>"></span>
-      <%= link(
-        gettext("Block #") <> "#{@transaction.block.number}",
-        to: block_path(ExplorerWeb.Endpoint, :show, @locale, @transaction.block)
-      ) %>
+    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start align-items-end text-md-right">
+      <span class="tile-title">
+        <%= ExplorerWeb.TransactionView.value(@transaction, include_label: false) %> POA
+      </span>
+      <span class="mr-2 mr-sm-0 text-muted"> <%= ExplorerWeb.TransactionView.formatted_fee(@transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
     </div>
   </div>
 </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -1,11 +1,11 @@
-<div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in  tile-status--<%= status(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
+<div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in  tile-status--<%= ExplorerWeb.TransactionView.status(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row">
     <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
       <span class="tile-label">
         <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
       </span>
       <div class="tile-status-label" data-test="transaction_status">
-        <%= formatted_status(@transaction) %>
+        <%= ExplorerWeb.TransactionView.formatted_status(@transaction) %>
       </div>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
@@ -26,14 +26,14 @@
       </span>
       <span>
         <%= if @address.hash == @transaction.from_address_hash do %>
-          <span class="badge badge-danger tile-badge">Out</span>
+          <span class="badge badge-danger tile-badge"><%= gettext "OUT" %></span>
         <% else %>
-          <span class="badge badge-success tile-badge">In</span>
+          <span class="badge badge-success tile-badge"><%= gettext "IN" %></span>
         <% end %>
         <span class="ml-1" data-from-now="<%= @transaction.block.timestamp %>"></span>
         <span class="ml-1">
           <%= link(
-            gettext("Block #") <> "#{@transaction.block.number}",
+            gettext("Block #%{number}", number: to_string(@transaction.block.number)),
             to: block_path(ExplorerWeb.Endpoint, :show, @locale, @transaction.block)
           ) %>
         </span>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -4,7 +4,9 @@
       <span class="tile-label">
         <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
       </span>
-      <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(@transaction) %></div>
+      <div class="tile-status-label" data-test="transaction_status">
+        <%= formatted_status(@transaction) %>
+      </div>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
@@ -39,7 +41,7 @@
     </div>
     <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start align-items-end text-md-right">
       <span class="tile-title">
-        <%= ExplorerWeb.TransactionView.value(@transaction, include_label: false) %> POA
+        <%= ExplorerWeb.TransactionView.value(@transaction, include_label: false) %> <%= gettext "Ether" %>
       </span>
       <span class="mr-2 mr-sm-0 text-muted"> <%= ExplorerWeb.TransactionView.formatted_fee(@transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
     </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in" data-transaction-hash="<%= @transaction.hash %>">
+<div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in  tile-status--<%= status(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row">
     <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
       <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -1,7 +1,12 @@
 <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(@transaction) %> fade-in" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row">
     <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-      <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
+      <div class="col-md-1" data-test="transaction_status">
+        <div class="transaction__dot transaction__dot--<%= status(@transaction) %>"></div>
+      </div>
+      <div class="col-md-11">
+        <%= ExplorerWeb.TransactionView.transaction_display_type(@transaction) %>
+      </div>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -149,7 +149,7 @@
               <%= for transaction <- @transactions do %>
                 <tr data-transaction-hash="<%= transaction.hash %>">
                   <td data-test="transaction_status">
-                    <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+                    <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
                   </td>
                   <td>
                     <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -149,7 +149,7 @@
               <%= for transaction <- @transactions do %>
                 <tr data-transaction-hash="<%= transaction.hash %>">
                   <td data-test="transaction_status">
-                    <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
+                    <div class="transaction__dot transaction__dot--<%= ExplorerWeb.TransactionView.status(transaction) %>" data-toggle="tooltip" title="<%= ExplorerWeb.TransactionView.formatted_status(transaction) %>"></div>
                   </td>
                   <td>
                     <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/index.html.eex
@@ -148,7 +148,7 @@
             <tbody>
               <%= for transaction <- @transactions do %>
                 <tr data-transaction-hash="<%= transaction.hash %>">
-                  <td>
+                  <td data-test="transaction_status">
                     <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
                   </td>
                   <td>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -6,7 +6,12 @@
     <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
       <div class="row" data-test="chain_transaction">
         <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-          <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+          <div class="col-md-1" data-test="transaction_status">
+            <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+          </div>
+          <div class="col-md-11">
+            <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+          </div>
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">
           <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -12,20 +12,27 @@
           </div>
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">
-          <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
+            <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
           <span>
             <%= render ExplorerWeb.AddressView, "_link.html", address_hash: transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(transaction.from_address), locale: @locale %>
             &rarr;
             <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.TransactionView.to_address_hash(transaction), contract: ExplorerWeb.AddressView.contract?(transaction.to_address), locale: @locale %>
           </span>
-          <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA
+          <span>
+            <span class="ml-1" data-from-now="<%= transaction.block.timestamp %>"></span>
+            <span class="ml-1">
+              <%= link(
+                gettext("Block #") <> "#{transaction.block.number}",
+                to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
+              ) %>
+            </span>
+          </span>
         </div>
-        <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start justify-content-md-end text-md-right">
-          <span class="mr-2 mr-sm-0" data-from-now="<%= transaction.block.timestamp %>"></span>
-          <%= link(
-            gettext("Block #") <> "#{transaction.block.number}",
-            to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
-          ) %>
+        <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right">
+          <span class="tile-title">
+            <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA
+          </span>
+          <span><%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
         </div>
       </div>
     </div>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -7,7 +7,7 @@
       <div class="row" data-test="chain_transaction">
         <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
           <div class="col-md-1" data-test="transaction_status">
-            <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+            <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
           </div>
           <div class="col-md-11">
             <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -7,7 +7,7 @@
       <div class="row" data-test="chain_transaction">
         <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
           <div class="ml-4">
-            <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+            <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
             <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
           </div>
         </div>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -5,12 +5,10 @@
     <%= for transaction <- @chain.transactions do %>
     <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
       <div class="row" data-test="chain_transaction">
-        <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-          <div class="col-md-1" data-test="transaction_status">
-            <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
-          </div>
-          <div class="col-md-11">
+        <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+          <div class="ml-4">
             <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+            <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
           </div>
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -3,12 +3,12 @@
     <%= link(gettext("View All Transactions →"), to: transaction_path(@conn, :index, Gettext.get_locale), class: "button button--secondary button--xsmall float-right") %>
     <h2 class="card-title"><%= gettext "Transactions" %></h2>
     <%= for transaction <- @chain.transactions do %>
-    <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
+    <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
       <div class="row" data-test="chain_transaction">
-        <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+        <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
           <div class="ml-4">
-            <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
-            <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
+            <span class="tile-label" data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
+            <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(transaction) %></div>
           </div>
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">
@@ -30,7 +30,7 @@
         </div>
         <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right">
           <span class="tile-title">
-            <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA
+            <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> <%= gettext "Ether" %>
           </span>
           <span><%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
         </div>

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -3,12 +3,12 @@
     <%= link(gettext("View All Transactions →"), to: transaction_path(@conn, :index, Gettext.get_locale), class: "button button--secondary button--xsmall float-right") %>
     <h2 class="card-title"><%= gettext "Transactions" %></h2>
     <%= for transaction <- @chain.transactions do %>
-    <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
+    <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= ExplorerWeb.TransactionView.status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
       <div class="row" data-test="chain_transaction">
         <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
           <div class="ml-4">
             <span class="tile-label" data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
-            <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(transaction) %></div>
+            <div class="tile-status-label" data-test="transaction_status"><%= ExplorerWeb.TransactionView.formatted_status(transaction) %></div>
           </div>
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">
@@ -22,7 +22,7 @@
             <span class="ml-1" data-from-now="<%= transaction.block.timestamp %>"></span>
             <span class="ml-1">
               <%= link(
-                gettext("Block #") <> "#{transaction.block.number}",
+                gettext("Block #%{number}", number: to_string(transaction.block.number)),
                 to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
               ) %>
             </span>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -29,7 +29,7 @@
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
               <div class="col-md-1" data-test="transaction_status">
-                <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+                <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
               </div>
               <div class="col-md-11">
                 <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -44,7 +44,7 @@
                   <%= gettext("Contract Address Pending") %>
                 <% end %>
               </span>
-              <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA
+              <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> <%= gettext "Ether" %>
             </div>
           </div>
         </div>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -29,7 +29,7 @@
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
               <div class="ml-4">
-                <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+                <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
                 <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
               </div>
             </div>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -28,7 +28,12 @@
         <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-              <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+              <div class="col-md-1" data-test="transaction_status">
+                <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+              </div>
+              <div class="col-md-11">
+                <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+              </div>
             </div>
 
             <div class="col-md-7 col-lg-8 d-flex flex-column">

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -27,15 +27,12 @@
       <%= for transaction <- @transactions do %>
         <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
-            <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-              <div class="col-md-1" data-test="transaction_status">
-                <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
-              </div>
-              <div class="col-md-11">
+            <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+              <div class="ml-4">
                 <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+                <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
               </div>
             </div>
-
             <div class="col-md-7 col-lg-8 d-flex flex-column">
               <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
               <span>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -30,7 +30,7 @@
             <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
               <div class="ml-4">
                 <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
-                <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
+                <div data-test="transaction_status" class="text-muted"><%= ExplorerWeb.TransactionView.formatted_status(transaction) %></div>
               </div>
             </div>
             <div class="col-md-7 col-lg-8 d-flex flex-column">

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -27,15 +27,12 @@
       <%= for transaction <- @transactions do %>
         <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
-            <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
-              <div class="col-md-1" data-test="transaction_status">
-                <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
-              </div>
-              <div class="col-md-11" data-test="transaction_type">
+            <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+              <div class="ml-4">
                 <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+                <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
               </div>
             </div>
-
             <div class="col-md-7 col-lg-8 d-flex flex-column">
               <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
               <span>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -40,14 +40,19 @@
                 &rarr;
                 <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.TransactionView.to_address_hash(transaction), contract: ExplorerWeb.AddressView.contract?(transaction.to_address), locale: @locale %>
               </span>
-              <%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA
+              <span>
+                <span data-from-now="<%= transaction.block.timestamp %>"></span>
+                <span class="ml-1">
+                  <%= link(
+                    gettext("Block #") <> "#{transaction.block.number}",
+                    to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
+                  ) %>
+                </span>
+              </span>
             </div>
-            <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start justify-content-md-end text-md-right">
-              <span class="mr-2 mr-sm-0" data-from-now="<%= transaction.block.timestamp %>"></span>
-              <%= link(
-                gettext("Block #") <> "#{transaction.block.number}",
-                to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
-              ) %>
+            <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right">
+              <span class="tile-title"><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA</span>
+              <span> <%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
             </div>
           </div>
         </div>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -29,7 +29,7 @@
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
               <div class="ml-4">
-                <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+                <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
                 <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
               </div>
             </div>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -29,7 +29,7 @@
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
               <div class="col-md-1" data-test="transaction_status">
-                <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+                <div class="transaction__dot transaction__dot--<%= status(transaction) %>" data-toggle="tooltip" title="<%= formatted_status(transaction) %>"></div>
               </div>
               <div class="col-md-11" data-test="transaction_type">
                 <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -27,8 +27,13 @@
       <%= for transaction <- @transactions do %>
         <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
-            <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label" data-test="transaction_type">
-              <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+            <div class="col-md-2 d-flex align-items-center justify-content-start justify-content-lg-center  tile-label">
+              <div class="col-md-1" data-test="transaction_status">
+                <div class="transaction__dot transaction__dot--<%= status(transaction) %>"></div>
+              </div>
+              <div class="col-md-11" data-test="transaction_type">
+                <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %>
+              </div>
             </div>
 
             <div class="col-md-7 col-lg-8 d-flex flex-column">

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -25,12 +25,12 @@
       <p><%= gettext("Showing %{count} Validated Transactions", count: Cldr.Number.to_string!(@transaction_estimated_count, format: "#,###")) %></p>
 
       <%= for transaction <- @transactions do %>
-        <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
+        <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= ExplorerWeb.TransactionView.status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
             <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
               <div class="ml-4">
                 <span class="tile-label" data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
-                <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(transaction) %></div>
+                <div class="tile-status-label" data-test="transaction_status"><%= ExplorerWeb.TransactionView.formatted_status(transaction) %></div>
               </div>
             </div>
             <div class="col-md-7 col-lg-8 d-flex flex-column">
@@ -44,7 +44,7 @@
                 <span data-from-now="<%= transaction.block.timestamp %>"></span>
                 <span class="ml-1">
                   <%= link(
-                    gettext("Block #") <> "#{transaction.block.number}",
+                    gettext("Block #%{number}", number: to_string(transaction.block.number)),
                     to: block_path(@conn, :show, @conn.assigns.locale, transaction.block)
                   ) %>
                 </span>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/index.html.eex
@@ -25,12 +25,12 @@
       <p><%= gettext("Showing %{count} Validated Transactions", count: Cldr.Number.to_string!(@transaction_estimated_count, format: "#,###")) %></p>
 
       <%= for transaction <- @transactions do %>
-        <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
+        <div class="tile tile-type-<%= ExplorerWeb.TransactionView.type_suffix(transaction) %> tile-status--<%= status(transaction) %>" data-test="<%= ExplorerWeb.TransactionView.type_suffix(transaction) %>" data-transaction-hash="<%= transaction.hash %>">
           <div class="row" data-test="chain_transaction">
-            <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center tile-label">
+            <div class="col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
               <div class="ml-4">
-                <span data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
-                <div data-test="transaction_status" class="text-muted"><%= formatted_status(transaction) %></div>
+                <span class="tile-label" data-test="transaction_type"> <%= ExplorerWeb.TransactionView.transaction_display_type(transaction) %></span>
+                <div class="tile-status-label" data-test="transaction_status"><%= formatted_status(transaction) %></div>
               </div>
             </div>
             <div class="col-md-7 col-lg-8 d-flex flex-column">
@@ -51,7 +51,7 @@
               </span>
             </div>
             <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right">
-              <span class="tile-title"><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> POA</span>
+              <span class="tile-title"><%= ExplorerWeb.TransactionView.value(transaction, include_label: false) %> <%= gettext "Ether" %></span>
               <span> <%= ExplorerWeb.TransactionView.formatted_fee(transaction, denomination: :ether) %> <%= gettext "Fee" %></span>
             </div>
           </div>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -24,8 +24,8 @@
                   <%= gettext "Transaction Status" %>
                 </th>
                 <td>
-                  <%= formatted_status(@transaction) %>
-                  <div class="transaction__dot transaction__dot--<%= status(@transaction) %>"></div>
+                  <%= ExplorerWeb.TransactionView.formatted_status(@transaction) %>
+                  <div class="transaction__dot transaction__dot--<%= ExplorerWeb.TransactionView.status(@transaction) %>"></div>
                 </td>
               </tr>
               <tr>

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -13,5 +13,6 @@ defmodule ExplorerWeb.AddressTransactionView do
     end
   end
 
+  defdelegate formatted_status(transaction), to: TransactionView
   defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -3,8 +3,6 @@ defmodule ExplorerWeb.AddressTransactionView do
 
   import ExplorerWeb.AddressView, only: [contract?: 1, smart_contract_verified?: 1]
 
-  alias ExplorerWeb.TransactionView
-
   def format_current_filter(filter) do
     case filter do
       "to" -> gettext("To")

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -10,5 +10,4 @@ defmodule ExplorerWeb.AddressTransactionView do
       _ -> gettext("All")
     end
   end
-
 end

--- a/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/address_transaction_view.ex
@@ -13,6 +13,4 @@ defmodule ExplorerWeb.AddressTransactionView do
     end
   end
 
-  defdelegate formatted_status(transaction), to: TransactionView
-  defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
@@ -3,6 +3,7 @@ defmodule ExplorerWeb.BlockTransactionView do
 
   alias ExplorerWeb.{BlockView, TransactionView}
 
+  defdelegate formatted_status(transaction), to: TransactionView
   defdelegate formatted_timestamp(block), to: BlockView
   defdelegate status(transacton), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
@@ -1,7 +1,7 @@
 defmodule ExplorerWeb.BlockTransactionView do
   use ExplorerWeb, :view
 
-  alias ExplorerWeb.{BlockView, TransactionView}
+  alias ExplorerWeb.BlockView
 
   defdelegate formatted_timestamp(block), to: BlockView
 end

--- a/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/block_transaction_view.ex
@@ -3,7 +3,5 @@ defmodule ExplorerWeb.BlockTransactionView do
 
   alias ExplorerWeb.{BlockView, TransactionView}
 
-  defdelegate formatted_status(transaction), to: TransactionView
   defdelegate formatted_timestamp(block), to: BlockView
-  defdelegate status(transacton), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -33,6 +33,4 @@ defmodule ExplorerWeb.ChainView do
     |> format_usd_value()
   end
 
-  defdelegate formatted_status(transaction), to: TransactionView
-  defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -33,5 +33,6 @@ defmodule ExplorerWeb.ChainView do
     |> format_usd_value()
   end
 
+  defdelegate formatted_status(transaction), to: TransactionView
   defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -3,6 +3,7 @@ defmodule ExplorerWeb.ChainView do
 
   alias Explorer.ExchangeRates.Token
   alias ExplorerWeb.ExchangeRates.USD
+  alias ExplorerWeb.TransactionView
 
   def encode_market_history_data(market_history_data) do
     market_history_data
@@ -31,4 +32,6 @@ defmodule ExplorerWeb.ChainView do
     |> USD.from()
     |> format_usd_value()
   end
+
+  defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -3,7 +3,6 @@ defmodule ExplorerWeb.ChainView do
 
   alias Explorer.ExchangeRates.Token
   alias ExplorerWeb.ExchangeRates.USD
-  alias ExplorerWeb.TransactionView
 
   def encode_market_history_data(market_history_data) do
     market_history_data

--- a/apps/explorer_web/lib/explorer_web/views/chain_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/chain_view.ex
@@ -31,5 +31,4 @@ defmodule ExplorerWeb.ChainView do
     |> USD.from()
     |> format_usd_value()
   end
-
 end

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -5,5 +5,6 @@ defmodule ExplorerWeb.PendingTransactionView do
 
   alias ExplorerWeb.TransactionView
 
+  defdelegate formatted_status(transaction), to: TransactionView
   defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -3,6 +3,4 @@ defmodule ExplorerWeb.PendingTransactionView do
 
   @dialyzer :no_match
 
-  alias ExplorerWeb.TransactionView
-
 end

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -5,6 +5,4 @@ defmodule ExplorerWeb.PendingTransactionView do
 
   alias ExplorerWeb.TransactionView
 
-  defdelegate formatted_status(transaction), to: TransactionView
-  defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -2,5 +2,4 @@ defmodule ExplorerWeb.PendingTransactionView do
   use ExplorerWeb, :view
 
   @dialyzer :no_match
-
 end

--- a/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/pending_transaction_view.ex
@@ -2,4 +2,8 @@ defmodule ExplorerWeb.PendingTransactionView do
   use ExplorerWeb, :view
 
   @dialyzer :no_match
+
+  alias ExplorerWeb.TransactionView
+
+  defdelegate status(transaction), to: TransactionView
 end

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,93 +1,61 @@
 #: lib/explorer_web/templates/block/index.html.eex:18
-#: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
-#: lib/explorer_web/templates/block_transaction/index.html.eex:141
-#: lib/explorer_web/templates/transaction/overview.html.eex:51
 #: lib/explorer_web/templates/transaction/overview.html.eex:51
 msgid "Age"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
-#: lib/explorer_web/templates/block_transaction/index.html.eex:140
 msgid "Block"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/_blocks.html.eex:5
-#: lib/explorer_web/templates/chain/_blocks.html.eex:5
-#: lib/explorer_web/templates/layout/_topnav.html.eex:13
 #: lib/explorer_web/templates/layout/_topnav.html.eex:13
 msgid "Blocks"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_footer.html.eex:18
-#: lib/explorer_web/templates/layout/_footer.html.eex:18
 msgid "Copyright %{year} POA"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:175
-#: lib/explorer_web/templates/transaction/overview.html.eex:175
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
-#: lib/explorer_web/templates/block_transaction/index.html.eex:30
-#: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 msgid "Hash"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:17
-#: lib/explorer_web/templates/block/index.html.eex:17
 msgid "Height"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/app.html.eex:7
 #: lib/explorer_web/templates/layout/app.html.eex:7
 msgid "POA Network Explorer"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:21
-#: lib/explorer_web/templates/address/overview.html.eex:21
-#: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:123
-#: lib/explorer_web/templates/address_transaction/index.html.eex:123
-#: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/layout/_topnav.html.eex:18
-#: lib/explorer_web/templates/layout/_topnav.html.eex:18
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:24
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:24
-#: lib/explorer_web/templates/transaction/index.html.eex:24
 #: lib/explorer_web/templates/transaction/index.html.eex:24
 msgid "Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
-#: lib/explorer_web/templates/transaction/overview.html.eex:71
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr ""
@@ -97,27 +65,20 @@ msgid "Block #%{number} Details"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:58
-#: lib/explorer_web/templates/block_transaction/index.html.eex:58
 msgid "Difficulty"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:142
 #: lib/explorer_web/templates/transaction/overview.html.eex:142
 msgid "Gas Limit"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:50
-#: lib/explorer_web/templates/block_transaction/index.html.eex:50
 msgid "Miner"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:116
 #: lib/explorer_web/templates/transaction/overview.html.eex:116
 msgid "Nonce"
 msgstr ""
@@ -127,31 +88,25 @@ msgid "Number"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:38
-#: lib/explorer_web/templates/block_transaction/index.html.eex:38
 msgid "Parent Hash"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:80
 #: lib/explorer_web/templates/block_transaction/index.html.eex:80
 msgid "Size"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:14
-#: lib/explorer_web/templates/block_transaction/index.html.eex:14
 msgid "Timestamp"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:72
 msgid "Total Difficulty"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:33
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
 msgid "Block Number"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:11
 #: lib/explorer_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr ""
@@ -161,20 +116,15 @@ msgid "Cumulative Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block/index.html.eex:21
 msgid "Gas"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:150
 #: lib/explorer_web/templates/transaction/overview.html.eex:150
 msgid "Gas Price"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:183
 #: lib/explorer_web/templates/transaction/overview.html.eex:183
 msgid "Input"
 msgstr ""
@@ -184,30 +134,20 @@ msgid "%{confirmations} block confirmations"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
-#: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/views/address_view.ex:15
 #: lib/explorer_web/views/address_view.ex:15
 msgid "Address"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
-#: lib/explorer_web/templates/block_transaction/index.html.eex:142
-#: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
 #: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr ""
@@ -218,23 +158,15 @@ msgid "Overview"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:70
-#: lib/explorer_web/views/transaction_view.ex:70
 msgid "Success"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
-#: lib/explorer_web/templates/block_transaction/index.html.eex:144
-#: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr ""
@@ -245,13 +177,10 @@ msgid "Transaction Hash"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:24
-#: lib/explorer_web/templates/transaction/overview.html.eex:24
 msgid "Transaction Status"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:12
 #: lib/explorer_web/templates/address/_values.html.eex:12
 msgid "Balance"
 msgstr ""
@@ -267,11 +196,9 @@ msgid "POA"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:39
-#: lib/explorer_web/templates/block/index.html.eex:39
 msgid "%{count} transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/block/index.html.eex:5
 #: lib/explorer_web/templates/block/index.html.eex:5
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr ""
@@ -281,41 +208,30 @@ msgid "Showing %{count} Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
 #: lib/explorer_web/views/transaction_view.ex:38
-#: lib/explorer_web/views/transaction_view.ex:38
-#: lib/explorer_web/views/transaction_view.ex:69
 #: lib/explorer_web/views/transaction_view.ex:69
 msgid "Pending"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:130
-#: lib/explorer_web/templates/transaction/overview.html.eex:130
 msgid "First Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:136
 #: lib/explorer_web/templates/transaction/overview.html.eex:136
 msgid "Last Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction_log/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:25
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:25
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:30
 #: lib/explorer_web/templates/transaction_log/index.html.eex:30
 msgid "Topic"
 msgstr ""
@@ -357,16 +273,13 @@ msgid "Next Page"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:67
-#: lib/explorer_web/views/transaction_view.ex:67
 msgid "Failed"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:68
-#: lib/explorer_web/views/transaction_view.ex:68
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 msgid "Status"
 msgstr ""
@@ -380,55 +293,37 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-#: lib/explorer_web/views/wei_helpers.ex:71
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr ""
 
 #: lib/explorer_web/views/block_view.ex:18
-#: lib/explorer_web/views/block_view.ex:18
-#: lib/explorer_web/views/wei_helpers.ex:70
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
-#: lib/explorer_web/templates/address_contract/index.html.eex:17
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_transaction/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/transaction_log/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_topnav.html.eex:27
-#: lib/explorer_web/templates/layout/_topnav.html.eex:27
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:67
 #: lib/explorer_web/templates/transaction_log/index.html.eex:67
 msgid "There are no logs currently."
 msgstr ""
@@ -446,43 +341,31 @@ msgid "Transactions To"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
 msgid "Type"
 msgstr ""
 
-#: lib/explorer_web/views/wei_helpers.ex:69
 #: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
 #: lib/explorer_web/templates/chain/_transactions.html.eex:35
-#: lib/explorer_web/templates/chain/_transactions.html.eex:35
-#: lib/explorer_web/templates/transaction/index.html.eex:55
 #: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:7
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:7
-#: lib/explorer_web/templates/transaction/index.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:7
 msgid "Validated"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:3
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
 msgstr ""
@@ -500,27 +383,20 @@ msgid "Avg Block Time"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/show.html.eex:18
-#: lib/explorer_web/templates/chain/show.html.eex:18
 msgid "Market Cap"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:10
 #: lib/explorer_web/templates/chain/show.html.eex:10
 msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
-#: lib/explorer_web/templates/address/_values.html.eex:12
-#: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
-#: lib/explorer_web/templates/transaction/overview.html.eex:167
-#: lib/explorer_web/views/currency_helpers.ex:32
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
 
-#: lib/explorer_web/templates/address/_values.html.eex:20
 #: lib/explorer_web/templates/address/_values.html.eex:20
 msgid "Number of Transactions"
 msgstr ""
@@ -529,7 +405,6 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:25
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
@@ -559,8 +434,6 @@ msgid "Total Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:22
-#: lib/explorer_web/views/transaction_view.ex:113
 #: lib/explorer_web/views/transaction_view.ex:113
 msgid "Transaction"
 msgstr ""
@@ -575,8 +448,6 @@ msgid "View All"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:167
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
 msgid "TX Fee"
 msgstr ""
@@ -586,7 +457,6 @@ msgid "Contract"
 msgstr ""
 
 #: lib/explorer_web/views/address_view.ex:13
-#: lib/explorer_web/views/address_view.ex:13
 msgid "Contract Address"
 msgstr ""
 
@@ -595,177 +465,137 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:192
-#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
-#: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/transaction/index.html.eex:62
 #: lib/explorer_web/templates/transaction/index.html.eex:62
 msgid "Older"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
-#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 msgid "Contract Source Code"
 msgstr ""
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:44
 #: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:31
-#: lib/explorer_web/templates/address_transaction/index.html.eex:31
-#: lib/explorer_web/templates/address_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:61
 msgid "Code"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:9
-#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:8
-#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr ""
 
-#: lib/explorer_web/templates/address/_values.html.eex:28
 #: lib/explorer_web/templates/address/_values.html.eex:28
 msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-#: lib/explorer_web/templates/transaction_log/index.html.eex:73
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:109
-#: lib/explorer_web/templates/transaction/overview.html.eex:109
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-#: lib/explorer_web/views/transaction_view.ex:111
 #: lib/explorer_web/views/transaction_view.ex:111
 msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:34
-#: lib/explorer_web/templates/layout/_topnav.html.eex:34
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:38
 #: lib/explorer_web/templates/layout/_topnav.html.eex:38
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:37
-#: lib/explorer_web/templates/layout/_topnav.html.eex:37
 msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
 #: lib/explorer_web/templates/layout/_footer.html.eex:4
 msgid "Facebook"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:7
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Instagram"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:13
 #: lib/explorer_web/templates/layout/_footer.html.eex:13
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
-#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:34
 #: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/transaction/index.html.eex:47
 #: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
-#: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/chain/_transactions.html.eex:3
 #: lib/explorer_web/templates/chain/_transactions.html.eex:3
 msgid "View All Transactions →"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:28
-#: lib/explorer_web/templates/chain/show.html.eex:28
 msgid "Average block time"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/chain/show.html.eex:36
 #: lib/explorer_web/templates/chain/show.html.eex:36
 msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:44
-#: lib/explorer_web/templates/chain/show.html.eex:44
 msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/transaction/overview.html.eex:46
 #: lib/explorer_web/templates/transaction/overview.html.eex:46
 msgid "block confirmations"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:81
-#: lib/explorer_web/templates/address_transaction/index.html.eex:81
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:8
 #: lib/explorer_web/templates/address/overview.html.eex:8
 msgid "Copy Address"
 msgstr ""
@@ -773,54 +603,45 @@ msgstr ""
 #, elixir-format
 #:
 #: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
 msgid "Internal Transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:76
 #: lib/explorer_web/templates/address_transaction/index.html.eex:76
 msgid "More messages have come in"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
-#: lib/explorer_web/templates/address/overview.html.eex:13
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:131
-#: lib/explorer_web/templates/address_transaction/index.html.eex:131
 msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/views/transaction_view.ex:112
-#: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:25
-#: lib/explorer_web/templates/address/overview.html.eex:25
 msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:36
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -293,6 +293,11 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:28
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
+#: lib/explorer_web/templates/chain/_transactions.html.eex:33
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction/index.html.eex:54
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
@@ -355,7 +360,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:46
 #: lib/explorer_web/templates/chain/_transactions.html.eex:35
 #: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
@@ -554,7 +559,7 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:34
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
 #: lib/explorer_web/templates/chain/_transactions.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -1,61 +1,93 @@
 #: lib/explorer_web/templates/block/index.html.eex:18
+#: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
+#: lib/explorer_web/templates/block_transaction/index.html.eex:141
+#: lib/explorer_web/templates/transaction/overview.html.eex:51
 #: lib/explorer_web/templates/transaction/overview.html.eex:51
 msgid "Age"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
+#: lib/explorer_web/templates/block_transaction/index.html.eex:140
 msgid "Block"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/_blocks.html.eex:5
+#: lib/explorer_web/templates/chain/_blocks.html.eex:5
+#: lib/explorer_web/templates/layout/_topnav.html.eex:13
 #: lib/explorer_web/templates/layout/_topnav.html.eex:13
 msgid "Blocks"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_footer.html.eex:18
+#: lib/explorer_web/templates/layout/_footer.html.eex:18
 msgid "Copyright %{year} POA"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:175
+#: lib/explorer_web/templates/transaction/overview.html.eex:175
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 msgid "Hash"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:17
 msgid "Height"
 msgstr ""
 
+#: lib/explorer_web/templates/layout/app.html.eex:7
 #: lib/explorer_web/templates/layout/app.html.eex:7
 msgid "POA Network Explorer"
 msgstr ""
 
 #: lib/explorer_web/templates/address/overview.html.eex:21
+#: lib/explorer_web/templates/address/overview.html.eex:21
+#: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:123
+#: lib/explorer_web/templates/address_transaction/index.html.eex:123
+#: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/layout/_topnav.html.eex:18
+#: lib/explorer_web/templates/layout/_topnav.html.eex:18
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:24
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:24
+#: lib/explorer_web/templates/transaction/index.html.eex:24
 #: lib/explorer_web/templates/transaction/index.html.eex:24
 msgid "Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
+#: lib/explorer_web/templates/transaction/overview.html.eex:71
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr ""
@@ -65,20 +97,27 @@ msgid "Block #%{number} Details"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:58
+#: lib/explorer_web/templates/block_transaction/index.html.eex:58
 msgid "Difficulty"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/transaction/overview.html.eex:142
 #: lib/explorer_web/templates/transaction/overview.html.eex:142
 msgid "Gas Limit"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:50
+#: lib/explorer_web/templates/block_transaction/index.html.eex:50
 msgid "Miner"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/transaction/overview.html.eex:116
 #: lib/explorer_web/templates/transaction/overview.html.eex:116
 msgid "Nonce"
 msgstr ""
@@ -88,25 +127,31 @@ msgid "Number"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:38
+#: lib/explorer_web/templates/block_transaction/index.html.eex:38
 msgid "Parent Hash"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:80
 #: lib/explorer_web/templates/block_transaction/index.html.eex:80
 msgid "Size"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:14
+#: lib/explorer_web/templates/block_transaction/index.html.eex:14
 msgid "Timestamp"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:72
 msgid "Total Difficulty"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:33
+#: lib/explorer_web/templates/transaction/overview.html.eex:33
 msgid "Block Number"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:11
 #: lib/explorer_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr ""
@@ -116,15 +161,20 @@ msgid "Cumulative Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block/index.html.eex:21
 msgid "Gas"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/transaction/overview.html.eex:150
 #: lib/explorer_web/templates/transaction/overview.html.eex:150
 msgid "Gas Price"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:183
 #: lib/explorer_web/templates/transaction/overview.html.eex:183
 msgid "Input"
 msgstr ""
@@ -134,20 +184,30 @@ msgid "%{confirmations} block confirmations"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
+#: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
+#: lib/explorer_web/templates/transaction_log/index.html.eex:29
+#: lib/explorer_web/views/address_view.ex:15
 #: lib/explorer_web/views/address_view.ex:15
 msgid "Address"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
+#: lib/explorer_web/templates/block_transaction/index.html.eex:142
+#: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_transaction_view.ex:11
 #: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr ""
@@ -158,15 +218,23 @@ msgid "Overview"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:70
+#: lib/explorer_web/views/transaction_view.ex:70
 msgid "Success"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
+#: lib/explorer_web/templates/block_transaction/index.html.eex:144
+#: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr ""
@@ -177,10 +245,13 @@ msgid "Transaction Hash"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:24
+#: lib/explorer_web/templates/transaction/overview.html.eex:24
 msgid "Transaction Status"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:12
 #: lib/explorer_web/templates/address/_values.html.eex:12
 msgid "Balance"
 msgstr ""
@@ -196,9 +267,11 @@ msgid "POA"
 msgstr ""
 
 #: lib/explorer_web/templates/block/index.html.eex:39
+#: lib/explorer_web/templates/block/index.html.eex:39
 msgid "%{count} transactions"
 msgstr ""
 
+#: lib/explorer_web/templates/block/index.html.eex:5
 #: lib/explorer_web/templates/block/index.html.eex:5
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr ""
@@ -208,30 +281,41 @@ msgid "Showing %{count} Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
+#: lib/explorer_web/templates/transaction/overview.html.eex:57
 #: lib/explorer_web/views/transaction_view.ex:38
+#: lib/explorer_web/views/transaction_view.ex:38
+#: lib/explorer_web/views/transaction_view.ex:69
 #: lib/explorer_web/views/transaction_view.ex:69
 msgid "Pending"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:130
+#: lib/explorer_web/templates/transaction/overview.html.eex:130
 msgid "First Seen"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:136
 #: lib/explorer_web/templates/transaction/overview.html.eex:136
 msgid "Last Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/transaction_log/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:25
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:25
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction_log/index.html.eex:30
 #: lib/explorer_web/templates/transaction_log/index.html.eex:30
 msgid "Topic"
 msgstr ""
@@ -273,13 +357,16 @@ msgid "Next Page"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:67
+#: lib/explorer_web/views/transaction_view.ex:67
 msgid "Failed"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:68
+#: lib/explorer_web/views/transaction_view.ex:68
 msgid "Out of Gas"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 msgid "Status"
 msgstr ""
@@ -293,37 +380,55 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+#: lib/explorer_web/views/wei_helpers.ex:71
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr ""
 
 #: lib/explorer_web/views/block_view.ex:18
+#: lib/explorer_web/views/block_view.ex:18
+#: lib/explorer_web/views/wei_helpers.ex:70
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
+#: lib/explorer_web/templates/address_contract/index.html.eex:17
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_transaction/index.html.eex:20
+#: lib/explorer_web/templates/address_transaction/index.html.eex:20
+#: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/transaction_log/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_topnav.html.eex:27
+#: lib/explorer_web/templates/layout/_topnav.html.eex:27
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction_log/index.html.eex:67
 #: lib/explorer_web/templates/transaction_log/index.html.eex:67
 msgid "There are no logs currently."
 msgstr ""
@@ -341,29 +446,43 @@ msgid "Transactions To"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
 msgid "Type"
 msgstr ""
 
+#: lib/explorer_web/views/wei_helpers.ex:69
 #: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:12
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:102
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/chain/_transactions.html.eex:35
+#: lib/explorer_web/templates/chain/_transactions.html.eex:35
+#: lib/explorer_web/templates/transaction/index.html.eex:55
+#: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:7
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:7
+#: lib/explorer_web/templates/transaction/index.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:7
 msgid "Validated"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:3
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
 msgstr ""
@@ -381,20 +500,27 @@ msgid "Avg Block Time"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/show.html.eex:18
+#: lib/explorer_web/templates/chain/show.html.eex:18
 msgid "Market Cap"
 msgstr ""
 
+#: lib/explorer_web/templates/chain/show.html.eex:10
 #: lib/explorer_web/templates/chain/show.html.eex:10
 msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
+#: lib/explorer_web/templates/address/_values.html.eex:12
+#: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
+#: lib/explorer_web/templates/transaction/overview.html.eex:167
+#: lib/explorer_web/views/currency_helpers.ex:32
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
 
+#: lib/explorer_web/templates/address/_values.html.eex:20
 #: lib/explorer_web/templates/address/_values.html.eex:20
 msgid "Number of Transactions"
 msgstr ""
@@ -403,6 +529,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/index.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:25
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
@@ -432,6 +559,8 @@ msgid "Total Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
+#: lib/explorer_web/templates/block_transaction/index.html.eex:22
+#: lib/explorer_web/views/transaction_view.ex:113
 #: lib/explorer_web/views/transaction_view.ex:113
 msgid "Transaction"
 msgstr ""
@@ -446,6 +575,8 @@ msgid "View All"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:167
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
 msgid "TX Fee"
 msgstr ""
@@ -455,6 +586,7 @@ msgid "Contract"
 msgstr ""
 
 #: lib/explorer_web/views/address_view.ex:13
+#: lib/explorer_web/views/address_view.ex:13
 msgid "Contract Address"
 msgstr ""
 
@@ -463,137 +595,177 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:192
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/transaction/index.html.eex:57
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
+#: lib/explorer_web/templates/transaction/index.html.eex:62
+#: lib/explorer_web/templates/transaction/index.html.eex:62
 msgid "Older"
 msgstr ""
 
+#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 #: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 msgid "Contract Source Code"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:44
+#: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:31
+#: lib/explorer_web/templates/address_transaction/index.html.eex:31
+#: lib/explorer_web/templates/address_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:61
 msgid "Code"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:9
+#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:8
+#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr ""
 
+#: lib/explorer_web/templates/address/_values.html.eex:28
 #: lib/explorer_web/templates/address/_values.html.eex:28
 msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/explorer_web/templates/transaction_log/index.html.eex:73
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:109
+#: lib/explorer_web/templates/transaction/overview.html.eex:109
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+#: lib/explorer_web/views/transaction_view.ex:111
 #: lib/explorer_web/views/transaction_view.ex:111
 msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:34
+#: lib/explorer_web/templates/layout/_topnav.html.eex:34
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:38
 #: lib/explorer_web/templates/layout/_topnav.html.eex:38
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:37
+#: lib/explorer_web/templates/layout/_topnav.html.eex:37
 msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
 #: lib/explorer_web/templates/layout/_footer.html.eex:4
 msgid "Facebook"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:7
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Instagram"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:13
 #: lib/explorer_web/templates/layout/_footer.html.eex:13
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
+#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:26
-#: lib/explorer_web/templates/transaction/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:4
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/_transactions.html.eex:3
+#: lib/explorer_web/templates/chain/_transactions.html.eex:3
 msgid "View All Transactions →"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:28
 #: lib/explorer_web/templates/chain/show.html.eex:28
 msgid "Average block time"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:36
+#: lib/explorer_web/templates/chain/show.html.eex:36
 msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:44
 #: lib/explorer_web/templates/chain/show.html.eex:44
 msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:46
+#: lib/explorer_web/templates/transaction/overview.html.eex:46
 msgid "block confirmations"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:81
+#: lib/explorer_web/templates/address_transaction/index.html.eex:81
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:8
 #: lib/explorer_web/templates/address/overview.html.eex:8
 msgid "Copy Address"
 msgstr ""
@@ -601,45 +773,54 @@ msgstr ""
 #, elixir-format
 #:
 #: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
 msgid "Internal Transaction"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address_transaction/index.html.eex:76
 #: lib/explorer_web/templates/address_transaction/index.html.eex:76
 msgid "More messages have come in"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
+#: lib/explorer_web/templates/address/overview.html.eex:13
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:131
+#: lib/explorer_web/templates/address_transaction/index.html.eex:131
 msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/views/transaction_view.ex:112
+#: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:25
+#: lib/explorer_web/templates/address/overview.html.eex:25
 msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:36
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -148,7 +148,7 @@ msgstr ""
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_transaction_view.ex:9
 msgid "From"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:8
 msgid "To"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:28
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:29
 #: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
 #: lib/explorer_web/templates/chain/_transactions.html.eex:33
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:47
@@ -356,7 +356,7 @@ msgstr ""
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
+#: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "All"
 msgstr ""
 
@@ -559,13 +559,6 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/transaction/index.html.eex:47
-msgid "Block #"
-msgstr ""
-
-#, elixir-format
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
@@ -649,4 +642,25 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/transaction/index.html.eex:47
+msgid "Block #%{number}"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:24
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:31
+msgid "IN"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:29
+msgid "OUT"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -470,8 +470,8 @@ msgstr ""
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:57
-#: lib/explorer_web/templates/transaction/index.html.eex:60
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
+#: lib/explorer_web/templates/transaction/index.html.eex:57
 msgid "Older"
 msgstr ""
 
@@ -553,8 +553,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:28
-#: lib/explorer_web/templates/transaction/index.html.eex:51
+#: lib/explorer_web/templates/chain/_transactions.html.eex:26
+#: lib/explorer_web/templates/transaction/index.html.eex:48
 msgid "Block #"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -470,8 +470,8 @@ msgstr ""
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:52
-#: lib/explorer_web/templates/transaction/index.html.eex:55
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:57
+#: lib/explorer_web/templates/transaction/index.html.eex:60
 msgid "Older"
 msgstr ""
 
@@ -552,9 +552,9 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:31
-#: lib/explorer_web/templates/chain/_transactions.html.eex:23
-#: lib/explorer_web/templates/transaction/index.html.eex:46
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
+#: lib/explorer_web/templates/chain/_transactions.html.eex:28
+#: lib/explorer_web/templates/transaction/index.html.eex:51
 msgid "Block #"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:42
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
 msgid "Contract Address Pending"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -482,8 +482,8 @@ msgstr ""
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:52
-#: lib/explorer_web/templates/transaction/index.html.eex:55
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:57
+#: lib/explorer_web/templates/transaction/index.html.eex:60
 msgid "Older"
 msgstr ""
 
@@ -564,9 +564,9 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:31
-#: lib/explorer_web/templates/chain/_transactions.html.eex:23
-#: lib/explorer_web/templates/transaction/index.html.eex:46
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
+#: lib/explorer_web/templates/chain/_transactions.html.eex:28
+#: lib/explorer_web/templates/transaction/index.html.eex:51
 msgid "Block #"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:42
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
 msgid "Contract Address Pending"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,95 +11,63 @@ msgstr ""
 "Language: en\n"
 
 #: lib/explorer_web/templates/block/index.html.eex:18
-#: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
-#: lib/explorer_web/templates/block_transaction/index.html.eex:141
-#: lib/explorer_web/templates/transaction/overview.html.eex:51
 #: lib/explorer_web/templates/transaction/overview.html.eex:51
 msgid "Age"
 msgstr "Age"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
-#: lib/explorer_web/templates/block_transaction/index.html.eex:140
 msgid "Block"
 msgstr "Block"
 
 #: lib/explorer_web/templates/chain/_blocks.html.eex:5
-#: lib/explorer_web/templates/chain/_blocks.html.eex:5
-#: lib/explorer_web/templates/layout/_topnav.html.eex:13
 #: lib/explorer_web/templates/layout/_topnav.html.eex:13
 msgid "Blocks"
 msgstr "Blocks"
 
 #: lib/explorer_web/templates/layout/_footer.html.eex:18
-#: lib/explorer_web/templates/layout/_footer.html.eex:18
 msgid "Copyright %{year} POA"
 msgstr "%{year} POA Network Ltd. All rights reserved"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:175
-#: lib/explorer_web/templates/transaction/overview.html.eex:175
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr "Gas Used"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
-#: lib/explorer_web/templates/block_transaction/index.html.eex:30
-#: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 msgid "Hash"
 msgstr "Hash"
 
 #: lib/explorer_web/templates/block/index.html.eex:17
-#: lib/explorer_web/templates/block/index.html.eex:17
 msgid "Height"
 msgstr "Height"
 
-#: lib/explorer_web/templates/layout/app.html.eex:7
 #: lib/explorer_web/templates/layout/app.html.eex:7
 msgid "POA Network Explorer"
 msgstr "POA Network Explorer"
 
 #: lib/explorer_web/templates/address/overview.html.eex:21
-#: lib/explorer_web/templates/address/overview.html.eex:21
-#: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_transaction/index.html.eex:13
-#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:123
-#: lib/explorer_web/templates/address_transaction/index.html.eex:123
-#: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/block_transaction/index.html.eex:124
-#: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/layout/_topnav.html.eex:18
-#: lib/explorer_web/templates/layout/_topnav.html.eex:18
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:24
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:24
-#: lib/explorer_web/templates/transaction/index.html.eex:24
 #: lib/explorer_web/templates/transaction/index.html.eex:24
 msgid "Transactions"
 msgstr "Transactions"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/block_transaction/index.html.eex:145
-#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
-#: lib/explorer_web/templates/transaction/overview.html.eex:71
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr "Value"
@@ -109,27 +77,20 @@ msgid "Block #%{number} Details"
 msgstr "Block #%{number} Details"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:58
-#: lib/explorer_web/templates/block_transaction/index.html.eex:58
 msgid "Difficulty"
 msgstr "Difficulty"
 
 #: lib/explorer_web/templates/block/index.html.eex:21
-#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/block_transaction/index.html.eex:96
-#: lib/explorer_web/templates/transaction/overview.html.eex:142
 #: lib/explorer_web/templates/transaction/overview.html.eex:142
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:50
-#: lib/explorer_web/templates/block_transaction/index.html.eex:50
 msgid "Miner"
 msgstr "Validator"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/block_transaction/index.html.eex:104
-#: lib/explorer_web/templates/transaction/overview.html.eex:116
 #: lib/explorer_web/templates/transaction/overview.html.eex:116
 msgid "Nonce"
 msgstr "Nonce"
@@ -139,31 +100,25 @@ msgid "Number"
 msgstr "Height"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:38
-#: lib/explorer_web/templates/block_transaction/index.html.eex:38
 msgid "Parent Hash"
 msgstr "Parent Hash"
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:80
 #: lib/explorer_web/templates/block_transaction/index.html.eex:80
 msgid "Size"
 msgstr "Size"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:14
-#: lib/explorer_web/templates/block_transaction/index.html.eex:14
 msgid "Timestamp"
 msgstr "Timestamp"
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:72
 msgid "Total Difficulty"
 msgstr "Total Difficulty"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:33
-#: lib/explorer_web/templates/transaction/overview.html.eex:33
 msgid "Block Number"
 msgstr "Block Height"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:11
 #: lib/explorer_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr "Transaction Details"
@@ -173,20 +128,15 @@ msgid "Cumulative Gas Used"
 msgstr "Cumulative Gas Used"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:20
-#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block/index.html.eex:21
 msgid "Gas"
 msgstr "Gas"
 
 #: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/block/index.html.eex:22
-#: lib/explorer_web/templates/transaction/overview.html.eex:150
 #: lib/explorer_web/templates/transaction/overview.html.eex:150
 msgid "Gas Price"
 msgstr "Gas Price"
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:183
 #: lib/explorer_web/templates/transaction/overview.html.eex:183
 msgid "Input"
 msgstr "Input"
@@ -196,30 +146,20 @@ msgid "%{confirmations} block confirmations"
 msgstr "%{confirmations} block confirmations"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
-#: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/templates/transaction_log/index.html.eex:29
-#: lib/explorer_web/views/address_view.ex:15
 #: lib/explorer_web/views/address_view.ex:15
 msgid "Address"
 msgstr "Address"
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
-#: lib/explorer_web/templates/block_transaction/index.html.eex:142
-#: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
 #: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr "From"
@@ -230,23 +170,15 @@ msgid "Overview"
 msgstr "Overview"
 
 #: lib/explorer_web/views/transaction_view.ex:70
-#: lib/explorer_web/views/transaction_view.ex:70
 msgid "Success"
 msgstr "Success"
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
-#: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
-#: lib/explorer_web/templates/block_transaction/index.html.eex:144
-#: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr "To"
@@ -257,13 +189,10 @@ msgid "Transaction Hash"
 msgstr "Transaction Hash"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:24
-#: lib/explorer_web/templates/transaction/overview.html.eex:24
 msgid "Transaction Status"
 msgstr "Transaction Status"
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:12
 #: lib/explorer_web/templates/address/_values.html.eex:12
 msgid "Balance"
 msgstr "Balance"
@@ -279,11 +208,9 @@ msgid "POA"
 msgstr "POA"
 
 #: lib/explorer_web/templates/block/index.html.eex:39
-#: lib/explorer_web/templates/block/index.html.eex:39
 msgid "%{count} transactions"
 msgstr "%{count} transactions"
 
-#: lib/explorer_web/templates/block/index.html.eex:5
 #: lib/explorer_web/templates/block/index.html.eex:5
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr "Showing #%{start_block} to #%{end_block}"
@@ -293,41 +220,30 @@ msgid "Showing %{count} Transactions"
 msgstr "Showing %{count} Transactions"
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
-#: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
-#: lib/explorer_web/templates/transaction/overview.html.eex:57
 #: lib/explorer_web/views/transaction_view.ex:38
-#: lib/explorer_web/views/transaction_view.ex:38
-#: lib/explorer_web/views/transaction_view.ex:69
 #: lib/explorer_web/views/transaction_view.ex:69
 msgid "Pending"
 msgstr "Pending"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:130
-#: lib/explorer_web/templates/transaction/overview.html.eex:130
 msgid "First Seen"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/overview.html.eex:136
 #: lib/explorer_web/templates/transaction/overview.html.eex:136
 msgid "Last Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
-#: lib/explorer_web/templates/transaction_log/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:25
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:25
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:30
 #: lib/explorer_web/templates/transaction_log/index.html.eex:30
 msgid "Topic"
 msgstr ""
@@ -369,16 +285,13 @@ msgid "Next Page"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:67
-#: lib/explorer_web/views/transaction_view.ex:67
 msgid "Failed"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:68
-#: lib/explorer_web/views/transaction_view.ex:68
 msgid "Out of Gas"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 msgid "Status"
 msgstr ""
@@ -392,55 +305,37 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
-#: lib/explorer_web/views/wei_helpers.ex:71
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr "POA"
 
 #: lib/explorer_web/views/block_view.ex:18
-#: lib/explorer_web/views/block_view.ex:18
-#: lib/explorer_web/views/wei_helpers.ex:70
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
-#: lib/explorer_web/templates/address_contract/index.html.eex:17
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_transaction/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction/index.html.eex:20
-#: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
-#: lib/explorer_web/templates/transaction_log/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_topnav.html.eex:27
-#: lib/explorer_web/templates/layout/_topnav.html.eex:27
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction_log/index.html.eex:67
 #: lib/explorer_web/templates/transaction_log/index.html.eex:67
 msgid "There are no logs currently."
 msgstr ""
@@ -458,43 +353,31 @@ msgid "Transactions To"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
 msgid "Type"
 msgstr ""
 
-#: lib/explorer_web/views/wei_helpers.ex:69
 #: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
-#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
 #: lib/explorer_web/templates/chain/_transactions.html.eex:35
-#: lib/explorer_web/templates/chain/_transactions.html.eex:35
-#: lib/explorer_web/templates/transaction/index.html.eex:55
 #: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:7
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:7
-#: lib/explorer_web/templates/transaction/index.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:7
 msgid "Validated"
 msgstr ""
 
-#: lib/explorer_web/templates/block_transaction/index.html.eex:3
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
 msgstr ""
@@ -512,27 +395,20 @@ msgid "Avg Block Time"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/show.html.eex:18
-#: lib/explorer_web/templates/chain/show.html.eex:18
 msgid "Market Cap"
 msgstr ""
 
-#: lib/explorer_web/templates/chain/show.html.eex:10
 #: lib/explorer_web/templates/chain/show.html.eex:10
 msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
-#: lib/explorer_web/templates/address/_values.html.eex:12
-#: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
-#: lib/explorer_web/templates/transaction/overview.html.eex:167
-#: lib/explorer_web/views/currency_helpers.ex:32
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
 
-#: lib/explorer_web/templates/address/_values.html.eex:20
 #: lib/explorer_web/templates/address/_values.html.eex:20
 msgid "Number of Transactions"
 msgstr ""
@@ -541,7 +417,6 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/explorer_web/templates/transaction/index.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:25
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
@@ -571,8 +446,6 @@ msgid "Total Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
-#: lib/explorer_web/templates/block_transaction/index.html.eex:22
-#: lib/explorer_web/views/transaction_view.ex:113
 #: lib/explorer_web/views/transaction_view.ex:113
 msgid "Transaction"
 msgstr ""
@@ -587,8 +460,6 @@ msgid "View All"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:159
-#: lib/explorer_web/templates/transaction/overview.html.eex:167
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
 msgid "TX Fee"
 msgstr ""
@@ -598,7 +469,6 @@ msgid "Contract"
 msgstr ""
 
 #: lib/explorer_web/views/address_view.ex:13
-#: lib/explorer_web/views/address_view.ex:13
 msgid "Contract Address"
 msgstr ""
 
@@ -607,177 +477,137 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:192
-#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
-#: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block/index.html.eex:60
-#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/transaction/index.html.eex:62
 #: lib/explorer_web/templates/transaction/index.html.eex:62
 msgid "Older"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
-#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 msgid "Contract Source Code"
 msgstr "Contract Source Code"
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:44
 #: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_contract/index.html.eex:27
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:31
-#: lib/explorer_web/templates/address_transaction/index.html.eex:31
-#: lib/explorer_web/templates/address_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:61
 msgid "Code"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:9
-#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr "No"
 
 #: lib/explorer_web/views/address_contract_view.ex:8
-#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr "Yes"
 
-#: lib/explorer_web/templates/address/_values.html.eex:28
 #: lib/explorer_web/templates/address/_values.html.eex:28
 msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
-#: lib/explorer_web/templates/transaction_log/index.html.eex:73
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:109
-#: lib/explorer_web/templates/transaction/overview.html.eex:109
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
-#: lib/explorer_web/views/transaction_view.ex:111
 #: lib/explorer_web/views/transaction_view.ex:111
 msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:34
-#: lib/explorer_web/templates/layout/_topnav.html.eex:34
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_topnav.html.eex:38
 #: lib/explorer_web/templates/layout/_topnav.html.eex:38
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:37
-#: lib/explorer_web/templates/layout/_topnav.html.eex:37
 msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
 #: lib/explorer_web/templates/layout/_footer.html.eex:4
 msgid "Facebook"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:7
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Instagram"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:13
 #: lib/explorer_web/templates/layout/_footer.html.eex:13
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
-#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:34
 #: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/transaction/index.html.eex:47
 #: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
-#: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/chain/_transactions.html.eex:3
 #: lib/explorer_web/templates/chain/_transactions.html.eex:3
 msgid "View All Transactions →"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:28
-#: lib/explorer_web/templates/chain/show.html.eex:28
 msgid "Average block time"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/chain/show.html.eex:36
 #: lib/explorer_web/templates/chain/show.html.eex:36
 msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:44
-#: lib/explorer_web/templates/chain/show.html.eex:44
 msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/transaction/overview.html.eex:46
 #: lib/explorer_web/templates/transaction/overview.html.eex:46
 msgid "block confirmations"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:81
-#: lib/explorer_web/templates/address_transaction/index.html.eex:81
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:8
 #: lib/explorer_web/templates/address/overview.html.eex:8
 msgid "Copy Address"
 msgstr ""
@@ -785,54 +615,45 @@ msgstr ""
 #, elixir-format
 #:
 #: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
 msgid "Internal Transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/index.html.eex:76
 #: lib/explorer_web/templates/address_transaction/index.html.eex:76
 msgid "More messages have come in"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
-#: lib/explorer_web/templates/address/overview.html.eex:13
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:131
-#: lib/explorer_web/templates/address_transaction/index.html.eex:131
 msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/views/transaction_view.ex:112
-#: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:25
-#: lib/explorer_web/templates/address/overview.html.eex:25
 msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:36
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,63 +11,95 @@ msgstr ""
 "Language: en\n"
 
 #: lib/explorer_web/templates/block/index.html.eex:18
+#: lib/explorer_web/templates/block/index.html.eex:18
 #: lib/explorer_web/templates/block_transaction/index.html.eex:141
+#: lib/explorer_web/templates/block_transaction/index.html.eex:141
+#: lib/explorer_web/templates/transaction/overview.html.eex:51
 #: lib/explorer_web/templates/transaction/overview.html.eex:51
 msgid "Age"
 msgstr "Age"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:140
+#: lib/explorer_web/templates/block_transaction/index.html.eex:140
 msgid "Block"
 msgstr "Block"
 
 #: lib/explorer_web/templates/chain/_blocks.html.eex:5
+#: lib/explorer_web/templates/chain/_blocks.html.eex:5
+#: lib/explorer_web/templates/layout/_topnav.html.eex:13
 #: lib/explorer_web/templates/layout/_topnav.html.eex:13
 msgid "Blocks"
 msgstr "Blocks"
 
 #: lib/explorer_web/templates/layout/_footer.html.eex:18
+#: lib/explorer_web/templates/layout/_footer.html.eex:18
 msgid "Copyright %{year} POA"
 msgstr "%{year} POA Network Ltd. All rights reserved"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/block_transaction/index.html.eex:88
 #: lib/explorer_web/templates/transaction/overview.html.eex:175
+#: lib/explorer_web/templates/transaction/overview.html.eex:175
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:34
 msgid "Gas Used"
 msgstr "Gas Used"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:30
+#: lib/explorer_web/templates/block_transaction/index.html.eex:139
 #: lib/explorer_web/templates/block_transaction/index.html.eex:139
 msgid "Hash"
 msgstr "Hash"
 
 #: lib/explorer_web/templates/block/index.html.eex:17
+#: lib/explorer_web/templates/block/index.html.eex:17
 msgid "Height"
 msgstr "Height"
 
+#: lib/explorer_web/templates/layout/app.html.eex:7
 #: lib/explorer_web/templates/layout/app.html.eex:7
 msgid "POA Network Explorer"
 msgstr "POA Network Explorer"
 
 #: lib/explorer_web/templates/address/overview.html.eex:21
+#: lib/explorer_web/templates/address/overview.html.eex:21
+#: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_contract/index.html.eex:10
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_transaction/index.html.eex:13
+#: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:47
 #: lib/explorer_web/templates/address_transaction/index.html.eex:123
+#: lib/explorer_web/templates/address_transaction/index.html.eex:123
+#: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block/index.html.eex:19
 #: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/block_transaction/index.html.eex:124
+#: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/chain/_transactions.html.eex:4
 #: lib/explorer_web/templates/layout/_topnav.html.eex:18
+#: lib/explorer_web/templates/layout/_topnav.html.eex:18
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:24
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:24
+#: lib/explorer_web/templates/transaction/index.html.eex:24
 #: lib/explorer_web/templates/transaction/index.html.eex:24
 msgid "Transactions"
 msgstr "Transactions"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/block_transaction/index.html.eex:145
+#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
+#: lib/explorer_web/templates/transaction/overview.html.eex:71
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
 msgid "Value"
 msgstr "Value"
@@ -77,20 +109,27 @@ msgid "Block #%{number} Details"
 msgstr "Block #%{number} Details"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:58
+#: lib/explorer_web/templates/block_transaction/index.html.eex:58
 msgid "Difficulty"
 msgstr "Difficulty"
 
 #: lib/explorer_web/templates/block/index.html.eex:21
+#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/block_transaction/index.html.eex:96
+#: lib/explorer_web/templates/transaction/overview.html.eex:142
 #: lib/explorer_web/templates/transaction/overview.html.eex:142
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:50
+#: lib/explorer_web/templates/block_transaction/index.html.eex:50
 msgid "Miner"
 msgstr "Validator"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/block_transaction/index.html.eex:104
+#: lib/explorer_web/templates/transaction/overview.html.eex:116
 #: lib/explorer_web/templates/transaction/overview.html.eex:116
 msgid "Nonce"
 msgstr "Nonce"
@@ -100,25 +139,31 @@ msgid "Number"
 msgstr "Height"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:38
+#: lib/explorer_web/templates/block_transaction/index.html.eex:38
 msgid "Parent Hash"
 msgstr "Parent Hash"
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:80
 #: lib/explorer_web/templates/block_transaction/index.html.eex:80
 msgid "Size"
 msgstr "Size"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:14
+#: lib/explorer_web/templates/block_transaction/index.html.eex:14
 msgid "Timestamp"
 msgstr "Timestamp"
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:72
 #: lib/explorer_web/templates/block_transaction/index.html.eex:72
 msgid "Total Difficulty"
 msgstr "Total Difficulty"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:33
+#: lib/explorer_web/templates/transaction/overview.html.eex:33
 msgid "Block Number"
 msgstr "Block Height"
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:11
 #: lib/explorer_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr "Transaction Details"
@@ -128,15 +173,20 @@ msgid "Cumulative Gas Used"
 msgstr "Cumulative Gas Used"
 
 #: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:20
+#: lib/explorer_web/templates/block/index.html.eex:21
 #: lib/explorer_web/templates/block/index.html.eex:21
 msgid "Gas"
 msgstr "Gas"
 
 #: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/block/index.html.eex:22
+#: lib/explorer_web/templates/transaction/overview.html.eex:150
 #: lib/explorer_web/templates/transaction/overview.html.eex:150
 msgid "Gas Price"
 msgstr "Gas Price"
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:183
 #: lib/explorer_web/templates/transaction/overview.html.eex:183
 msgid "Input"
 msgstr "Input"
@@ -146,20 +196,30 @@ msgid "%{confirmations} block confirmations"
 msgstr "%{confirmations} block confirmations"
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:25
+#: lib/explorer_web/templates/block_transaction/index.html.eex:25
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
 #: lib/explorer_web/templates/transaction_log/index.html.eex:29
+#: lib/explorer_web/templates/transaction_log/index.html.eex:29
+#: lib/explorer_web/views/address_view.ex:15
 #: lib/explorer_web/views/address_view.ex:15
 msgid "Address"
 msgstr "Address"
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:98
+#: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/address_transaction/index.html.eex:109
 #: lib/explorer_web/templates/block_transaction/index.html.eex:142
+#: lib/explorer_web/templates/block_transaction/index.html.eex:142
+#: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_internal_transaction_view.ex:9
+#: lib/explorer_web/views/address_transaction_view.ex:11
 #: lib/explorer_web/views/address_transaction_view.ex:11
 msgid "From"
 msgstr "From"
@@ -170,15 +230,23 @@ msgid "Overview"
 msgstr "Overview"
 
 #: lib/explorer_web/views/transaction_view.ex:70
+#: lib/explorer_web/views/transaction_view.ex:70
 msgid "Success"
 msgstr "Success"
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:86
+#: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/address_transaction/index.html.eex:97
 #: lib/explorer_web/templates/block_transaction/index.html.eex:144
+#: lib/explorer_web/templates/block_transaction/index.html.eex:144
+#: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_internal_transaction_view.ex:8
+#: lib/explorer_web/views/address_transaction_view.ex:10
 #: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "To"
 msgstr "To"
@@ -189,10 +257,13 @@ msgid "Transaction Hash"
 msgstr "Transaction Hash"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:24
+#: lib/explorer_web/templates/transaction/overview.html.eex:24
 msgid "Transaction Status"
 msgstr "Transaction Status"
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:12
 #: lib/explorer_web/templates/address/_values.html.eex:12
 msgid "Balance"
 msgstr "Balance"
@@ -208,9 +279,11 @@ msgid "POA"
 msgstr "POA"
 
 #: lib/explorer_web/templates/block/index.html.eex:39
+#: lib/explorer_web/templates/block/index.html.eex:39
 msgid "%{count} transactions"
 msgstr "%{count} transactions"
 
+#: lib/explorer_web/templates/block/index.html.eex:5
 #: lib/explorer_web/templates/block/index.html.eex:5
 msgid "Showing #%{start_block} to #%{end_block}"
 msgstr "Showing #%{start_block} to #%{end_block}"
@@ -220,30 +293,41 @@ msgid "Showing %{count} Transactions"
 msgstr "Showing %{count} Transactions"
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:14
+#: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/index.html.eex:14
 #: lib/explorer_web/templates/transaction/overview.html.eex:57
+#: lib/explorer_web/templates/transaction/overview.html.eex:57
 #: lib/explorer_web/views/transaction_view.ex:38
+#: lib/explorer_web/views/transaction_view.ex:38
+#: lib/explorer_web/views/transaction_view.ex:69
 #: lib/explorer_web/views/transaction_view.ex:69
 msgid "Pending"
 msgstr "Pending"
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:130
+#: lib/explorer_web/templates/transaction/overview.html.eex:130
 msgid "First Seen"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/overview.html.eex:136
 #: lib/explorer_web/templates/transaction/overview.html.eex:136
 msgid "Last Seen"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:18
+#: lib/explorer_web/templates/transaction_log/index.html.eex:18
 #: lib/explorer_web/templates/transaction_log/index.html.eex:18
 msgid "Logs"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:25
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:25
 msgid "Showing %{count} Pending Transactions"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction_log/index.html.eex:30
 #: lib/explorer_web/templates/transaction_log/index.html.eex:30
 msgid "Topic"
 msgstr ""
@@ -285,13 +369,16 @@ msgid "Next Page"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:67
+#: lib/explorer_web/views/transaction_view.ex:67
 msgid "Failed"
 msgstr ""
 
 #: lib/explorer_web/views/transaction_view.ex:68
+#: lib/explorer_web/views/transaction_view.ex:68
 msgid "Out of Gas"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:137
 #: lib/explorer_web/templates/block_transaction/index.html.eex:137
 msgid "Status"
 msgstr ""
@@ -305,37 +392,55 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
+#: lib/explorer_web/views/wei_helpers.ex:71
 #: lib/explorer_web/views/wei_helpers.ex:71
 msgid "Ether"
 msgstr "POA"
 
 #: lib/explorer_web/views/block_view.ex:18
+#: lib/explorer_web/views/block_view.ex:18
+#: lib/explorer_web/views/wei_helpers.ex:70
 #: lib/explorer_web/views/wei_helpers.ex:70
 msgid "Gwei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:17
+#: lib/explorer_web/templates/address_contract/index.html.eex:17
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:52
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:111
 #: lib/explorer_web/templates/address_transaction/index.html.eex:20
+#: lib/explorer_web/templates/address_transaction/index.html.eex:20
+#: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/address_transaction/index.html.eex:52
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:11
+#: lib/explorer_web/templates/transaction_log/index.html.eex:11
 #: lib/explorer_web/templates/transaction_log/index.html.eex:11
 msgid "Internal Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/layout/_topnav.html.eex:27
+#: lib/explorer_web/templates/layout/_topnav.html.eex:27
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:64
 msgid "There are no Internal Transactions"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction_log/index.html.eex:67
 #: lib/explorer_web/templates/transaction_log/index.html.eex:67
 msgid "There are no logs currently."
 msgstr ""
@@ -353,29 +458,43 @@ msgid "Transactions To"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:30
 msgid "Type"
 msgstr ""
 
+#: lib/explorer_web/views/wei_helpers.ex:69
 #: lib/explorer_web/views/wei_helpers.ex:69
 msgid "Wei"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
+#: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_internal_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:12
 #: lib/explorer_web/views/address_transaction_view.ex:12
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/index.html.eex:102
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:42
+#: lib/explorer_web/templates/chain/_transactions.html.eex:35
+#: lib/explorer_web/templates/chain/_transactions.html.eex:35
+#: lib/explorer_web/templates/transaction/index.html.eex:55
+#: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
 msgstr ""
 
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:7
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:7
+#: lib/explorer_web/templates/transaction/index.html.eex:7
 #: lib/explorer_web/templates/transaction/index.html.eex:7
 msgid "Validated"
 msgstr ""
 
+#: lib/explorer_web/templates/block_transaction/index.html.eex:3
 #: lib/explorer_web/templates/block_transaction/index.html.eex:3
 msgid "Block Details"
 msgstr ""
@@ -393,20 +512,27 @@ msgid "Avg Block Time"
 msgstr ""
 
 #: lib/explorer_web/templates/chain/show.html.eex:18
+#: lib/explorer_web/templates/chain/show.html.eex:18
 msgid "Market Cap"
 msgstr ""
 
+#: lib/explorer_web/templates/chain/show.html.eex:10
 #: lib/explorer_web/templates/chain/show.html.eex:10
 msgid "Price"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:12
+#: lib/explorer_web/templates/address/_values.html.eex:12
+#: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:71
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
+#: lib/explorer_web/templates/transaction/overview.html.eex:167
+#: lib/explorer_web/views/currency_helpers.ex:32
 #: lib/explorer_web/views/currency_helpers.ex:32
 msgid "USD"
 msgstr ""
 
+#: lib/explorer_web/templates/address/_values.html.eex:20
 #: lib/explorer_web/templates/address/_values.html.eex:20
 msgid "Number of Transactions"
 msgstr ""
@@ -415,6 +541,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
+#: lib/explorer_web/templates/transaction/index.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:25
 msgid "Showing %{count} Validated Transactions"
 msgstr ""
@@ -444,6 +571,8 @@ msgid "Total Gas Used"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:22
+#: lib/explorer_web/templates/block_transaction/index.html.eex:22
+#: lib/explorer_web/views/transaction_view.ex:113
 #: lib/explorer_web/views/transaction_view.ex:113
 msgid "Transaction"
 msgstr ""
@@ -458,6 +587,8 @@ msgid "View All"
 msgstr ""
 
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:159
+#: lib/explorer_web/templates/transaction/overview.html.eex:167
 #: lib/explorer_web/templates/transaction/overview.html.eex:167
 msgid "TX Fee"
 msgstr ""
@@ -467,6 +598,7 @@ msgid "Contract"
 msgstr ""
 
 #: lib/explorer_web/views/address_view.ex:13
+#: lib/explorer_web/views/address_view.ex:13
 msgid "Contract Address"
 msgstr ""
 
@@ -475,137 +607,177 @@ msgid "Contract bytecode"
 msgstr ""
 
 #: lib/explorer_web/templates/block_transaction/index.html.eex:192
+#: lib/explorer_web/templates/block_transaction/index.html.eex:192
 msgid "There are no Transactions"
 msgstr ""
 
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:125
+#: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block/index.html.eex:60
+#: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:54
-#: lib/explorer_web/templates/transaction/index.html.eex:57
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
+#: lib/explorer_web/templates/transaction/index.html.eex:62
+#: lib/explorer_web/templates/transaction/index.html.eex:62
 msgid "Older"
 msgstr ""
 
+#: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 #: lib/explorer_web/templates/address_contract_verification/new.html.eex:9
 msgid "Contract Source Code"
 msgstr "Contract Source Code"
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:44
+#: lib/explorer_web/templates/address_contract/index.html.eex:44
 msgid "Verify and Publish"
 msgstr ""
 
 #: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_contract/index.html.eex:27
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:31
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:31
+#: lib/explorer_web/templates/address_transaction/index.html.eex:31
+#: lib/explorer_web/templates/address_transaction/index.html.eex:61
 #: lib/explorer_web/templates/address_transaction/index.html.eex:61
 msgid "Code"
 msgstr ""
 
 #: lib/explorer_web/views/address_contract_view.ex:9
+#: lib/explorer_web/views/address_contract_view.ex:9
 msgid "false"
 msgstr "No"
 
 #: lib/explorer_web/views/address_contract_view.ex:8
+#: lib/explorer_web/views/address_contract_view.ex:8
 msgid "true"
 msgstr "Yes"
 
+#: lib/explorer_web/templates/address/_values.html.eex:28
 #: lib/explorer_web/templates/address/_values.html.eex:28
 msgid "Last Updated In Block"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/explorer_web/templates/transaction_log/index.html.eex:73
 #: lib/explorer_web/templates/transaction_log/index.html.eex:73
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:109
+#: lib/explorer_web/templates/transaction/overview.html.eex:109
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:47
+#: lib/explorer_web/views/transaction_view.ex:111
 #: lib/explorer_web/views/transaction_view.ex:111
 msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:34
+#: lib/explorer_web/templates/layout/_topnav.html.eex:34
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_topnav.html.eex:38
 #: lib/explorer_web/templates/layout/_topnav.html.eex:38
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_topnav.html.eex:37
+#: lib/explorer_web/templates/layout/_topnav.html.eex:37
 msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
 #: lib/explorer_web/templates/layout/_footer.html.eex:4
 msgid "Facebook"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:7
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Instagram"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:13
 #: lib/explorer_web/templates/layout/_footer.html.eex:13
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/layout/_footer.html.eex:10
+#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:26
-#: lib/explorer_web/templates/transaction/index.html.eex:48
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:32
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/_blocks.html.eex:4
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/_transactions.html.eex:3
+#: lib/explorer_web/templates/chain/_transactions.html.eex:3
 msgid "View All Transactions →"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:28
 #: lib/explorer_web/templates/chain/show.html.eex:28
 msgid "Average block time"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/chain/show.html.eex:36
+#: lib/explorer_web/templates/chain/show.html.eex:36
 msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/chain/show.html.eex:44
 #: lib/explorer_web/templates/chain/show.html.eex:44
 msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/transaction/overview.html.eex:46
+#: lib/explorer_web/templates/transaction/overview.html.eex:46
 msgid "block confirmations"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:81
+#: lib/explorer_web/templates/address_transaction/index.html.eex:81
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:8
 #: lib/explorer_web/templates/address/overview.html.eex:8
 msgid "Copy Address"
 msgstr ""
@@ -613,45 +785,54 @@ msgstr ""
 #, elixir-format
 #:
 #: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:4
 msgid "Internal Transaction"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address_transaction/index.html.eex:76
 #: lib/explorer_web/templates/address_transaction/index.html.eex:76
 msgid "More messages have come in"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
+#: lib/explorer_web/templates/address/overview.html.eex:13
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:118
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/index.html.eex:131
+#: lib/explorer_web/templates/address_transaction/index.html.eex:131
 msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/views/transaction_view.ex:112
+#: lib/explorer_web/views/transaction_view.ex:112
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:25
+#: lib/explorer_web/templates/address/overview.html.eex:25
 msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
+#: lib/explorer_web/templates/address/overview.html.eex:36
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -305,6 +305,11 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:28
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
+#: lib/explorer_web/templates/chain/_transactions.html.eex:33
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
+#: lib/explorer_web/templates/transaction/index.html.eex:54
 #: lib/explorer_web/templates/transaction/overview.html.eex:63
 #: lib/explorer_web/templates/transaction/overview.html.eex:159
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:33
@@ -367,7 +372,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:46
 #: lib/explorer_web/templates/chain/_transactions.html.eex:35
 #: lib/explorer_web/templates/transaction/index.html.eex:55
 msgid "Fee"
@@ -566,7 +571,7 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:34
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
 #: lib/explorer_web/templates/chain/_transactions.html.eex:25
 #: lib/explorer_web/templates/transaction/index.html.eex:47
 msgid "Block #"

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -160,7 +160,7 @@ msgstr "Address"
 #: lib/explorer_web/templates/transaction/overview.html.eex:79
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:31
 #: lib/explorer_web/views/address_internal_transaction_view.ex:9
-#: lib/explorer_web/views/address_transaction_view.ex:11
+#: lib/explorer_web/views/address_transaction_view.ex:9
 msgid "From"
 msgstr "From"
 
@@ -179,7 +179,7 @@ msgstr "Success"
 #: lib/explorer_web/templates/transaction/overview.html.eex:91
 #: lib/explorer_web/templates/transaction_internal_transaction/index.html.eex:32
 #: lib/explorer_web/views/address_internal_transaction_view.ex:8
-#: lib/explorer_web/views/address_transaction_view.ex:10
+#: lib/explorer_web/views/address_transaction_view.ex:8
 msgid "To"
 msgstr "To"
 
@@ -305,7 +305,7 @@ msgid "Showing #%{number}"
 msgstr ""
 
 #: lib/explorer_web/templates/address/_values.html.eex:4
-#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:28
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:29
 #: lib/explorer_web/templates/address_transaction/_transaction.html.eex:44
 #: lib/explorer_web/templates/chain/_transactions.html.eex:33
 #: lib/explorer_web/templates/pending_transaction/index.html.eex:47
@@ -368,7 +368,7 @@ msgstr ""
 #: lib/explorer_web/templates/address_internal_transaction/index.html.eex:80
 #: lib/explorer_web/templates/address_transaction/index.html.eex:91
 #: lib/explorer_web/views/address_internal_transaction_view.ex:10
-#: lib/explorer_web/views/address_transaction_view.ex:12
+#: lib/explorer_web/views/address_transaction_view.ex:10
 msgid "All"
 msgstr ""
 
@@ -571,13 +571,6 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:25
-#: lib/explorer_web/templates/transaction/index.html.eex:47
-msgid "Block #"
-msgstr ""
-
-#, elixir-format
 #: lib/explorer_web/templates/chain/_blocks.html.eex:4
 msgid "View All Blocks →"
 msgstr ""
@@ -661,4 +654,25 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:36
 msgid "at"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
+#: lib/explorer_web/templates/chain/_transactions.html.eex:25
+#: lib/explorer_web/templates/transaction/index.html.eex:47
+msgid "Block #%{number}"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:24
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:31
+msgid "IN"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
+#: lib/explorer_web/templates/address_transaction/_transaction.html.eex:29
+msgid "OUT"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -482,8 +482,8 @@ msgstr ""
 #: lib/explorer_web/templates/address_transaction/index.html.eex:138
 #: lib/explorer_web/templates/block/index.html.eex:60
 #: lib/explorer_web/templates/block_transaction/index.html.eex:198
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:57
-#: lib/explorer_web/templates/transaction/index.html.eex:60
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:54
+#: lib/explorer_web/templates/transaction/index.html.eex:57
 msgid "Older"
 msgstr ""
 
@@ -565,8 +565,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address_transaction/_transaction.html.eex:36
-#: lib/explorer_web/templates/chain/_transactions.html.eex:28
-#: lib/explorer_web/templates/transaction/index.html.eex:51
+#: lib/explorer_web/templates/chain/_transactions.html.eex:26
+#: lib/explorer_web/templates/transaction/index.html.eex:48
 msgid "Block #"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/pending_transaction/index.html.eex:47
+#: lib/explorer_web/templates/pending_transaction/index.html.eex:44
 msgid "Contract Address Pending"
 msgstr ""
 

--- a/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/address_page.ex
@@ -67,6 +67,10 @@ defmodule ExplorerWeb.AddressPage do
     css("[data-test='transaction_count']")
   end
 
+  def transaction_status(%Transaction{hash: transaction_hash}) do
+    css("[data-transaction-hash='#{transaction_hash}'] [data-test='transaction_status']")
+  end
+
   def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
 
   def visit_page(session, address_hash) do

--- a/apps/explorer_web/test/explorer_web/features/pages/block_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/block_page.ex
@@ -3,9 +3,9 @@ defmodule ExplorerWeb.BlockPage do
 
   use Wallaby.DSL
 
-  import Wallaby.Query, only: [css: 2]
+  import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.{Block, InternalTransaction}
+  alias Explorer.Chain.{Block, InternalTransaction, Transaction}
 
   def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
     css("[data-address-hash='#{hash}']", text: "Contract Creation")
@@ -13,6 +13,14 @@ defmodule ExplorerWeb.BlockPage do
 
   def detail_number(%Block{number: block_number}) do
     css("[data-test='block_detail_number']", text: to_string(block_number))
+  end
+
+  def transaction(%Transaction{hash: transaction_hash}) do
+    css("[data-transaction-hash='#{transaction_hash}']")
+  end
+
+  def transaction_status(%Transaction{hash: transaction_hash}) do
+    css("[data-transaction-hash='#{transaction_hash}'] [data-test='transaction_status']")
   end
 
   def visit_page(session, %Block{number: block_number}) do

--- a/apps/explorer_web/test/explorer_web/features/pages/home_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/home_page.ex
@@ -5,7 +5,7 @@ defmodule ExplorerWeb.HomePage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.InternalTransaction
+  alias Explorer.Chain.{InternalTransaction, Transaction}
 
   def blocks(count: count) do
     css("[data-test='chain_block']", count: count)
@@ -23,6 +23,10 @@ defmodule ExplorerWeb.HomePage do
 
   def transactions(count: count) do
     css("[data-test='chain_transaction']", count: count)
+  end
+
+  def transaction_status(%Transaction{hash: transaction_hash}) do
+    css("[data-transaction-hash='#{transaction_hash}'] [data-test='transaction_status']")
   end
 
   def visit_page(session) do

--- a/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
+++ b/apps/explorer_web/test/explorer_web/features/pages/transaction_list_page.ex
@@ -23,6 +23,10 @@ defmodule ExplorerWeb.TransactionListPage do
     css("[data-transaction-hash='#{transaction_hash}']")
   end
 
+  def transaction_status(%Transaction{hash: transaction_hash}) do
+    css("[data-transaction-hash='#{transaction_hash}'] [data-test='transaction_status']")
+  end
+
   def visit_page(session) do
     visit(session, "/en/transactions")
   end

--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -115,6 +115,7 @@ defmodule ExplorerWeb.ViewingAddressesTest do
       |> AddressPage.visit_page(addresses.lincoln)
       |> assert_has(AddressPage.transaction(transactions.from_taft))
       |> assert_has(AddressPage.transaction(transactions.from_lincoln))
+      |> assert_has(AddressPage.transaction_status(transactions.from_lincoln))
     end
 
     test "can filter to only see transactions from an address", %{

--- a/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
@@ -43,6 +43,21 @@ defmodule ExplorerWeb.ViewingBlocksTest do
     |> assert_has(BlockPage.detail_number(block))
   end
 
+  test "block detail page has transactions", %{session: session} do
+    block = insert(:block, number: 42)
+
+    transaction =
+      :transaction
+      |> insert()
+      |> with_block(block)
+
+    session
+    |> BlockPage.visit_page(block)
+    |> assert_has(BlockPage.detail_number(block))
+    |> assert_has(BlockPage.transaction(transaction))
+    |> assert_has(BlockPage.transaction_status(transaction))
+  end
+
   test "contract creation is shown for to_address in transaction list", %{session: session} do
     block = insert(:block, number: 42)
 

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -94,6 +94,7 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       session
       |> TransactionListPage.visit_page()
       |> assert_has(TransactionListPage.transaction(transaction))
+      |> assert_has(TransactionListPage.transaction_status(transaction))
       |> refute_has(TransactionListPage.transaction(pending))
     end
 
@@ -103,6 +104,7 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
       |> TransactionListPage.click_pending()
       |> assert_has(TransactionListPage.transaction(pending))
       |> assert_has(TransactionListPage.transaction(pending_contract))
+      |> assert_has(TransactionListPage.transaction_status(pending_contract))
     end
 
     test "contract creation is shown for to_address on list page", %{session: session} do


### PR DESCRIPTION
resolves #368 
resolves #400 

## Motivation

Visually show the current status of a given transaction. Current statuses are Success, Pending, Failed and Out of Gas. Failed and Out of Gas transactions are given a colored border to call attention to them. Transaction statuses will also live update as blocks are validated.

## Changelog

### Enhancements
* Added a text label that describes the transaction's status
* Added a colored border to call attention to Failed and Out of Gase transactions

### Screenshots
![localhost_4000_en_addresses_0x00f5ba0190675051175eacbc21b2dc649887d3b9_transactions](https://user-images.githubusercontent.com/1641169/42783077-d1217b92-8918-11e8-8255-b32c5cec8711.png)
