### PR TITLE
[WIP] - Optimize created_contract_address_hash lookup on transaction to only …

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -343,22 +343,6 @@ defmodule Explorer.Chain.Transaction do
     end
   end
 
-  defmacrop exists_contract_creation_with_matching_address_hash_fragment(transaction_hash, bytes) do
-    quote do
-      fragment(
-        ~s[
-          EXISTS (
-          SELECT 1
-          FROM "internal_transactions" AS i
-          WHERE i."transaction_hash" = ? AND i."type" = 'create' AND i."created_contract_address_hash" = ?
-          )
-        ],
-        unquote(transaction_hash),
-        unquote(bytes)
-      )
-    end
-  end
-
   @doc """
   Adds to the given transaction's query a `where` with one of the conditions that the matched
   function returns.
@@ -371,11 +355,6 @@ defmodule Explorer.Chain.Transaction do
   - returns a query considering that the given address_hash is equal to from_address_hash from
     transactions' table or is equal to from_address_hash from token transfers't table.
 
-  `where_address_fields_match(query, address, nil)`
-  - returns a query considering that the given address_hash can be: to_address_hash,
-    from_address_hash, created_contract_address_hash from internal_transactions' table,
-    to_address_hash or from_address_hash from token_transfers' table.
-
   ### Token transfers' preload
 
   Token transfers will be preloaded according to the given address_hash considering if it's equal
@@ -383,8 +362,8 @@ defmodule Explorer.Chain.Transaction do
   """
   def where_address_fields_match(query, address_hash, :to) do
     query
-    |> join_token_tranfers()
-    |> preload_token_transfers(address_hash)
+    |> join(:left, [t], tt in assoc(t, :token_transfers))
+    # |> preload_token_transfers(address_hash)
     |> where(
       [t, it, tt],
       t.to_address_hash == ^address_hash or it.created_contract_address_hash == ^address_hash or
@@ -394,30 +373,12 @@ defmodule Explorer.Chain.Transaction do
 
   def where_address_fields_match(query, address_hash, :from) do
     query
-    |> join_token_tranfers()
-    |> preload_token_transfers(address_hash)
+    |> join(:left, [t], tt in assoc(t, :token_transfers))
+    # |> preload_token_transfers(address_hash)
     |> where([t, _, tt], t.from_address_hash == ^address_hash or tt.from_address_hash == ^address_hash)
   end
 
-  def where_address_fields_match(query, address_hash, nil) do
-    query
-    |> join_token_tranfers()
-    |> preload_token_transfers(address_hash)
-    |> where(
-      [t, it, tt],
-      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or
-        it.created_contract_address_hash == ^address_hash or tt.to_address_hash == ^address_hash or
-        tt.from_address_hash == ^address_hash or
-        (is_nil(t.to_address_hash) and
-           exists_contract_creation_with_matching_address_hash_fragment(t.hash, ^address_hash.bytes))
-    )
-  end
-
-  defp join_token_tranfers(query) do
-    join(query, :left, [t], tt in assoc(t, :token_transfers))
-  end
-
-  defp preload_token_transfers(query, address_hash) do
+  def preload_token_transfers(query, address_hash) do
     token_transfers_query =
       from(
         tt in TokenTransfer,

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -385,14 +385,18 @@ defmodule Explorer.Chain.Transaction do
     query
     |> join_token_tranfers()
     |> preload_token_transfers(address_hash)
-    |> where([t, tt], t.to_address_hash == ^address_hash or tt.to_address_hash == ^address_hash)
+    |> where(
+      [t, it, tt],
+      t.to_address_hash == ^address_hash or it.created_contract_address_hash == ^address_hash or
+        tt.to_address_hash == ^address_hash
+    )
   end
 
   def where_address_fields_match(query, address_hash, :from) do
     query
     |> join_token_tranfers()
     |> preload_token_transfers(address_hash)
-    |> where([t, tt], t.from_address_hash == ^address_hash or tt.from_address_hash == ^address_hash)
+    |> where([t, _, tt], t.from_address_hash == ^address_hash or tt.from_address_hash == ^address_hash)
   end
 
   def where_address_fields_match(query, address_hash, nil) do
@@ -400,8 +404,9 @@ defmodule Explorer.Chain.Transaction do
     |> join_token_tranfers()
     |> preload_token_transfers(address_hash)
     |> where(
-      [t, tt],
-      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or tt.to_address_hash == ^address_hash or
+      [t, it, tt],
+      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or
+        it.created_contract_address_hash == ^address_hash or tt.to_address_hash == ^address_hash or
         tt.from_address_hash == ^address_hash or
         (is_nil(t.to_address_hash) and
            exists_contract_creation_with_matching_address_hash_fragment(t.hash, ^address_hash.bytes))

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -478,7 +478,7 @@ defmodule Explorer.ChainTest do
       transaction =
         %Transaction{hash: hash_with_block} =
         :transaction
-        |> insert()
+        |> insert(to_address: nil)
         |> with_block()
 
       %InternalTransaction{created_contract_address_hash: contract_hash} =
@@ -509,7 +509,7 @@ defmodule Explorer.ChainTest do
   end
 
   describe "hashes_to_transactions/2" do
-    test "with transaction with block required without block returns nil" do
+    test "with transaction with block required without block returns empty list" do
       [%Transaction{hash: hash_with_block1}, %Transaction{hash: hash_with_block2}] =
         2
         |> insert_list(:transaction)
@@ -530,10 +530,9 @@ defmodule Explorer.ChainTest do
                )
 
       assert [%Transaction{hash: ^hash_without_index1}, %Transaction{hash: ^hash_without_index2}] =
-               Chain.hashes_to_transactions(
-                 [hash_without_index1, hash_without_index2],
-                 necessity_by_association: %{block: :optional}
-               )
+               [hash_without_index1, hash_without_index2]
+               |> Chain.hashes_to_transactions(necessity_by_association: %{block: :optional})
+               |> Enum.sort_by(& &1.hash)
     end
   end
 
@@ -1047,7 +1046,7 @@ defmodule Explorer.ChainTest do
     test "it has contract_creation_address_hash added" do
       transaction =
         :transaction
-        |> insert()
+        |> insert(to_address: nil)
         |> with_block()
 
       %InternalTransaction{created_contract_address_hash: hash} =

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -188,8 +188,8 @@ defmodule Explorer.ChainTest do
       token_transfer = insert(:token_transfer, to_address: address, transaction: transaction)
       insert(:token_transfer, to_address: build(:address), transaction: transaction)
 
-      transaction = Chain.address_to_transactions(address) |> List.first()
-      assert transaction.token_transfers |> Enum.map(& &1.id) == [token_transfer.id]
+      assert [%Transaction{token_transfers: token_transfers}] = Chain.address_to_transactions(address)
+      assert Enum.map(token_transfers, & &1.id) == [token_transfer.id]
     end
 
     test "returns just the token transfers related to the given contract address" do

--- a/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -63,7 +63,7 @@ defmodule ExplorerWeb.TransactionInternalTransactionControllerTest do
     test "with no to_address_hash overview contains contract create address", %{conn: conn} do
       transaction =
         :transaction
-        |> insert()
+        |> insert(to_address: nil)
         |> with_block()
 
       internal_transaction = insert(:internal_transaction_create, transaction: transaction, index: 0)

--- a/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
@@ -37,6 +37,8 @@ defmodule ExplorerWeb.AddressContractVerificationTest do
     |> click(option(version))
     |> click(radio_button("No"))
     |> fill_in(text_field("Enter the Solidity Contract Code below"), with: source_code)
+
+    session
     |> click(button("Verify and publish"))
 
     assert current_path(session) =~ ~r/\/en\/addresses\/#{address_hash}\/contracts/


### PR DESCRIPTION
Resolves #477 

## Motivation

Address page loading has slowed significantly based on the queries implemented in [PR#382](https://github.com/poanetwork/poa-explorer/pull/382).

## Changelog

### Enhancements
* Optimize created_contract_address_hash population on transactions by using a left join if the transaction.to_address == nil and the internal_transaction.type == :create