### PR TITLE
Add RPC API account balancemulti

### DIFF
--- a/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
@@ -4,11 +4,11 @@ defmodule ExplorerWeb.API.RPC.AddressController do
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Wei}
 
-  def balance(conn, params) do
+  def balance(conn, params, template \\ :balance) do
     with {:address_param, {:ok, address_param}} <- fetch_address(params),
          {:format, {:ok, address_hashes}} <- to_address_hashes(address_param) do
       addresses = hashes_to_addresses(address_hashes)
-      render(conn, :balance, %{addresses: addresses})
+      render(conn, template, %{addresses: addresses})
     else
       {:address_param, :error} ->
         conn
@@ -20,6 +20,10 @@ defmodule ExplorerWeb.API.RPC.AddressController do
         |> put_status(400)
         |> render(:error, error: "Invalid address hash")
     end
+  end
+
+  def balancemulti(conn, params) do
+    balance(conn, params, :balancemulti)
   end
 
   defp fetch_address(params) do

--- a/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
@@ -8,7 +8,11 @@ defmodule ExplorerWeb.API.RPC.AddressView do
     RPCView.render("show.json", data: ether_balance)
   end
 
-  def render("balance.json", %{addresses: addresses}) do
+  def render("balance.json", assigns) do
+    render("balancemulti.json", assigns)
+  end
+
+  def render("balancemulti.json", %{addresses: addresses}) do
     data =
       Enum.map(addresses, fn address ->
         %{

--- a/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
@@ -80,55 +80,9 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response["message"] == "OK"
     end
 
-    test "with an invalid and a valid address hash", %{conn: conn} do
-      address1 = "invalidhash"
-      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
-
-      params = %{
-        "module" => "account",
-        "action" => "balance",
-        "address" => "#{address1},#{address2}"
-      }
-
-      assert response =
-               conn
-               |> get("/api", params)
-               |> json_response(400)
-
-      assert response["message"] =~ "Invalid address hash"
-      assert response["status"] == "0"
-      assert Map.has_key?(response, "result")
-      refute response["result"]
-    end
-
-    test "with multiple addresses that don't exist", %{conn: conn} do
-      address1 = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
-      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
-
-      params = %{
-        "module" => "account",
-        "action" => "balance",
-        "address" => "#{address1},#{address2}"
-      }
-
-      expected_result = [
-        %{"account" => address1, "balance" => "0"},
-        %{"account" => address2, "balance" => "0"}
-      ]
-
-      assert response =
-               conn
-               |> get("/api", params)
-               |> json_response(200)
-
-      assert response["result"] == expected_result
-      assert response["status"] == "1"
-      assert response["message"] == "OK"
-    end
-
     test "with multiple valid addresses", %{conn: conn} do
       addresses =
-        for _ <- 1..4 do
+        for _ <- 1..2 do
           insert(:address, fetched_balance: Enum.random(1..1_000))
         end
 
@@ -162,6 +116,91 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end
+  end
+
+  describe "balancemulti" do
+    test "with an invalid and a valid address hash", %{conn: conn} do
+      address1 = "invalidhash"
+      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
+
+      params = %{
+        "module" => "account",
+        "action" => "balancemulti",
+        "address" => "#{address1},#{address2}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(400)
+
+      assert response["message"] =~ "Invalid address hash"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with multiple addresses that don't exist", %{conn: conn} do
+      address1 = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      address2 = "0x9bf49d5875030175f3d5d4a67631a87ab4df526b"
+
+      params = %{
+        "module" => "account",
+        "action" => "balancemulti",
+        "address" => "#{address1},#{address2}"
+      }
+
+      expected_result = [
+        %{"account" => address1, "balance" => "0"},
+        %{"account" => address2, "balance" => "0"}
+      ]
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with multiple valid addresses", %{conn: conn} do
+      addresses =
+        for _ <- 1..4 do
+          insert(:address, fetched_balance: Enum.random(1..1_000))
+        end
+
+      address_param =
+        addresses
+        |> Enum.map(&"#{&1.hash}")
+        |> Enum.join(",")
+
+      params = %{
+        "module" => "account",
+        "action" => "balancemulti",
+        "address" => address_param
+      }
+
+      expected_result =
+        Enum.map(addresses, fn address ->
+          expected_balance =
+            address.fetched_balance
+            |> Wei.to(:ether)
+            |> Decimal.to_string(:normal)
+
+          %{"account" => "#{address.hash}", "balance" => expected_balance}
+        end)
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
 
     test "with an address that exists and one that doesn't", %{conn: conn} do
       address1 = insert(:address, fetched_balance: 100)
@@ -169,7 +208,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
 
       params = %{
         "module" => "account",
-        "action" => "balance",
+        "action" => "balancemulti",
         "address" => "#{address1.hash},#{address2_hash}"
       }
 
@@ -203,7 +242,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
 
       params = %{
         "module" => "account",
-        "action" => "balance",
+        "action" => "balancemulti",
         "address" => address_param
       }
 
@@ -213,6 +252,34 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
                |> json_response(200)
 
       assert length(response["result"]) == 20
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a single address", %{conn: conn} do
+      address = insert(:address, fetched_balance: 100)
+
+      params = %{
+        "module" => "account",
+        "action" => "balancemulti",
+        "address" => "#{address.hash}"
+      }
+
+      expected_balance =
+        address.fetched_balance
+        |> Wei.to(:ether)
+        |> Decimal.to_string(:normal)
+
+      expected_result = [
+        %{"account" => "#{address.hash}", "balance" => expected_balance}
+      ]
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end


### PR DESCRIPTION
## Motivation

* After a first iteration of the account balance  API endpoint was
merged into master, we noticed Etherscan has a separate action for
getting the Ether balance of multiple addresses in a single call:
`action=balancemulti`. This commit adds support for this action.
* Issue link: https://github.com/poanetwork/poa-explorer/issues/138

## Changelog

### Enhancements
* Editing `API.RPC.AddressControllerTest` to have coverage for
`action=balancemulti` calls and make sure `action=balance` works as we'd
like when multiple addresses are given.
* Adding `balancemulti/2` to `API.RPC.AddressController`.

### Bug Fixes
* n/a

### Incompatible Changes
* n/a

## Upgrading
* n/a