### PR TITLE
Prevent holes and fill in holes during realtime indexing

### DIFF
--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -9,6 +9,8 @@ config :explorer, Explorer.Repo,
   database: "explorer_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
+  # Default of `5_000` was too low for `BlockFetcher` test
+  pool_timeout: 10_000,
   ownership_timeout: 60_000
 
 config :explorer, Explorer.Chain.Statistics.Server, enabled: false

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_rate: 5_000,
+  block_interval: 5_000,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_rate: 5_000,
+  block_interval: 5_000,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_rate: 5_000,
+  block_interval: 5_000,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_rate: 5_000,
+  block_interval: 5_000,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [

--- a/apps/indexer/lib/indexer.ex
+++ b/apps/indexer/lib/indexer.ex
@@ -79,16 +79,6 @@ defmodule Indexer do
     Application.put_env(:indexer, :debug_logs, false)
   end
 
-  @doc """
-  Starts a child task of `Indexer.TaskSupervisor` and monitors it, instead of linking to it.
-  """
-  @spec start_monitor((() -> term())) :: {:ok, pid, reference}
-  def start_monitor(task_function) when is_function(task_function, 0) do
-    {:ok, pid} = Task.Supervisor.start_child(Indexer.TaskSupervisor, task_function)
-    ref = Process.monitor(pid)
-    {:ok, pid, ref}
-  end
-
   defp debug_logs_enabled? do
     Application.fetch_env!(:indexer, :debug_logs)
   end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -23,7 +23,7 @@ defmodule Indexer.BlockFetcher do
   @blocks_concurrency 10
 
   # milliseconds
-  @block_rate 5_000
+  @block_interval 5_000
 
   @receipts_batch_size 250
   @receipts_concurrency 10
@@ -45,7 +45,8 @@ defmodule Indexer.BlockFetcher do
       Defaults to #{@blocks_concurrency}.  So upto `blocks_concurrency * block_batch_size` (defaults to
       `#{@blocks_concurrency * @blocks_batch_size}`) blocks can be requested from the JSONRPC at once over all
       connections.
-    * `:block_rate` - The millisecond rate new blocks are published at. Defaults to `#{@block_rate}` milliseconds.
+    * `:block_interval` - The number of milliseconds between new blocks being published. Defaults to
+        `#{@block_interval}` milliseconds.
     * `:receipts_batch_size` - The number of receipts to request in one call to the JSONRPC.  Defaults to
       `#{@receipts_batch_size}`.  Receipt requests also include the logs for when the transaction was collated into the
       block.  *These logs are not paginated.*
@@ -70,7 +71,7 @@ defmodule Indexer.BlockFetcher do
       json_rpc_named_arguments: Keyword.fetch!(opts, :json_rpc_named_arguments),
       genesis_task: nil,
       realtime_task: nil,
-      realtime_interval: opts[:block_rate] || @block_rate,
+      realtime_interval: opts[:block_interval] || @block_interval,
       starting_block_number: nil,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -72,7 +72,6 @@ defmodule Indexer.BlockFetcher do
       genesis_task: nil,
       realtime_tasks: [],
       realtime_interval: div(opts[:block_interval] || @block_interval, 2),
-      starting_block_number: nil,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),
       receipts_batch_size: Keyword.get(opts, :receipts_batch_size, @receipts_batch_size),

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -115,7 +115,7 @@ defmodule Indexer.BlockFetcher do
   end
 
   def handle_info({:DOWN, ref, :process, pid, reason}, %{genesis_task: %Task{pid: pid, ref: ref}} = state) do
-    Logger.error(fn -> "gensis index stream exited with reason (#{inspect(reason)}). Restarting" end)
+    Logger.error(fn -> "genesis index stream exited with reason (#{inspect(reason)}). Restarting" end)
 
     {:noreply, schedule_next_catchup_index(%{state | genesis_task: nil})}
   end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -11,7 +11,7 @@ defmodule Indexer.BlockFetcher do
 
   alias EthereumJSONRPC
   alias Explorer.Chain
-  alias Indexer.{BalanceFetcher, AddressExtraction, InternalTransactionFetcher, Sequence}
+  alias Indexer.{BalanceFetcher, AddressExtraction, BoundInterval, InternalTransactionFetcher, Sequence}
 
   # dialyzer thinks that Logger.debug functions always have no_local_return
   @dialyzer {:nowarn_function, import_range: 3}
@@ -60,6 +60,17 @@ defmodule Indexer.BlockFetcher do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  defstruct json_rpc_named_arguments: [],
+            catchup_task: nil,
+            catchup_block_number: nil,
+            catchup_bound_interval: nil,
+            realtime_tasks: [],
+            realtime_interval: nil,
+            blocks_batch_size: @blocks_batch_size,
+            blocks_concurrency: @blocks_concurrency,
+            receipts_batch_size: @receipts_batch_size,
+            receipts_concurrency: @receipts_concurrency
+
   @impl GenServer
   def init(opts) do
     opts =
@@ -67,48 +78,81 @@ defmodule Indexer.BlockFetcher do
       |> Application.get_all_env()
       |> Keyword.merge(opts)
 
-    state = %{
+    interval = div(opts[:block_interval] || @block_interval, 2)
+
+    state = %__MODULE__{
       json_rpc_named_arguments: Keyword.fetch!(opts, :json_rpc_named_arguments),
-      catchup_task: nil,
-      realtime_tasks: [],
-      realtime_interval: div(opts[:block_interval] || @block_interval, 2),
+      catchup_bound_interval: BoundInterval.within(interval..(interval * 10)),
+      realtime_interval: interval,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),
       receipts_batch_size: Keyword.get(opts, :receipts_batch_size, @receipts_batch_size),
       receipts_concurrency: Keyword.get(opts, :receipts_concurrency, @receipts_concurrency)
     }
 
+    send(self(), :catchup_index)
     {:ok, _} = :timer.send_interval(state.realtime_interval, :realtime_index)
 
-    {:ok, schedule_next_catchup_index(state)}
+    {:ok, state}
   end
 
   @impl GenServer
-  def handle_info(:catchup_index, %{} = state) do
+  def handle_info(:catchup_index, %__MODULE__{} = state) do
     catchup_task = Task.Supervisor.async_nolink(Indexer.TaskSupervisor, fn -> catchup_task(state) end)
 
     {:noreply, %{state | catchup_task: catchup_task}}
   end
 
-  def handle_info(:realtime_index, %{realtime_tasks: realtime_tasks} = state) when is_list(realtime_tasks) do
+  def handle_info(:realtime_index, %__MODULE__{realtime_tasks: realtime_tasks} = state) when is_list(realtime_tasks) do
     realtime_task = Task.Supervisor.async_nolink(Indexer.TaskSupervisor, fn -> realtime_task(state) end)
 
     {:noreply, %{state | realtime_tasks: [realtime_task | realtime_tasks]}}
   end
 
-  def handle_info({:DOWN, ref, :process, pid, :normal}, %{catchup_task: %Task{pid: pid, ref: ref}} = state) do
-    Logger.info(fn -> "Finished index down to genesis. Transitioning to only realtime index." end)
+  def handle_info(
+        {ref, missing_block_count},
+        %__MODULE__{
+          catchup_block_number: catchup_block_number,
+          catchup_bound_interval: catchup_bound_interval,
+          catchup_task: %Task{ref: ref}
+        } = state
+      )
+      when is_integer(missing_block_count) do
+    new_catchup_bound_interval =
+      case missing_block_count do
+        0 ->
+          Logger.info("Index already caught up in #{catchup_block_number}-0")
 
-    {:noreply, %{state | catchup_task: nil}}
+          BoundInterval.increase(catchup_bound_interval)
+
+        _ ->
+          Logger.info("Index had to catch up #{missing_block_count} blocks in #{catchup_block_number}-0")
+
+          BoundInterval.decrease(catchup_bound_interval)
+      end
+
+    Process.demonitor(ref, [:flush])
+
+    interval = new_catchup_bound_interval.current
+
+    Logger.info(fn ->
+      "Checking if index needs to catch up in #{interval}ms"
+    end)
+
+    Process.send_after(self(), :catchup_index, interval)
+
+    {:noreply, %{state | catchup_bound_interval: new_catchup_bound_interval, catchup_task: nil}}
   end
 
-  def handle_info({:DOWN, ref, :process, pid, reason}, %{catchup_task: %Task{pid: pid, ref: ref}} = state) do
-    Logger.error(fn -> "catchup index stream exited with reason (#{inspect(reason)}). Restarting" end)
+  def handle_info({:DOWN, ref, :process, pid, reason}, %__MODULE__{catchup_task: %Task{pid: pid, ref: ref}} = state) do
+    Logger.error(fn -> "Catchup index stream exited with reason (#{inspect(reason)}). Restarting" end)
 
-    {:noreply, schedule_next_catchup_index(%{state | catchup_task: nil})}
+    send(self(), :catchup_index)
+
+    {:noreply, %__MODULE__{state | catchup_task: nil}}
   end
 
-  def handle_info({:DOWN, ref, :process, pid, reason}, %{realtime_tasks: realtime_tasks} = state)
+  def handle_info({:DOWN, ref, :process, pid, reason}, %__MODULE__{realtime_tasks: realtime_tasks} = state)
       when is_list(realtime_tasks) do
     {down_realtime_tasks, running_realtime_tasks} =
       Enum.split_with(realtime_tasks, fn
@@ -127,7 +171,7 @@ defmodule Indexer.BlockFetcher do
         Logger.error(fn -> "Unexpected pid (#{inspect(pid)}) exited with reason (#{inspect(reason)})." end)
     end
 
-    {:noreply, %{state | realtime_tasks: running_realtime_tasks}}
+    {:noreply, %__MODULE__{state | realtime_tasks: running_realtime_tasks}}
   end
 
   defp cap_seq(seq, next, range) do
@@ -145,9 +189,12 @@ defmodule Indexer.BlockFetcher do
     :ok
   end
 
-  defp fetch_transaction_receipts(_state, []), do: {:ok, %{logs: [], receipts: []}}
+  defp fetch_transaction_receipts(%__MODULE__{} = _state, []), do: {:ok, %{logs: [], receipts: []}}
 
-  defp fetch_transaction_receipts(%{json_rpc_named_arguments: json_rpc_named_arguments} = state, transaction_params) do
+  defp fetch_transaction_receipts(
+         %__MODULE__{json_rpc_named_arguments: json_rpc_named_arguments} = state,
+         transaction_params
+       ) do
     debug(fn -> "fetching #{length(transaction_params)} transaction receipts" end)
     stream_opts = [max_concurrency: state.receipts_concurrency, timeout: :infinity]
 
@@ -166,17 +213,42 @@ defmodule Indexer.BlockFetcher do
     end)
   end
 
-  defp catchup_task(%{json_rpc_named_arguments: json_rpc_named_arguments} = state) do
+  # Returns number of missing blocks that had to be caught up
+  defp catchup_task(%__MODULE__{json_rpc_named_arguments: json_rpc_named_arguments} = state) do
     {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
-    missing_ranges = Chain.missing_block_number_ranges(latest_block_number..0)
-    count = Enum.count(missing_ranges)
 
-    debug(fn -> "#{count} missed block ranges between #{latest_block_number} and genesis" end)
+    case latest_block_number do
+      # let realtime indexer get the genesis block
+      0 ->
+        0
 
-    {:ok, seq} = Sequence.start_link(ranges: missing_ranges, step: -1 * state.blocks_batch_size)
-    Sequence.cap(seq)
+      _ ->
+        # realtime indexer gets the current latest block
+        first = latest_block_number - 1
+        last = 0
+        missing_ranges = Chain.missing_block_number_ranges(first..last)
+        range_count = Enum.count(missing_ranges)
 
-    stream_import(state, seq, max_concurrency: state.blocks_concurrency)
+        missing_block_count =
+          missing_ranges
+          |> Stream.map(&Enum.count/1)
+          |> Enum.sum()
+
+        debug(fn -> "#{missing_block_count} missed blocks in #{range_count} ranges between #{first} and #{last}" end)
+
+        case missing_block_count do
+          0 ->
+            :ok
+
+          _ ->
+            {:ok, seq} = Sequence.start_link(ranges: missing_ranges, step: -1 * state.blocks_batch_size)
+            Sequence.cap(seq)
+
+            stream_import(state, seq, max_concurrency: state.blocks_concurrency)
+        end
+
+        missing_block_count
+    end
   end
 
   defp insert(seq, range, options) when is_list(options) do
@@ -253,13 +325,13 @@ defmodule Indexer.BlockFetcher do
     |> InternalTransactionFetcher.async_fetch(10_000)
   end
 
-  defp realtime_task(%{json_rpc_named_arguments: json_rpc_named_arguments} = state) do
+  defp realtime_task(%__MODULE__{json_rpc_named_arguments: json_rpc_named_arguments} = state) do
     {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
     {:ok, seq} = Sequence.start_link(first: latest_block_number, step: 2)
     stream_import(state, seq, max_concurrency: 1)
   end
 
-  defp stream_import(state, seq, task_opts) do
+  defp stream_import(%__MODULE__{} = state, seq, task_opts) do
     seq
     |> Sequence.build_stream()
     |> Task.async_stream(
@@ -272,7 +344,7 @@ defmodule Indexer.BlockFetcher do
   # Run at state.blocks_concurrency max_concurrency when called by `stream_import/3`
   # Only public for testing
   @doc false
-  def import_range(range, %{json_rpc_named_arguments: json_rpc_named_arguments} = state, seq) do
+  def import_range(range, %__MODULE__{json_rpc_named_arguments: json_rpc_named_arguments} = state, seq) do
     with {:blocks, {:ok, next, result}} <-
            {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
          %{blocks: blocks, transactions: transactions_without_receipts} = result,
@@ -320,10 +392,5 @@ defmodule Indexer.BlockFetcher do
     Enum.map(transactions_params, fn %{hash: transaction_hash} = transaction_params ->
       Map.merge(transaction_params, Map.fetch!(transaction_hash_to_receipt_params, transaction_hash))
     end)
-  end
-
-  defp schedule_next_catchup_index(state) do
-    send(self(), :catchup_index)
-    state
   end
 end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -97,7 +97,7 @@ defmodule Indexer.BlockFetcher do
   end
 
   def handle_info({:DOWN, ref, :process, pid, :normal}, %{genesis_task: %Task{pid: pid, ref: ref}} = state) do
-    Logger.info(fn -> "Finished index from genesis. Transitioning to only realtime index." end)
+    Logger.info(fn -> "Finished index down to genesis. Transitioning to only realtime index." end)
 
     {:noreply, %{state | genesis_task: nil}}
   end

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -71,7 +71,7 @@ defmodule Indexer.BlockFetcher do
       json_rpc_named_arguments: Keyword.fetch!(opts, :json_rpc_named_arguments),
       genesis_task: nil,
       realtime_task: nil,
-      realtime_interval: opts[:block_interval] || @block_interval,
+      realtime_interval: div(opts[:block_interval] || @block_interval, 2),
       starting_block_number: nil,
       blocks_batch_size: Keyword.get(opts, :blocks_batch_size, @blocks_batch_size),
       blocks_concurrency: Keyword.get(opts, :blocks_concurrency, @blocks_concurrency),

--- a/apps/indexer/lib/indexer/bound_interval.ex
+++ b/apps/indexer/lib/indexer/bound_interval.ex
@@ -1,0 +1,31 @@
+defmodule Indexer.BoundInterval do
+  @moduledoc """
+  An interval for `Process.send_after` that is restricted to being between a `minimum` and `maximum` value
+  """
+
+  @enforce_keys ~w(maximum)a
+  defstruct minimum: 1,
+            current: 1,
+            maximum: nil
+
+  def within(minimum..maximum) when is_integer(minimum) and is_integer(maximum) and minimum <= maximum do
+    %__MODULE__{minimum: minimum, current: minimum, maximum: maximum}
+  end
+
+  def decrease(%__MODULE__{minimum: minimum, current: current} = bound_interval)
+      when is_integer(minimum) and is_integer(current) do
+    new_current =
+      current
+      |> div(2)
+      |> max(minimum)
+
+    %__MODULE__{bound_interval | current: new_current}
+  end
+
+  def increase(%__MODULE__{current: current, maximum: maximum} = bound_interval)
+      when is_integer(current) and is_integer(maximum) do
+    new_current = min(current * 2, maximum)
+
+    %__MODULE__{bound_interval | current: new_current}
+  end
+end


### PR DESCRIPTION
## Blockers
- [x] Test full-index on AWS to check if blocks are still missed during catch-up. (In-progress on @KronicDeth's setup)

Fixes #421 
Fixes #453

## Changelog

### Enhancements
* Remove need for `Indexer.start_monitor` by using `Task.Supervisor.async_nolink` because `Task.Supervisor.async_nolink` monitors the `Task` pid instead of linking, so it does the same thing as our `Indexer.start_monitor`.
* When a catchup_index task completes without error, increase the interval until the next check by 2 if no blocks were missing and decrease it by 2 if blocks were missing.  Minimum interval is the same as the realtime interval while the maximum interval is arbitarily chosen to be 10x the
realtime interval.

### Bug Fixes
* `block_rate` is measured in milliseconds / block, but a rate would blocks / unit-of-time, so rename `block_rate` to `block_interval` to reflect it is the interval between blocks.
* The `realtime_interval` should be half of the `block_interval` to ensure that we don't get stuck in a state where we just miss a new block because using precisely the block rate doesn't account for processing time.  The exact value of half the `block_interval` was chosen for the [Nyquist rules](https://en.wikipedia.org/wiki/Nyquist_frequency)
* Fix typo where `genesis` was `gensis`.
* Instead of scheduling the next realtime index in block_interval / 2 only after the previous one complete, run the realtime index every block_interval / 2 using `:timer.send_interval`.  This ensures that the time it takes to complete the realtime index doesn't slowly build up, which is currently leading a missed block approximately every 15 blocks.
* Remove unused `start_block_number` in `BlockFetcher` state.
* Fix phrasing in log message when genesis task completes.
* Handle output from `Task`s: previously, `BlockFetcher` only had handle_info for the `:DOWN` message from realtime tasks, but when the reason is `:normal`, the `Task` would have succeeded and therefore, the BlockFetcher would also have received a `{ref, :ok}` that was not being matched.
* Allow pending transactions to be broadcast.
* Increase `pool_timeout` from default of 5,000 milliseconds to 10,000 milliseconds to prevent flaky timeouts from `apps/indexer/test/indexer/block_fetcher_test.exs:50` like
    
    ```
    [error] Realtime index stream exited with reason ({:timeout, {GenServer, :call, [#PID<0.596.0>, {:checkout, #Reference<0.851308976.2388656130.16563>, true, 120000}, 5000]}})
    ```

### Incompatible Changes
* `block_rate` option has been renamed to `block_interval`.

## Upgrading

Any `config :index, block_rate: ...` needs to be changed to `config :indexer, block_interval: ...`.  The configs in Git already have these changes.  Only customizations or forks need to be manually updated.