### PR TITLE
API returns 200s for errors

### DIFF
--- a/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
+++ b/apps/explorer_web/lib/explorer_web/controllers/api/rpc/address_controller.ex
@@ -12,12 +12,12 @@ defmodule ExplorerWeb.API.RPC.AddressController do
     else
       {:address_param, :error} ->
         conn
-        |> put_status(400)
+        |> put_status(200)
         |> render(:error, error: "Query parameter 'address' is required")
 
       {:format, :error} ->
         conn
-        |> put_status(400)
+        |> put_status(200)
         |> render(:error, error: "Invalid address hash")
     end
   end
@@ -36,12 +36,12 @@ defmodule ExplorerWeb.API.RPC.AddressController do
     else
       {:address_param, :error} ->
         conn
-        |> put_status(400)
+        |> put_status(200)
         |> render(:error, error: "Query parameter 'address' is required")
 
       {:format, :error} ->
         conn
-        |> put_status(400)
+        |> put_status(200)
         |> render(:error, error: "Invalid address format")
 
       {:error, :not_found} ->

--- a/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/explorer_web/test/explorer_web/controllers/api/rpc/address_controller_test.exs
@@ -14,7 +14,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response =
                conn
                |> get("/api", params)
-               |> json_response(400)
+               |> json_response(200)
 
       assert response["message"] =~ "'address' is required"
       assert response["status"] == "0"
@@ -32,7 +32,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response =
                conn
                |> get("/api", params)
-               |> json_response(400)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid address hash"
       assert response["status"] == "0"
@@ -133,7 +133,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response =
                conn
                |> get("/api", params)
-               |> json_response(400)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid address hash"
       assert response["status"] == "0"
@@ -296,7 +296,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response =
                conn
                |> get("/api", params)
-               |> json_response(400)
+               |> json_response(200)
 
       assert response["message"] =~ "'address' is required"
       assert response["status"] == "0"
@@ -314,7 +314,7 @@ defmodule ExplorerWeb.API.RPC.AddressControllerTest do
       assert response =
                conn
                |> get("/api", params)
-               |> json_response(400)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid address format"
       assert response["status"] == "0"


### PR DESCRIPTION
## Motivation

* Etherscan returns 200s for errors, so we'd like to do the same for
compatibility.
* Issue link: related to https://github.com/poanetwork/poa-explorer/issues/138

## Changelog

### Enhancements
* Editing `API.RPC.AddressController` for the `balance/3`,
`balancemulti/2`, and `txlist/2` actions to return 200s for errors.
* Editing `API.RPC.AddressControllerTest` to assert errors are returned
as 200s.

### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a
