### PR TITLE
Disable EventHandler (live updates) because of memory leak

### DIFF
--- a/apps/explorer_web/lib/explorer_web/application.ex
+++ b/apps/explorer_web/lib/explorer_web/application.ex
@@ -5,7 +5,7 @@ defmodule ExplorerWeb.Application do
 
   use Application
 
-  alias ExplorerWeb.{Endpoint, EventHandler}
+  alias ExplorerWeb.Endpoint
 
   def start(_type, _args) do
     import Supervisor.Spec
@@ -13,8 +13,7 @@ defmodule ExplorerWeb.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
-      supervisor(Endpoint, []),
-      {EventHandler, name: EventHandler}
+      supervisor(Endpoint, [])
       # Start your own worker by calling: PoaexpWeb.Worker.start_link(arg1, arg2, arg3)
       # worker(PoaexpWeb.Worker, [arg1, arg2, arg3]),
     ]


### PR DESCRIPTION
Resolves: #455 

## Motivation

* This is a quick fix to resolve the memory leak for now. The long-term solution is to do both of the following:
  * Only send events to the client that originated in the realtime indexer.
  * Optimize n+1 query to `Chain.hash_to_transaction` in the Notifier.

## Changelog

### Bug Fixes
* Suppress memory leak caused by EventHandler.