### PR TITLE
Fixed social media links

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/layout/_footer.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/layout/_footer.html.eex
@@ -1,16 +1,13 @@
 <footer class="footer">
   <div class="footer-body container">
     <div class="icon-links icon-links-primary">
-      <a href="https://www.facebook.com/PoaNetwork/" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Facebook") %>">
-        <i class="fab fa-facebook-f"></i>
-      </a>
-      <a href="https://www.instagram.com/PoaNetwork/" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Instagram") %>">
-        <i class="fab fa-instagram"></i>
+      <a href="https://github.com/poanetwork" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Github") %>">
+        <i class="fab fa-github"></i>
       </a>
       <a href="https://www.twitter.com/PoaNetwork/" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Twitter") %>">
         <i class="fab fa-twitter"></i>
       </a>
-      <a href="https://www.twitter.com/PoaNetwork/" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Telegram") %>">
+      <a href="http://t.me/oraclesnetwork" target="_blank" class="icon-link" data-toggle="tooltip" data-placement="top" title="<%= gettext("Telegram") %>">
         <i class="fab fa-telegram-plane"></i>
       </a>
     </div>

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -12,7 +12,7 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: lib/explorer_web/templates/layout/_footer.html.eex:18
+#: lib/explorer_web/templates/layout/_footer.html.eex:15
 msgid "Copyright %{year} POA"
 msgstr ""
 
@@ -538,22 +538,12 @@ msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
-msgid "Facebook"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
-msgid "Instagram"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:13
+#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:10
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Twitter"
 msgstr ""
 
@@ -698,4 +688,9 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:75
 msgid "Close"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
+msgid "Github"
 msgstr ""

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Block"
 msgid "Blocks"
 msgstr "Blocks"
 
-#: lib/explorer_web/templates/layout/_footer.html.eex:18
+#: lib/explorer_web/templates/layout/_footer.html.eex:15
 msgid "Copyright %{year} POA"
 msgstr "%{year} POA Network Ltd. All rights reserved"
 
@@ -550,22 +550,12 @@ msgid "POA Sokol"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:4
-msgid "Facebook"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:7
-msgid "Instagram"
-msgstr ""
-
-#, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:13
+#: lib/explorer_web/templates/layout/_footer.html.eex:10
 msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/layout/_footer.html.eex:10
+#: lib/explorer_web/templates/layout/_footer.html.eex:7
 msgid "Twitter"
 msgstr ""
 
@@ -710,4 +700,9 @@ msgstr ""
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:75
 msgid "Close"
+msgstr ""
+
+#, elixir-format
+#: lib/explorer_web/templates/layout/_footer.html.eex:4
+msgid "Github"
 msgstr ""


### PR DESCRIPTION
Fixes #450 

## Motivation

Facebook and Instagram are not used by POA Network.  Github is a social link POA would like to promote.

## Changelog

- fixed Telegram link, was linking to Twitter
- removed social links to Facebook and Instagram
- added Github social link

