### PR TITLE
Fix transaction addresses wrapping onto two lines

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_internal_transaction/_internal_transaction.html.eex
@@ -5,7 +5,7 @@
     </div>
     <div class="col-md-9 col-lg-7 d-flex flex-column text-nowrap">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @internal_transaction.transaction_hash %>
-      <span>
+      <span class="text-nowrap">
         <%= if @address.hash == @internal_transaction.from_address_hash do %>
           <%= render ExplorerWeb.AddressView, "_responsive_hash.html", address_hash: @internal_transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(@internal_transaction.from_address) %>
         <% else %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_transaction/_transaction.html.eex
@@ -12,7 +12,7 @@
     </div>
     <div class="col-md-9 col-lg-7 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
-      <span>
+      <span class="text-nowrap">
         <%= if @address.hash == @transaction.from_address_hash do %>
           <%= render ExplorerWeb.AddressView, "_responsive_hash.html", address_hash: @transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(@transaction.from_address) %>
         <% else %>

--- a/apps/explorer_web/lib/explorer_web/templates/block_transaction/_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/block_transaction/_transaction.html.eex
@@ -10,7 +10,7 @@
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
-      <span>
+      <span class="text-nowrap">
         <%= render ExplorerWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(@transaction.from_address), locale: @locale %>
 
         &rarr;

--- a/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/chain/_transactions.html.eex
@@ -13,7 +13,7 @@
         </div>
         <div class="col-md-7 col-lg-8 d-flex flex-column">
             <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
-          <span>
+          <span class="text-nowrap">
             <%= render ExplorerWeb.AddressView, "_link.html", address_hash: transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(transaction.from_address), locale: @locale %>
             &rarr;
             <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.TransactionView.to_address_hash(transaction), contract: ExplorerWeb.AddressView.contract?(transaction.to_address), locale: @locale %>

--- a/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/pending_transaction/index.html.eex
@@ -57,7 +57,7 @@
             </div>
             <div class="col-md-9 col-lg-7 d-flex flex-column">
               <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
-              <span>
+              <span class="text-nowrap">
                 <%= render ExplorerWeb.AddressView, "_link.html", address_hash: transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(transaction.from_address), locale: @locale %>
                 &rarr;
                 <%= if transaction.to_address_hash do %>

--- a/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/_internal_transaction.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction_internal_transaction/_internal_transaction.html.eex
@@ -5,7 +5,7 @@
     </div>
     <div class="col-md-9 col-lg-10 d-flex flex-column text-nowrap">
       <%= render ExplorerWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @internal_transaction.transaction_hash %>
-      <span>
+      <span class="text-nowrap">
         <%= render ExplorerWeb.AddressView, "_link.html", address_hash: @internal_transaction.from_address_hash, contract: ExplorerWeb.AddressView.contract?(@internal_transaction.from_address), locale: @locale %>
         &rarr;
         <%= render ExplorerWeb.AddressView, "_link.html", address_hash: ExplorerWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: ExplorerWeb.AddressView.contract?(@internal_transaction.to_address), locale: @locale %>


### PR DESCRIPTION
Resolves: #474 

## Motivation
![image](https://user-images.githubusercontent.com/1641169/43326144-118cee62-9186-11e8-8cc7-40841666900b.png)


## Changelog

### Enhancements
* Force the To and From addresses on the transaction tiles to stay on one line and not wrap to maintain layout consistency.
