### PR TITLE
Restore don't broadcast from catchup

### DIFF
--- a/apps/indexer/lib/indexer/block_fetcher/catchup.ex
+++ b/apps/indexer/lib/indexer/block_fetcher/catchup.ex
@@ -17,7 +17,7 @@ defmodule Indexer.BlockFetcher.Catchup do
   defstruct ~w(block_fetcher bound_interval task)a
 
   def new(%{block_fetcher: %BlockFetcher{} = common_block_fetcher, block_interval: block_interval}) do
-    block_fetcher = %BlockFetcher{common_block_fetcher | broadcast: true, callback_module: __MODULE__}
+    block_fetcher = %BlockFetcher{common_block_fetcher | broadcast: false, callback_module: __MODULE__}
     minimum_interval = div(block_interval, 2)
 
     %__MODULE__{


### PR DESCRIPTION
## Changelog

### Bug Fixes
* Fixes rebase during #366  picking wrong version with broadcasting turned on for catchup index, which we don't want