### PR TITLE
Adds API docs page with 'try it' UI

### DIFF
--- a/apps/explorer_web/assets/css/app.scss
+++ b/apps/explorer_web/assets/css/app.scss
@@ -74,6 +74,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/icon-link";
 @import "components/badge";
 @import "components/description-list";
+@import "components/nounderline-link";
 
 
 :export {

--- a/apps/explorer_web/assets/css/components/_card.scss
+++ b/apps/explorer_web/assets/css/components/_card.scss
@@ -21,3 +21,8 @@
 .card-body {
   padding: 2.25rem 1.25rem;
 }
+
+.card-server-response-body {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/apps/explorer_web/assets/css/components/_nounderline-link.scss
+++ b/apps/explorer_web/assets/css/components/_nounderline-link.scss
@@ -1,0 +1,3 @@
+a.nounderline {
+  text-decoration: none;
+}

--- a/apps/explorer_web/assets/css/components/_tile.scss
+++ b/apps/explorer_web/assets/css/components/_tile.scss
@@ -63,6 +63,14 @@
         color: $teal;
       }
     }
+
+    &-api-documentation {
+      border-left: 4px solid $primary;
+
+      .tile-label {
+        color: $primary;
+      }
+    }
   }
 
   &-status {

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -24,6 +24,8 @@ import './lib/market_history_chart'
 import './lib/reload_button'
 import './lib/tooltip'
 import './lib/smart_contract/read_function'
+import './lib/pretty_json'
+import './lib/try_api'
 
 import './pages/address'
 import './pages/chain'

--- a/apps/explorer_web/assets/js/lib/pretty_json.js
+++ b/apps/explorer_web/assets/js/lib/pretty_json.js
@@ -1,0 +1,9 @@
+import $ from 'jquery'
+
+function prettyPrint (element) {
+  let jsonString = element.dataset.json
+  let pretty = JSON.stringify(JSON.parse(jsonString), undefined, 2)
+  element.innerHTML = pretty
+}
+
+$('[data-json]').each((_index, element) => prettyPrint(element))

--- a/apps/explorer_web/assets/js/lib/try_api.js
+++ b/apps/explorer_web/assets/js/lib/try_api.js
@@ -1,0 +1,135 @@
+import $ from 'jquery'
+
+// This file adds event handlers responsible for the 'Try it out' UI in the
+// Etherscan-compatible API documentation page.
+
+function composeQuery (module, action, inputs) {
+  const parameters = queryParametersFromInputs(inputs)
+  return `?module=${module}&action=${action}` + parameters.join('')
+}
+
+function queryParametersFromInputs (inputs) {
+  return $.map(inputs, queryParameterFromInput)
+}
+
+function queryParameterFromInput (input) {
+  const key = $(input).attr('data-parameter-key')
+  const value = $(input).val()
+
+  if (value === '') {
+    return ''
+  } else {
+    return `&${key}=${value}`
+  }
+}
+
+function composeRequestUrl (query) {
+  const url = $('[data-endpoint-url]').attr('data-endpoint-url')
+  return `${url}${query}`
+}
+
+function composeCurlCommand (requestUrl) {
+  return `curl -X GET "${requestUrl}" -H "accept: application/json"`
+}
+
+function isResultVisible (module, action) {
+  return $(`[data-selector="${module}-${action}-try-api-ui-result"]`).is(':visible')
+}
+
+function handleSuccess (query, xhr, clickedButton) {
+  const module = clickedButton.attr('data-module')
+  const action = clickedButton.attr('data-action')
+  const curl = $(`[data-selector="${module}-${action}-curl"]`)[0]
+  const requestUrl = $(`[data-selector="${module}-${action}-request-url"]`)[0]
+  const code = $(`[data-selector="${module}-${action}-server-response-code"]`)[0]
+  const body = $(`[data-selector="${module}-${action}-server-response-body"]`)[0]
+  const url = composeRequestUrl(query)
+
+  curl.innerHTML = composeCurlCommand(url)
+  requestUrl.innerHTML = url
+  code.innerHTML = xhr.status
+  body.innerHTML = JSON.stringify(xhr.responseJSON, undefined, 2)
+  $(`[data-selector="${module}-${action}-try-api-ui-result"]`).show()
+  $(`[data-selector="${module}-${action}-btn-try-api-clear"]`).show()
+  clickedButton.html(clickedButton.data('original-text'))
+  clickedButton.prop('disabled', false)
+}
+
+// Show 'Try it out' UI for a module/action.
+$('button[data-selector*="btn-try-api"]').click(event => {
+  const clickedButton = $(event.target)
+  const module = clickedButton.attr('data-module')
+  const action = clickedButton.attr('data-action')
+  clickedButton.hide()
+  $(`button[data-selector="${module}-${action}-btn-try-api-cancel"]`).show()
+  $(`[data-selector="${module}-${action}-try-api-ui"]`).show()
+
+  if (isResultVisible(module, action)) {
+    $(`[data-selector="${module}-${action}-btn-try-api-clear"]`).show()
+  }
+})
+
+// Hide 'Try it out' UI for a module/action.
+$('button[data-selector*="btn-try-api-cancel"]').click(event => {
+  const clickedButton = $(event.target)
+  const module = clickedButton.attr('data-module')
+  const action = clickedButton.attr('data-action')
+  clickedButton.hide()
+  $(`[data-selector="${module}-${action}-try-api-ui"]`).hide()
+  $(`[data-selector="${module}-${action}-btn-try-api-clear"]`).hide()
+  $(`button[data-selector="${module}-${action}-btn-try-api"]`).show()
+})
+
+// Clear API server response/result, curl command, and request URL
+$('button[data-selector*="btn-try-api-clear"]').click(event => {
+  const clickedButton = $(event.target)
+  const module = clickedButton.attr('data-module')
+  const action = clickedButton.attr('data-action')
+  clickedButton.hide()
+  $(`[data-selector="${module}-${action}-try-api-ui-result"]`).hide()
+})
+
+// Remove invalid class from required fields if not empty
+$('input[data-selector*="try-api-ui"][data-required="true"]').on('keyup', (event) => {
+  if (event.target.value !== '') {
+    event.target.classList.remove('is-invalid')
+  } else {
+    event.target.classList.add('is-invalid')
+  }
+})
+
+// Execute API call
+//
+// Makes a request to the Explorer API with a given set of user defined
+// parameters. The following related information is subsequently rendered below
+// the execute button:
+//
+//   * curl commmand
+//   * requuest URL
+//   * server response
+//
+$('button[data-try-api-ui-button-type="execute"]').click(event => {
+  const clickedButton = $(event.target)
+  const module = clickedButton.attr('data-module')
+  const action = clickedButton.attr('data-action')
+  const inputs = $(`input[data-selector="${module}-${action}-try-api-ui"]`)
+  const query = composeQuery(module, action, inputs)
+  const loadingText = '<i class="fa fa-spinner fa-spin"></i> loading...'
+
+  clickedButton.prop('disabled', true)
+  clickedButton.data('original-text', clickedButton.html())
+
+  if (clickedButton.html() !== loadingText) {
+    clickedButton.html(loadingText)
+  }
+
+  $.ajax({
+    url: `/api${query}`,
+    success: (_data, _status, xhr) => {
+      handleSuccess(query, xhr, clickedButton)
+    },
+    error: (xhr) => {
+      handleSuccess(query, xhr, clickedButton)
+    }
+  })
+})

--- a/apps/explorer_web/lib/explorer_web/controllers/api_docs_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/api_docs_controller.ex
@@ -1,0 +1,11 @@
+defmodule ExplorerWeb.APIDocsController do
+  use ExplorerWeb, :controller
+
+  alias ExplorerWeb.Etherscan
+
+  def index(conn, _params) do
+    conn
+    |> assign(:documentation, Etherscan.get_documentation())
+    |> render("index.html")
+  end
+end

--- a/apps/explorer_web/lib/explorer_web/etherscan.ex
+++ b/apps/explorer_web/lib/explorer_web/etherscan.ex
@@ -1,0 +1,301 @@
+defmodule ExplorerWeb.Etherscan do
+  @moduledoc """
+  Documentation data for Etherscan-compatible API.
+  """
+
+  @account_balance_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => "663046792267785498951364"
+  }
+
+  @account_balancemulti_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => [
+      %{
+        "account" => "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a",
+        "balance" => "40807168566070000000000"
+      },
+      %{
+        "account" => "0x63a9975ba31b0b9626b34300f7f627147df1f526",
+        "balance" => "332567136222827062478"
+      },
+      %{
+        "account" => "0x198ef1ec325a96cc354c7266a038be8b5c558f67",
+        "balance" => "185178830000000000"
+      }
+    ]
+  }
+
+  @account_txlist_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    result: [
+      %{
+        "blockNumber" => "65204",
+        "timeStamp" => "1439232889",
+        "hash" => "0x98beb27135aa0a25650557005ad962919d6a278c4b3dde7f4f6a3a1e65aa746c",
+        "nonce" => "0",
+        "blockHash" => "0x373d339e45a701447367d7b9c7cef84aab79c2b2714271b908cda0ab3ad0849b",
+        "transactionIndex" => "0",
+        "from" => "0x3fb1cd2cd96c6d5c0b5eb3322d807b34482481d4",
+        "to" => "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+        "value" => "0",
+        "gas" => "122261",
+        "gasPrice" => "50000000000",
+        "isError" => "0",
+        "txreceipt_status" => "1",
+        "input" =>
+          "0xf00d4b5d000000000000000000000000036c8cecce8d8bbf0831d840d7f29c9e3ddefa63000000000000000000000000c5a96db085dda36ffbe390f455315d30d6d3dc52",
+        "contractAddress" => "",
+        "cumulativeGasUsed" => "122207",
+        "gasUsed" => "122207",
+        "confirmations" => "5994246"
+      }
+    ]
+  }
+
+  @status_type %{
+    type: "status",
+    enum: ~s(["0", "1"]),
+    enum_interpretation: %{"0" => "error", "1" => "ok"}
+  }
+
+  @message_type %{
+    type: "string",
+    example: ~s("OK")
+  }
+
+  @wei_type %{
+    type: "wei",
+    definition: &__MODULE__.wei_type_definition/1,
+    example: ~s("663046792267785498951364")
+  }
+
+  @gas_type %{
+    type: "gas",
+    definition: "A nonnegative number roughly equivalent to computational steps.",
+    example: ~s("122261")
+  }
+
+  @address_hash_type %{
+    type: "address hash",
+    definition: "A 160-bit code used for identifying Accounts.",
+    example: ~s("0x95426f2bc716022fcf1def006dbc4bb81f5b5164")
+  }
+
+  @transaction_hash_type %{
+    type: "transaction hash",
+    definition:
+      "Either a 20-byte address hash or, in the case of being a contract creation transaction, it is the RLP empty byte sequence. Used for identifying transactions.",
+    example: ~s("0x9c81f44c29ff0226f835cd0a8a2f2a7eca6db52a711f8211b566fd15d3e0e8d4")
+  }
+
+  @block_number_type %{
+    type: "block number",
+    definition: "A nonnegative number used to identify blocks.",
+    example: ~s("34092")
+  }
+
+  @address_balance %{
+    name: "AddressBalance",
+    fields: %{
+      address: @address_hash_type,
+      balance: @wei_type
+    }
+  }
+
+  @transaction %{
+    name: "Transaction",
+    fields: %{
+      blockNumber: @block_number_type,
+      timeStamp: %{
+        type: "timestamp",
+        definition: "The transaction's block-timestamp.",
+        example: ~s("1439232889")
+      },
+      hash: @transaction_hash_type,
+      nonce: %{
+        type: "nonce",
+        definition: "A scalar value equal to the number of transactions sent by the sender prior to this transaction.",
+        example: ~s("0")
+      },
+      blockHash: %{
+        type: "block hash",
+        definition: "A 32-byte hash used for identifying blocks.",
+        example: ~s("0xd3cabad6adab0b52eb632c386ea194036805713682c62cb589b5abcd76de2159")
+      },
+      transactionIndex: %{
+        type: "transaction index",
+        definition: "Index of the transaction in it's block.",
+        example: ~s("0")
+      },
+      from: @address_hash_type,
+      to: @address_hash_type,
+      value: @wei_type,
+      gas: @gas_type,
+      gasPrice: @wei_type,
+      isError: %{
+        type: "error",
+        enum: ~s(["0", "1"]),
+        enum_interpretation: %{"0" => "ok", "1" => "error"}
+      },
+      txreceipt_status: @status_type,
+      input: %{
+        type: "input",
+        definition: "Data sent along with the transaction. A variable-byte-length binary.",
+        example: ~s("0x797af627d02e23b68e085092cd0d47d6cfb54be025f37b5989c0264398f534c08af7dea9")
+      },
+      contractAddress: @address_hash_type,
+      cumulativeGasUsed: @gas_type,
+      gasUsed: @gas_type,
+      confirmations: %{
+        type: "confirmations",
+        definition: "A number equal to the current block height minus the transaction's block-number.",
+        example: ~s("6005998")
+      }
+    }
+  }
+
+  @account_balance_action %{
+    name: "balance",
+    description: "Get balance for address",
+    required_params: [
+      %{
+        key: "address",
+        placeholder: "addressHash",
+        type: "string",
+        description: "A 160-bit code used for identifying Accounts."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        example_value: Jason.encode!(@account_balance_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: @wei_type
+          }
+        }
+      }
+    ]
+  }
+
+  @account_balancemulti_action %{
+    name: "balancemulti",
+    description: "Get balance for multiple addresses",
+    required_params: [
+      %{
+        key: "address",
+        placeholder: "addressHash1,addressHash2,addressHash3",
+        type: "string",
+        description:
+          "A 160-bit code used for identifying Accounts. Separate addresses by comma. Maximum of 20 addresses."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        example_value: Jason.encode!(@account_balancemulti_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "array",
+              array_type: @address_balance
+            }
+          }
+        }
+      }
+    ]
+  }
+
+  @account_txlist_action %{
+    name: "txlist",
+    description: "Get transactions by address. Up to a maximum of 10,000 transactions.",
+    required_params: [
+      %{
+        key: "address",
+        placeholder: "addressHash",
+        type: "string",
+        description: "A 160-bit code used for identifying Accounts."
+      }
+    ],
+    optional_params: [
+      %{
+        key: "sort",
+        type: "string",
+        description:
+          "A string representing the order by block number direction. Defaults to ascending order. Available values: asc, desc"
+      },
+      %{
+        key: "startblock",
+        type: "integer",
+        description: "A nonnegative integer that represents the starting block number."
+      },
+      %{
+        key: "endblock",
+        type: "integer",
+        description: "A nonnegative integer that represents the ending block number."
+      },
+      %{
+        key: "page",
+        type: "integer",
+        description:
+          "A nonnegative integer that represents the page number to be used for pagination. 'offset' must be provided in conjunction."
+      },
+      %{
+        key: "offset",
+        type: "integer",
+        description:
+          "A nonnegative integer that represents the maximum number of records to return when paginating. 'page' must be provided in conjunction."
+      }
+    ],
+    responses: [
+      %{
+        code: "200",
+        example_value: Jason.encode!(@account_txlist_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "array",
+              array_type: @transaction
+            }
+          }
+        }
+      }
+    ]
+  }
+
+  @account_module %{
+    name: "account",
+    actions: [
+      @account_balance_action,
+      @account_balancemulti_action,
+      @account_txlist_action
+    ]
+  }
+
+  @documentation [@account_module]
+
+  def get_documentation do
+    @documentation
+  end
+
+  def wei_type_definition(coin) do
+    "The smallest subdenomination of #{coin}, " <>
+      "and thus the one in which all integer values of the currency are counted, is the Wei. " <>
+      "One #{coin} is defined as being 10<sup>18</sup> Wei."
+  end
+end

--- a/apps/explorer_web/lib/explorer_web/router.ex
+++ b/apps/explorer_web/lib/explorer_web/router.ex
@@ -95,5 +95,7 @@ defmodule ExplorerWeb.Router do
     end
 
     get("/search", ChainController, :search)
+
+    get("/api_docs", APIDocsController, :index)
   end
 end

--- a/apps/explorer_web/lib/explorer_web/templates/api_docs/_action_tile.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/api_docs/_action_tile.html.eex
@@ -1,0 +1,212 @@
+<a class="nounderline" data-toggle="collapse" href="#<%= action_tile_id(@module_name, @action.name) %>" role="button" aria-expanded="false" aria-controls="<%= action_tile_id(@module_name, @action.name) %>">
+  <div class="tile tile-type-api-documentation">
+    <h3>
+      <span class="badge badge-secondary tile-badge float-right">POST</span>
+      <span class="badge badge-primary tile-badge float-right mr-1">GET</span>
+      <strong class="tile-label"><%= @action.name %></strong>
+    </h3>
+    <h4 class="text-dark"><%= @action.description %></h4>
+    <code><%= raw query_params(@module_name, @action) %></code>
+  </div>
+</a>
+
+<div class="row mt-2">
+  <div class="col">
+    <div class="collapse multi-collapse" id="<%= action_tile_id(@module_name, @action.name) %>">
+      <div class="card card-body pt-3 rounded">
+        <h4 class="text-primary">Parameters
+          <button data-selector="<%= "#{@module_name}-#{@action.name}-btn-try-api" %>" role="button" class="btn btn-sm btn-outline-primary float-right" style="width: 8rem" data-module="<%= @module_name %>" data-action="<%= @action.name %>">Try it out</button>
+          <button data-selector="<%= "#{@module_name}-#{@action.name}-btn-try-api-cancel" %>" role="button" class="collapse btn btn-sm btn-outline-secondary float-right" style="width: 8rem" data-module="<%= @module_name %>" data-action="<%= @action.name %>">Cancel</button>
+        </h4>
+
+        <div class="table-responsive">
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">
+                  module
+                  <span class="text-danger">
+                    * <small>required</small>
+                  </span>
+                  <span class="row col font-weight-light">string</span>
+                  <em class="row col text-muted">(query)</em>
+                </th>
+                <td>
+                  A string with the name of the module to be invoked.
+                  <em>Must be set to:</em> <%= @module_name %>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  action
+                  <span class="align-text-bottom text-danger">
+                    * <small>required</small>
+                  </span>
+                  <span class="row col font-weight-light">string</span>
+                  <em class="row col text-muted">(query)</em>
+                </th>
+                <td>
+                  A string with the name of the action to be invoked.
+                  <em>Must be set to:</em> <%= @action.name %>
+                </td>
+              </tr>
+              <tr>
+                <%= for required_param <- @action.required_params do %>
+                  <th scope="row">
+                    <%= required_param.key %>
+                    <span class="align-text-bottom text-danger">
+                      * <small>required</small>
+                    </span>
+                    <span class="row col font-weight-light"><%= required_param.type %></span>
+                    <em class="row col text-muted">(query)</em>
+                  </th>
+                  <td>
+                    <%= required_param.description %>
+                    <div class="form-group has-danger">
+                      <input data-selector="<%= "#{@module_name}-#{@action.name}-try-api-ui" %>" data-required="true" type="text" class="collapse form-control form-control-danger is-invalid" placeholder="<%= input_placeholder(required_param) %>" data-parameter-key="<%= required_param.key %>">
+                    </div>
+                  </td>
+              </tr>
+            <% end %>
+            <%= for optional_param <- @action.optional_params do %>
+              <th scope="row">
+                <%= optional_param.key %>
+                <span class="row col font-weight-light"><%= optional_param.type %></span>
+                <em class="row col text-muted">(query)</em>
+              </th>
+              <td>
+                <%= optional_param.description %>
+                <input data-selector="<%= "#{@module_name}-#{@action.name}-try-api-ui" %>" type="text" class="collapse form-control" placeholder="<%= input_placeholder(optional_param) %>" data-parameter-key="<%= optional_param.key %>">
+              </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+
+          <div class="btn-group m-1 d-flex" role="group">
+            <button data-selector="<%= "#{@module_name}-#{@action.name}-try-api-ui" %>" data-try-api-ui-button-type="execute" role="button" class="collapse btn btn-primary w-100" data-module="<%= @module_name %>" data-action="<%= @action.name %>">Execute</button>
+            <button role="button" class="collapse btn btn-outline-secondary w-100" data-selector="<%= "#{@module_name}-#{@action.name}-btn-try-api-clear" %>" data-module="<%= @module_name %>" data-action="<%= @action.name %>">Clear</button>
+          </div> <!-- /btn-group -->
+
+        </div> <!-- /table-responsive -->
+
+        <h4 class="text-primary mt-4">Responses</h4>
+
+        <div data-selector="<%= "#{@module_name}-#{@action.name}-try-api-ui-result" %>" class="collapse">
+
+          <h5>Curl</h5>
+          <div class="card card-body bg-dark rounded p-0">
+            <pre data-selector="<%= "#{@module_name}-#{@action.name}-curl" %>" class="text-white m-2"></pre>
+          </div>
+
+          <h5>Request URL</h5>
+          <div class="card card-body bg-dark rounded p-0">
+            <pre data-selector="<%= "#{@module_name}-#{@action.name}-request-url" %>" class="text-white m-2"></pre>
+          </div>
+
+          <h5>Server Response</h5>
+
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">Code</th>
+                  <th scope="col">Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-selector="<%= "#{@module_name}-#{@action.name}-server-response-code" %>">
+                  </td>
+                  <td>
+                    <h5 class="">Response Body</h5>
+                    <div class="card card-body bg-dark rounded p-0 card-server-response-body">
+                      <pre data-selector="<%= "#{@module_name}-#{@action.name}-server-response-body" %>" class="text-white m-2"></pre>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h5>Responses</h5>
+
+        </div> <!-- /*-try-api-ui-result -->
+
+        <div class="table-responsive">
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Code</th>
+                <th scope="col">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for response <- @action.responses do %>
+              <tr>
+                <td>
+                  <%= response.code %>
+                </td>
+                <td>
+                  <div class="card card-body bg-dark rounded p-0">
+                    <pre class="text-white m-2"><em>successful operation</em></pre>
+                  </div>
+
+                  <ul class="nav nav-pills mb-3" role="tablist">
+                    <li class="nav-item">
+                      <a class="nav-link active"
+                         id="<%= "#{@module_name}-#{@action.name}-example-value-tab" %>"
+                         data-toggle="pill"
+                         href="#<%= "#{@module_name}-#{@action.name}-example-value" %>"
+                         role="tab"
+                         aria-controls="<%= "#{@module_name}-#{@action.name}-example-value" %>"
+                         aria-selected="true">
+                         Example Value
+                      </a>
+                    </li>
+                    <li class="nav-item">
+                      <a class="nav-link"
+                         id="<%= "#{@module_name}-#{@action.name}-model-tab" %>"
+                         data-toggle="pill"
+                         href="#<%= "#{@module_name}-#{@action.name}-model" %>"
+                         role="tab"
+                         aria-controls="<%= "#{@module_name}-#{@action.name}-model" %>"
+                         aria-selected="false">
+                         Model
+                      </a>
+                    </li>
+                  </ul>
+                  <div class="tab-content">
+                    <div class="tab-pane fade show active"
+                         id="<%= "#{@module_name}-#{@action.name}-example-value" %>"
+                         role="tabpanel"
+                         aria-labelledby="<%= "#{@module_name}-#{@action.name}-example-value-tab" %>">
+                         <div class="card card-body bg-dark rounded p-0">
+                           <pre class="text-white m-2" data-json='<%= response.example_value %>'></pre>
+                         </div>
+                    </div> <!-- /tab-pane -->
+                    <div class="tab-pane fade"
+                         id="<%= "#{@module_name}-#{@action.name}-model" %>"
+                         role="tabpanel"
+                         aria-labelledby="<%= "#{@module_name}-#{@action.name}-model-tab" %>">
+                         <%= render "_model_table.html", model: response.model %>
+                    </div> <!-- /tab-pane -->
+                  </div> <!-- /tab-content -->
+
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/explorer_web/lib/explorer_web/templates/api_docs/_model_table.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/api_docs/_model_table.html.eex
@@ -1,0 +1,71 @@
+<div class="card card-body bg-light rounded p-0">
+  <div class="m-2">
+    <h3><strong><%= @model.name %></strong> {</h3>
+    <div class="table-responsive">
+      <table class="table table-borderless table-sm bg-light">
+        <tbody>
+          <%= for {key, details} <- @model.fields do %>
+            <tr>
+              <th scope="row">
+                <%= key %>
+              </th>
+              <td>
+                <span class="row text-primary">
+                  <%= details.type %>
+                  <%= if details[:definition] do %>
+                    <i class="fas fa-info-circle ml-2"
+                       data-toggle="tooltip"
+                       data-placement="right"
+                       data-html="true"
+                       title="<%= model_type_definition(details.definition) %>"></i>
+                  <% end %>
+                </span>
+                <%= if details[:type] == "array" do %>
+                  <span class="row">
+                    [<strong><%= details.array_type.name %></strong>]
+                  </span>
+                <% end %>
+                <%= if details[:enum] do %>
+                  <span class="row">enum: <%= details.enum %></span>
+
+                  <table class="table table-bordered bg-light">
+                    <thead>
+                      <tr>
+                        <th scope="col">enum</th>
+                        <th scope="col">interpretation</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <%= for {enum, interpretation} <- details[:enum_interpretation] do %>
+                        <tr>
+                          <td scope="row">
+                            "<%= enum %>"
+                          </td>
+                          <td>
+                            <%= interpretation %>
+                          </td>
+                        </tr>
+                      <% end %>
+                    </tbody>
+                  </table>
+                <% end %>
+                <%= if details[:example] do %>
+                  <span class="row">example: <%= details.example %></span>
+                <% end %>
+                <%= if details[:description] do %>
+                  <span class="row">description: <%= details.description %></span>
+                <% end %>
+              </td>
+              <td></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div> <!-- /table-responsive -->
+    <h3>}</h3>
+  </div>
+</div>
+
+<%= if @model.fields[:result][:type] == "array" do %>
+  <%= render "_model_table.html", model: @model.fields[:result].array_type %>
+<% end %>

--- a/apps/explorer_web/lib/explorer_web/templates/api_docs/_module_card.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/api_docs/_module_card.html.eex
@@ -1,0 +1,13 @@
+<div class="card">
+  <h2 class="card-header">
+    <%= "#{String.capitalize(@module.name)}s" %>
+    <small class="text-primary">?module=<%= @module.name %></small>
+  </h2>
+
+  <div class="card-body">
+    <%= for action <- @module.actions do %>
+      <%= render "_action_tile.html", module_name: @module.name, action: action %>
+    <% end %>
+  </div> <!-- /card-body -->
+</div> <!-- /card -->
+

--- a/apps/explorer_web/lib/explorer_web/templates/api_docs/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/api_docs/index.html.eex
@@ -1,0 +1,16 @@
+<section class="container">
+  <div class="card">
+    <div class="card-body">
+
+      <h1 class="card-title mb-0">API Documentation</h2>
+      <small class="text-monospace text-secondary" data-endpoint-url="<%= ExplorerWeb.Endpoint.url() %>/api">[ Base URL: <%= @conn.host %>/api ]</small>
+      <p class="mt-4">This API is provided for developers transitioning their applications from Etherscan to Explorer. It supports GET and POST requests.</p>
+
+    </div>
+  </div>
+
+  <%= for module <- @documentation do %>
+    <%= render "_module_card.html", module: module %>
+  <% end %>
+
+</section>

--- a/apps/explorer_web/lib/explorer_web/views/api_docs_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/api_docs_view.ex
@@ -1,0 +1,36 @@
+defmodule ExplorerWeb.APIDocsView do
+  use ExplorerWeb, :view
+
+  def action_tile_id(module, action) do
+    "#{module}-#{action}"
+  end
+
+  def query_params(module, action) do
+    module_and_action(module, action) <> Enum.join(required_params(action))
+  end
+
+  def input_placeholder(param) do
+    "#{param.key} - #{param.description}"
+  end
+
+  def model_type_definition(definition) when is_binary(definition) do
+    definition
+  end
+
+  def model_type_definition(definition_func) when is_function(definition_func, 1) do
+    coin = Application.get_env(:explorer, :coin)
+    definition_func.(coin)
+  end
+
+  defp module_and_action(module, action) do
+    "?module=<strong>#{module}</strong>&action=<strong>#{action.name}</strong>"
+  end
+
+  defp required_params(action) do
+    Enum.map(action.required_params, fn param ->
+      "&#{param.key}=" <>
+        "<span class='text-primary'>{</span>" <>
+        "<strong>#{param.placeholder}</strong><span class='text-primary'>}</span>"
+    end)
+  end
+end

--- a/apps/explorer_web/test/explorer_web/controllers/api_docs_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api_docs_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule ExplorerWeb.APIDocsControllerTest do
+  use ExplorerWeb.ConnCase
+
+  import ExplorerWeb.Router.Helpers, only: [api_docs_path: 3]
+
+  describe "GET index/2" do
+    test "renders documentation tiles for each API module#action", %{conn: conn} do
+      conn = get(conn, api_docs_path(ExplorerWeb.Endpoint, :index, :en))
+
+      documentation = ExplorerWeb.Etherscan.get_documentation()
+
+      for module <- documentation, action <- module.actions do
+        assert html_response(conn, 200) =~ action.name
+        assert html_response(conn, 200) =~ action.description
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #454 

## Motivation

* We'd like to provide an API documentation page with a 'Try it out' UI
for the API. We first considered using Swagger for this but when we
looked into it we realized it didn't fit our needs. It doesn't fit our
needs because Swagger is an API specification and the Swagger UI is
built for this specification. The Etherscan-compatible API we're
building doesn't meet the Swagger specification (name was changed to
OpenAPI on the latest version) so we can't easily use Swagger tools to
document our API.
* Issue link: https://github.com/poanetwork/poa-explorer/issues/454

## Changelog

### Enhancements
* Adding API documentation page with 'Try it out' UI at `/api_docs`. The
API documentation data is defined within `ExplorerWeb.Etherscan` and
rendered by Phoenix templates, with partial templates for 'module
cards', 'action tiles', and 'model tables'. The `Try it out` UI is
powered by the `try_api.js` file, which shows/hides the 'Try it out' UI
as needed and provides support for testing the API from the docs page.

### Bug Fixes
* n/a

### Incompatible Changes
* n/a

## Upgrading
* n/a
