### PR TITLE
Fix prod config file to use prod config instead of dev

### DIFF
--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -4,4 +4,4 @@ variant = System.get_env("ETHEREUM_JSONRPC_VARIANT") || "parity"
 
 # Import variant specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "dev/#{variant}.exs"
+import_config "prod/#{variant}.exs"


### PR DESCRIPTION
## Changelog

### Bug Fixes
Import `prod` config file at the `indexer/config/prod.exs` instead of `dev`
