### PR TITLE
Move transaction_hashes to transactions fetching to single query

### DIFF
--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -233,18 +233,20 @@ defmodule ExplorerWeb.ViewingAddressesTest do
   end
 
   test "viewing new transactions via live update", %{addresses: addresses, session: session} do
-    transaction =
-      :transaction
-      |> insert(from_address: addresses.lincoln)
+    [transaction1, transaction2] =
+      2
+      |> insert_list(:transaction, from_address: addresses.lincoln)
       |> with_block()
 
     session
     |> AddressPage.visit_page(addresses.lincoln)
     |> assert_has(AddressPage.balance())
 
-    Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+    Notifier.handle_event({:chain_event, :transactions, [transaction1.hash, transaction2.hash]})
 
-    assert_has(session, AddressPage.transaction(transaction))
+    session
+    |> assert_has(AddressPage.transaction(transaction1))
+    |> assert_has(AddressPage.transaction(transaction2))
   end
 
   test "transaction count live updates", %{addresses: addresses, session: session} do


### PR DESCRIPTION
Co-authored-by: jimmay5469 <jimmay5469@gmail.com>

Resolves #460 

## Motivation

Realtime-indexer events are the only events worth broadcasting.  Also need to ensure that a bulk list of transactions doesn't impact performance and delay realtime updates.

## Changelog

### Enhancements
* Fetch all transactions in single query to optimize retrieval speed for broadcasting updates to the channel
