### PR TITLE
Fix dropdown overlaps on homepage.

### DIFF
--- a/apps/explorer_web/assets/css/components/_dashboard-banner.scss
+++ b/apps/explorer_web/assets/css/components/_dashboard-banner.scss
@@ -45,7 +45,7 @@
     "legend stats";
   margin-top: -1rem;
   margin-bottom: 3rem;
-  z-index: 10;
+  z-index: 9;
 
   @media (max-width: 992px) {
     grid-template-rows: 2rem auto;


### PR DESCRIPTION
I want to resolve issue #405 

## Motivation
When open the homepage and click in *Mainnet* dropdown the network stats block the button click event.

### Bug Fixes

Decreases *.dashboard-banner* *z-index* from 10 to 9. 

I've tested in other pages looks ok
