### PR TITLE
Dynamically add websocket endpoint to CSP

### DIFF
--- a/apps/explorer_web/.sobelow-conf
+++ b/apps/explorer_web/.sobelow-conf
@@ -5,5 +5,5 @@
   router: "lib/explorer_web/router.ex",
   exit: "low",
   format: "compact",
-  ignore: ["Config.CSRF"]
+  ignore: ["Config.Headers"]
 ]

--- a/apps/explorer_web/lib/explorer_web/csp_header.ex
+++ b/apps/explorer_web/lib/explorer_web/csp_header.ex
@@ -3,8 +3,8 @@ defmodule ExplorerWeb.CSPHeader do
   Plug to set content-security-policy with websocket endpoints
   """
 
-  alias ExplorerWeb.Router.Helpers
   alias Phoenix.Controller
+  alias Plug.Conn
 
   def init(opts), do: opts
 
@@ -22,9 +22,7 @@ defmodule ExplorerWeb.CSPHeader do
   end
 
   defp websocket_endpoints(conn) do
-    endpoint = conn |> Helpers.url() |> URI.parse()
-    ws_endpoint = %{endpoint | scheme: "ws"} |> URI.to_string()
-    wss_endpoint = %{endpoint | scheme: "wss"} |> URI.to_string()
-    "#{ws_endpoint} #{wss_endpoint}"
+    host = Conn.get_req_header(conn, "host")
+    "ws://#{host} wss://#{host}"
   end
 end

--- a/apps/explorer_web/lib/explorer_web/csp_header.ex
+++ b/apps/explorer_web/lib/explorer_web/csp_header.ex
@@ -1,0 +1,29 @@
+defmodule ExplorerWeb.CSPHeader do
+  @moduledoc """
+  Plug to set content-security-policy with websocket endpoints
+  """
+
+  alias Phoenix.Controller
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    Controller.put_secure_browser_headers(conn, %{
+      "content-security-policy" => "\
+        connect-src 'self' #{websocket_endpoints(conn)}; \
+        default-src 'self';\
+        script-src 'self' 'unsafe-inline' 'unsafe-eval';\
+        style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\
+        img-src 'self' 'unsafe-inline' 'unsafe-eval' data:;\
+        font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com data:;\
+      "
+    })
+  end
+
+  defp websocket_endpoints(conn) do
+    endpoint = Controller.endpoint_module(conn)
+    ws_endpoint = %{endpoint.struct_url | scheme: "ws"} |> URI.to_string()
+    wss_endpoint = %{endpoint.struct_url | scheme: "wss"} |> URI.to_string()
+    "#{ws_endpoint} #{wss_endpoint}"
+  end
+end

--- a/apps/explorer_web/lib/explorer_web/csp_header.ex
+++ b/apps/explorer_web/lib/explorer_web/csp_header.ex
@@ -3,6 +3,7 @@ defmodule ExplorerWeb.CSPHeader do
   Plug to set content-security-policy with websocket endpoints
   """
 
+  alias ExplorerWeb.Router.Helpers
   alias Phoenix.Controller
 
   def init(opts), do: opts
@@ -21,9 +22,9 @@ defmodule ExplorerWeb.CSPHeader do
   end
 
   defp websocket_endpoints(conn) do
-    endpoint = Controller.endpoint_module(conn)
-    ws_endpoint = %{endpoint.struct_url | scheme: "ws"} |> URI.to_string()
-    wss_endpoint = %{endpoint.struct_url | scheme: "wss"} |> URI.to_string()
+    endpoint = conn |> Helpers.url() |> URI.parse()
+    ws_endpoint = %{endpoint | scheme: "ws"} |> URI.to_string()
+    wss_endpoint = %{endpoint | scheme: "wss"} |> URI.to_string()
     "#{ws_endpoint} #{wss_endpoint}"
   end
 end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -6,17 +6,7 @@ defmodule ExplorerWeb.Router do
     plug(:fetch_session)
     plug(:fetch_flash)
     plug(:protect_from_forgery)
-
-    plug(:put_secure_browser_headers, %{
-      "content-security-policy" => "\
-        connect-src 'self' ws://localhost:*;\
-        default-src 'self';\
-        script-src 'self' 'unsafe-inline' 'unsafe-eval';\
-        style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\
-        img-src 'self' 'unsafe-inline' 'unsafe-eval' data:;\
-        font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com data:;\
-      "
-    })
+    plug(ExplorerWeb.CSPHeader)
   end
 
   pipeline :api do


### PR DESCRIPTION
Resolves #414

## Changelog

### Bug Fixes
- Fix CSP to allow connection to the explorer_web websocket endpoint in order to support live updates.