### PR TITLE
Edit API account balance actions to return Wei

### DIFF
--- a/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
+++ b/apps/explorer_web/lib/explorer_web/views/api/rpc/address_view.ex
@@ -4,8 +4,7 @@ defmodule ExplorerWeb.API.RPC.AddressView do
   alias ExplorerWeb.API.RPC.RPCView
 
   def render("balance.json", %{addresses: [address]}) do
-    ether_balance = wei_to_ether(address.fetched_balance)
-    RPCView.render("show.json", data: ether_balance)
+    RPCView.render("show.json", data: "#{address.fetched_balance.value}")
   end
 
   def render("balance.json", assigns) do
@@ -17,7 +16,7 @@ defmodule ExplorerWeb.API.RPC.AddressView do
       Enum.map(addresses, fn address ->
         %{
           "account" => "#{address.hash}",
-          "balance" => wei_to_ether(address.fetched_balance)
+          "balance" => "#{address.fetched_balance.value}"
         }
       end)
 
@@ -31,10 +30,6 @@ defmodule ExplorerWeb.API.RPC.AddressView do
 
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
-  end
-
-  defp wei_to_ether(wei) do
-    format_wei_value(wei, :ether, include_unit_label: false)
   end
 
   defp prepare_transaction(transaction) do

--- a/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
   use ExplorerWeb.ConnCase
 
   alias Explorer.Chain
-  alias Explorer.Chain.{Transaction, Wei}
+  alias Explorer.Chain.Transaction
 
   describe "balance" do
     test "with missing address hash", %{conn: conn} do
@@ -66,17 +66,12 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
         "address" => "#{address.hash}"
       }
 
-      expected_balance =
-        address.fetched_balance
-        |> Wei.to(:ether)
-        |> Decimal.to_string(:normal)
-
       assert response =
                conn
                |> get("/api", params)
                |> json_response(200)
 
-      assert response["result"] == expected_balance
+      assert response["result"] == "#{address.fetched_balance.value}"
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end
@@ -100,12 +95,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
 
       expected_result =
         Enum.map(addresses, fn address ->
-          expected_balance =
-            address.fetched_balance
-            |> Wei.to(:ether)
-            |> Decimal.to_string(:normal)
-
-          %{"account" => "#{address.hash}", "balance" => expected_balance}
+          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_balance.value}"}
         end)
 
       assert response =
@@ -185,12 +175,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
 
       expected_result =
         Enum.map(addresses, fn address ->
-          expected_balance =
-            address.fetched_balance
-            |> Wei.to(:ether)
-            |> Decimal.to_string(:normal)
-
-          %{"account" => "#{address.hash}", "balance" => expected_balance}
+          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_balance.value}"}
         end)
 
       assert response =
@@ -213,14 +198,9 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
         "address" => "#{address1.hash},#{address2_hash}"
       }
 
-      expected_balance1 =
-        address1.fetched_balance
-        |> Wei.to(:ether)
-        |> Decimal.to_string(:normal)
-
       expected_result = [
         %{"account" => address2_hash, "balance" => "0"},
-        %{"account" => "#{address1.hash}", "balance" => expected_balance1}
+        %{"account" => "#{address1.hash}", "balance" => "#{address1.fetched_balance.value}"}
       ]
 
       assert response =
@@ -266,13 +246,8 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
         "address" => "#{address.hash}"
       }
 
-      expected_balance =
-        address.fetched_balance
-        |> Wei.to(:ether)
-        |> Decimal.to_string(:normal)
-
       expected_result = [
-        %{"account" => "#{address.hash}", "balance" => expected_balance}
+        %{"account" => "#{address.hash}", "balance" => "#{address.fetched_balance.value}"}
       ]
 
       assert response =


### PR DESCRIPTION
## Motivation

* Currently, the `account#balance` and `account#balancemulti` API calls
return the Ether balance. It was built this way initially because the
Etherscan docs say those API calls should return Ether. This seems to be
a bug in their documentation because the API responds with the balance
in Wei.
* Issue link: related to https://github.com/poanetwork/poa-explorer/issues/138

## Changelog

### Enhancements
* Editing the `account#balance` and `account#balancemulti` API calls to
return Wei instead of Ether.
* Editing `API.RPC.AddressControllerTest` to assert account balances are
returned in Wei.

### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a

