### PR TITLE
Improve Logs in development environment

### DIFF
--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -1,11 +1,13 @@
 use Mix.Config
 
+# Do not log Statistics queries on development mode.
+config :explorer, Explorer.Chain.Statistics.Server, enabled: false
+
 # Configure your database
 config :explorer, Explorer.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "explorer_dev",
   hostname: "localhost",
-  loggers: [],
   pool_size: 20,
   pool_timeout: 60_000,
   timeout: 80_000

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,4 @@
 use Mix.Config
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
-config :logger, level: :debug
+config :logger, :console, format: "[$level] $message\n", level: :debug


### PR DESCRIPTION
### Motivation
See logs about the database in the development environment.

![image](https://user-images.githubusercontent.com/27698968/43028412-3633f79a-8c56-11e8-8af9-05b59d266aea.png)

IMHO, it's very helpful to see which query is being generated by Ecto and how long it's taking. For some reason it was disabled, I'm not sure if it was intentional or a mistake.

If it was intentional, we can close this one and keep just as a reference for developers that want to enable these logs.