### PR TITLE
Add Token and TokenTransfers schema

### DIFF
--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -1,0 +1,53 @@
+defmodule Explorer.Chain.Token do
+  @moduledoc """
+  Represents an ERC-20 token.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  alias Explorer.Chain.{Address, Hash, Token}
+
+  @typedoc """
+  * `:name` - Name of the token
+  * `:symbol` - Trading symbol of the token
+  * `:total_supply` - The total supply of the token
+  * `:decimals` - Number of decimal places the token can be subdivided to
+  * `:contract_address` - The `t:Address.t/0` of the token's contract
+  * `:contract_address_hash` - Address hash foreign key
+  """
+  @type t :: %Token{
+          name: String.t(),
+          symbol: String.t(),
+          total_supply: Decimal.t(),
+          decimals: non_neg_integer(),
+          contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
+          contract_address_hash: Hash.Address.t()
+        }
+
+  schema "tokens" do
+    field(:name, :string)
+    field(:symbol, :string)
+    field(:total_supply, :decimal)
+    field(:decimals, :integer)
+
+    belongs_to(
+      :contract_address,
+      Address,
+      foreign_key: :contract_address_hash,
+      references: :hash,
+      type: Hash.Address
+    )
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Token{} = token, params \\ %{}) do
+    token
+    |> cast(params, ~w(name symbol total_supply decimals contract_address_hash)a)
+    |> validate_required(~w(contract_address_hash))
+    |> foreign_key_constraint(:contract_address)
+    |> unique_constraint(:contract_address_hash)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -1,0 +1,95 @@
+defmodule Explorer.Chain.TokenTransfer do
+  @moduledoc """
+  Represents a token transfer between addresses for a given token.
+
+  ## Overview
+
+  Token transfers are special cases from a `t:Explorer.Chain.Log.t/0`. A token
+  transfer is always signified by the value from the `first_topic` in a log. That value
+  is always `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`.
+
+  ## Data Mapping From a Log
+
+  Here's how a log's data maps to a token transfer:
+
+  | Log                 | Token Transfer                 | Description                     |
+  |---------------------|--------------------------------|---------------------------------|
+  | `:second_topic`     | `:from_address_hash`           | Address sending tokens          |
+  | `:third_topic`      | `:to_address_hash`             | Address receiving tokens        |
+  | `:data`             | `:amount`                      | Amount of tokens transferred    |
+  | `:transaction_hash` | `:transaction_hash`            | Transaction of the transfer     |
+  | `:address_hash`     | `:token_contract_address_hash` | Address of token's contract     |
+  | `:index`            | `:log_index`                   | Index of log in transaction     |
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Explorer.Chain.{Address, Hash, Transaction, TokenTransfer}
+
+  @typedoc """
+  * `:amount` - The token transferred amount
+  * `:from_address` - The `t:Explorer.Chain.Address.t/0` that sent the tokens
+  * `:from_address_hash` - Address hash foreign key
+  * `:to_address` - The `t:Explorer.Chain.Address.t/0` that recieved the tokens
+  * `:to_address_hash` - Address hash foreign key
+  * `:token_contract_address` - The `t:Explorer.Chain.Address.t/0` of the token's contract.
+  * `:token_contract_address_hash` - Address hash foreign key
+  * `:transaction` - The `t:Explorer.Chain.Transaction.t/0` ledger
+  * `:transaction_hash` - Transaction foreign key
+  * `:log_index` - Index of the corresponding `t:Explorer.Chain.Log.t/0` in the transaction.
+  """
+  @type t :: %TokenTransfer{
+          amount: Decimal.t(),
+          from_address: %Ecto.Association.NotLoaded{} | Address.t(),
+          from_address_hash: Hash.Address.t(),
+          to_address: %Ecto.Association.NotLoaded{} | Address.t(),
+          to_address_hash: Hash.Address.t(),
+          token_contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
+          token_contract_address_hash: Hash.Address.t(),
+          transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
+          transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
+          transaction_hash: Hash.Full.t(),
+          log_index: non_neg_integer()
+        }
+
+  @constant "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+  schema "token_transfers" do
+    field(:amount, :decimal)
+    field(:log_index, :integer)
+
+    belongs_to(:from_address, Address, foreign_key: :from_address_hash, references: :hash, type: Hash.Address)
+    belongs_to(:to_address, Address, foreign_key: :to_address_hash, references: :hash, type: Hash.Address)
+
+    belongs_to(
+      :token_contract_address,
+      Address,
+      foreign_key: :token_contract_address_hash,
+      references: :hash,
+      type: Hash.Address
+    )
+
+    belongs_to(:transaction, Transaction, foreign_key: :transaction_hash, references: :hash, type: Hash.Full)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%TokenTransfer{} = struct, params \\ %{}) do
+    struct
+    |> cast(params, ~w(amount log_index from_address_hash to_address_hash token_contract_address_hash transaction_hash))
+    |> validate_required(~w(log_index from_address_hash to_address_hash token_contract_address_hash))
+    |> foreign_key_constraint(:from_address)
+    |> foreign_key_constraint(:to_address)
+    |> foreign_key_constraint(:token_contract_address)
+    |> foreign_key_constraint(:transaction)
+  end
+
+  @doc """
+  Value that represents a token transfer in a `t:Explorer.Chain.Log.t/0`'s
+  `first_topic` field.
+  """
+  def constant, do: @constant
+end

--- a/apps/explorer/priv/repo/migrations/20180606135149_create_tokens.exs
+++ b/apps/explorer/priv/repo/migrations/20180606135149_create_tokens.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Repo.Migrations.CreateTokens do
+  use Ecto.Migration
+
+  def change do
+    create table(:tokens) do
+      add(:name, :string)
+      add(:symbol, :string)
+      add(:total_supply, :decimal)
+      add(:decimals, :smallint)
+
+      add(
+        :contract_address_hash,
+        references(:addresses, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false
+      )
+
+      timestamps()
+    end
+
+    create(unique_index(:tokens, :contract_address_hash))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
@@ -1,0 +1,28 @@
+defmodule Explorer.Repo.Migrations.CreateTokenTransfers do
+  use Ecto.Migration
+
+  def change do
+    create table(:token_transfers) do
+      add(
+        :transaction_hash,
+        references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false
+      )
+
+      add(:log_index, :integer, null: false)
+      add(:from_address_hash, references(:addresses, column: :hash, type: :bytea), null: false)
+      add(:to_address_hash, references(:addresses, column: :hash, type: :bytea), null: false)
+      add(:amount, :decimal, null: false)
+      add(:token_contract_address_hash, references(:addresses, column: :hash, type: :bytea), null: false)
+
+      timestamps()
+    end
+
+    create(index(:token_transfers, :transaction_hash))
+    create(index(:token_transfers, :to_address_hash))
+    create(index(:token_transfers, :from_address_hash))
+    create(index(:token_transfers, :token_contract_address_hash))
+
+    create(unique_index(:token_transfers, [:transaction_hash, :log_index]))
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -15,8 +15,10 @@ defmodule Explorer.Factory do
     Hash,
     InternalTransaction,
     Log,
-    Transaction,
-    SmartContract
+    SmartContract,
+    Token,
+    TokenTransfer,
+    Transaction
   }
 
   alias Explorer.Market.MarketHistory
@@ -220,6 +222,70 @@ defmodule Explorer.Factory do
     }
   end
 
+  def token_factory do
+    %Token{
+      name: "Infinite Token",
+      symbol: "IT",
+      total_supply: 1_000_000_000,
+      decimals: 18,
+      contract_address: build(:address)
+    }
+  end
+
+  def token_transfer_log_factory do
+    token_contract_address = build(:address)
+    to_address = build(:address)
+    from_address = build(:address)
+
+    transaction = build(:transaction, to_address: token_contract_address, from_address: from_address)
+
+    log_params = %{
+      first_topic: TokenTransfer.constant(),
+      second_topic: zero_padded_address_hash_string(from_address.hash),
+      third_topic: zero_padded_address_hash_string(to_address.hash),
+      address_hash: token_contract_address.hash,
+      data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+      transaction: transaction
+    }
+
+    build(:log, log_params)
+  end
+
+  def token_transfer_log_with_transaction(%Log{} = log, %Transaction{} = transaction) do
+    params = %{
+      second_topic: zero_padded_address_hash_string(transaction.from_address.hash),
+      transaction: transaction
+    }
+
+    struct!(log, params)
+  end
+
+  def token_transfer_log_with_to_address(%Log{} = log, %Address{} = to_address) do
+    %Log{log | third_topic: zero_padded_address_hash_string(to_address.hash)}
+  end
+
+  def token_transfer_factory do
+    log = insert(:token_transfer_log)
+    to_address_hash = address_hash_from_zero_padded_hash_string(log.third_topic)
+
+    # `to_address` is only the only thing that isn't created from the token_transfer_log_factory
+
+    insert(:address, hash: to_address_hash)
+
+    from_address_hash = address_hash_from_zero_padded_hash_string(log.second_topic)
+
+    %TokenTransfer{
+      amount: Decimal.new(1),
+      from_address: nil,
+      from_address_hash: from_address_hash,
+      to_address: nil,
+      to_address_hash: to_address_hash,
+      transaction: nil,
+      transaction_hash: log.transaction.hash,
+      log_index: log.index
+    }
+  end
+
   def market_history_factory do
     %MarketHistory{
       closing_price: price(),
@@ -338,5 +404,15 @@ defmodule Explorer.Factory do
     |> Enum.random()
     |> Decimal.new()
     |> Decimal.div(Decimal.new(100))
+  end
+
+  defp zero_padded_address_hash_string(%Explorer.Chain.Hash{byte_count: 20} = hash) do
+    "0x" <> hash_string = Explorer.Chain.Hash.to_string(hash)
+    "0x000000000000000000000000" <> hash_string
+  end
+
+  defp address_hash_from_zero_padded_hash_string("0x000000000000000000000000" <> hash_string) do
+    {:ok, hash} = Explorer.Chain.Hash.cast(Explorer.Chain.Hash.Truncated, "0x" <> hash_string)
+    hash
   end
 end


### PR DESCRIPTION
It contains the modeling definition and factories of both entities that will be indexed after PR #334 (which where they came from originally ❤️).

We're breaking it in this PR since they're are the only dependencies for the front-end Token features. By doing this we'll be able to improve these issues workflow since we wouldn't need to rebase our PRs in a WIP.

The issues that have a dependency on it can be seen here: https://github.com/poanetwork/poa-explorer/projects/3?card_filter_query=label%3Atokens
