### PR TITLE
geth configureable from environment

### DIFF
--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -12,7 +12,15 @@ config :explorer, Explorer.Repo,
 
 import_config "dev.secret.exs"
 
-variant = System.get_env("ETHEREUM_JSONRPC_VARIANT") || "parity"
+variant =
+  if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
+    "parity"
+  else
+    System.get_env("ETHEREUM_JSONRPC_VARIANT")
+    |> String.split(".")
+    |> List.last()
+    |> String.downcase()
+  end
 
 # Import variant specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -5,7 +5,9 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url:
+        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
+          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -5,7 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -5,9 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url:
-        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
-          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -9,7 +9,15 @@ config :explorer, Explorer.Repo,
   prepare: :unnamed,
   timeout: 60_000
 
-variant = System.get_env("ETHEREUM_JSONRPC_VARIANT") || "parity"
+variant =
+  if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
+    "parity"
+  else
+    System.get_env("ETHEREUM_JSONRPC_VARIANT")
+    |> String.split(".")
+    |> List.last()
+    |> String.downcase()
+  end
 
 # Import variant specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -5,7 +5,9 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url:
+        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
+          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -5,7 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -5,9 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url:
-        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
-          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -1,6 +1,14 @@
 use Mix.Config
 
-variant = System.get_env("ETHEREUM_JSONRPC_VARIANT") || "parity"
+variant =
+  if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
+    "parity"
+  else
+    System.get_env("ETHEREUM_JSONRPC_VARIANT")
+    |> String.split(".")
+    |> List.last()
+    |> String.downcase()
+  end
 
 # Import variant specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -6,9 +6,7 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url:
-        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
-          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -6,7 +6,9 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url:
+        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
+          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -6,7 +6,7 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -1,6 +1,14 @@
 use Mix.Config
 
-variant = System.get_env("ETHEREUM_JSONRPC_VARIANT") || "parity"
+variant =
+  if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
+    "parity"
+  else
+    System.get_env("ETHEREUM_JSONRPC_VARIANT")
+    |> String.split(".")
+    |> List.last()
+    |> String.downcase()
+  end
 
 # Import variant specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -6,9 +6,7 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url:
-        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
-          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -6,7 +6,9 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url:
+        System.get_env("ETHEREUM_JSONRPC_HTTP_URL") ||
+          "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -6,7 +6,7 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("GETH_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth


### PR DESCRIPTION
Related to #183 

## Motivation

Allow switching the variant and URL for developing against Geth without changing the config files under source control.

## Changelog

### Enhancements
* Environment variables (`ETHEREUM_JSONRPC_VARIANT` and `ETHEREUM_JSONRPC_URL`) used for testing Geth now work in `dev` too.  You can now switch to Geth by setting `ETHEREUM_JSONRPC_VARIANT=EthereumJSONRC.Geth` and its URL `ETHEREUM_JSONRPC_URL=https://...`.
