### PR TITLE
Add transaction hash to order_by on address_to_transactions query to …

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -179,10 +179,11 @@ defmodule Explorer.Chain do
       when is_list(options) do
     direction = Keyword.get(options, :direction)
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    options
-    |> Keyword.get(:paging_options, @default_paging_options)
-    |> fetch_transactions()
+    Transaction
+    |> order_by([transaction], desc: transaction.block_number, desc: transaction.index, asc: transaction.hash)
+    |> handle_paging_options(paging_options)
     |> Transaction.where_address_fields_match(address_hash, direction)
     |> join_associations(necessity_by_association)
     |> Transaction.preload_token_transfers(address_hash)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -181,6 +181,8 @@ defmodule Explorer.Chain do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
+    # Added transaction.hash to order_by to force postgres to not use `transactions_recent_collated_index` for an
+    # index_scan before filtering based on the WHERE clauses (i.e. to speed up the query)
     Transaction
     |> order_by([transaction], desc: transaction.block_number, desc: transaction.index, asc: transaction.hash)
     |> handle_paging_options(paging_options)


### PR DESCRIPTION
Resolves #519 

## Motivation

Address transactions page still loads slow with a fully indexed chain on deployment.

## Changelog

### Enhancements

* Add transaction hash to order_by of address_to_transactions query to force postgres to not use `transactions_recent_collated_index` in an `index_scan` before filtering by the WHERE clauses of the query.

Before:
```sql
SELECT t0."hash", t0."block_number", t0."cumulative_gas_used", t0."gas", t0."gas_price", t0."gas_used", t0."index", t0."internal_transactions_indexed_at", t0."input", t0."nonce", t0."r", t0."s", t0."status", t0."v", t0."value", t0."inserted_at", t0."updated_at", t0."block_hash", t0."from_address_hash", t0."to_address_hash", t0."created_contract_address_hash" FROM "transactions" AS t0 WHERE (t0."hash" = ANY(
	(
	  SELECT t0.hash AS hash
	  FROM transactions AS t0
	  WHERE t0.to_address_hash = $1 OR t0.from_address_hash = $1 OR t0.created_contract_address_hash = $1
	)
	UNION
	(
	  SELECT tt.transaction_hash AS hash
	  FROM token_transfers AS tt
	  WHERE tt.to_address_hash = $1 OR tt.from_address_hash = $1
	)
))
ORDER BY t0.block_number DESC, t0.index DESC
LIMIT 50
```

Query Plan:
```
Limit  (cost=992.44..1405.40 rows=50 width=354) (actual time=0.376..1870.622 rows=6 loops=1)
  ->  Nested Loop Semi Join  (cost=992.44..1519732.23 rows=183884 width=354) (actual time=0.375..1870.618 rows=6 loops=1)
        Join Filter: (t0.hash = t0_1.hash)
        Rows Removed by Join Filter: 2206593
        ->  Index Scan using transactions_recent_collated_index on transactions t0  (cost=0.42..62369.04 rows=367769 width=354) (actual time=0.081..1119.490 rows=367769 loops=1)
        ->  Materialize  (cost=992.01..998.61 rows=264 width=32) (actual time=0.000..0.001 rows=6 loops=367769)
              ->  HashAggregate  (cost=992.01..994.65 rows=264 width=33) (actual time=0.089..0.092 rows=6 loops=1)
                    Group Key: t0_1.hash
                    ->  Append  (cost=19.40..991.35 rows=264 width=33) (actual time=0.050..0.074 rows=6 loops=1)
                          ->  Bitmap Heap Scan on transactions t0_1  (cost=19.40..959.25 rows=258 width=33) (actual time=0.050..0.061 rows=6 loops=1)
                                Recheck Cond: ((to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (created_contract_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea))
                                Heap Blocks: exact=6
                                ->  BitmapOr  (cost=19.40..19.40 rows=258 width=0) (actual time=0.042..0.042 rows=0 loops=1)
                                      ->  Bitmap Index Scan on transactions_to_address_hash_index  (cost=0.00..4.71 rows=38 width=0) (actual time=0.025..0.025 rows=3 loops=1)
                                            Index Cond: (to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on transactions_from_address_hash_index  (cost=0.00..10.07 rows=220 width=0) (actual time=0.010..0.010 rows=3 loops=1)
                                            Index Cond: (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on transactions_created_contract_address_hash_index  (cost=0.00..4.43 rows=1 width=0) (actual time=0.007..0.007 rows=0 loops=1)
                                            Index Cond: (created_contract_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                          ->  Bitmap Heap Scan on token_transfers tt  (cost=8.62..29.46 rows=6 width=33) (actual time=0.012..0.012 rows=0 loops=1)
                                Recheck Cond: ((to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea))
                                ->  BitmapOr  (cost=8.62..8.62 rows=6 width=0) (actual time=0.012..0.012 rows=0 loops=1)
                                      ->  Bitmap Index Scan on token_transfers_to_address_hash_index  (cost=0.00..4.30 rows=3 width=0) (actual time=0.006..0.006 rows=0 loops=1)
                                            Index Cond: (to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on token_transfers_from_address_hash_index  (cost=0.00..4.31 rows=4 width=0) (actual time=0.006..0.006 rows=0 loops=1)
                                            Index Cond: (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
Planning time: 0.655 ms
Execution time: 1870.873 ms
```

After:
```sql
SELECT t0."hash", t0."block_number", t0."cumulative_gas_used", t0."gas", t0."gas_price", t0."gas_used", t0."index", t0."internal_transactions_indexed_at", t0."input", t0."nonce", t0."r", t0."s", t0."status", t0."v", t0."value", t0."inserted_at", t0."updated_at", t0."block_hash", t0."from_address_hash", t0."to_address_hash", t0."created_contract_address_hash" FROM "transactions" AS t0 WHERE (t0."hash" = ANY(
	(
	  SELECT t0.hash AS hash
	  FROM transactions AS t0
	  WHERE t0.to_address_hash = $1 OR t0.from_address_hash = $1 OR t0.created_contract_address_hash = $1
	)
	UNION
	(
	  SELECT tt.transaction_hash AS hash
	  FROM token_transfers AS tt
	  WHERE tt.to_address_hash = $1 OR tt.from_address_hash = $1
	)
))
ORDER BY t0.block_number DESC, t0.index DESC, t0.hash
LIMIT 50
```

Query Plan:
```
Limit  (cost=9294.35..9294.47 rows=50 width=354) (actual time=0.225..0.226 rows=6 loops=1)
  ->  Sort  (cost=9294.35..9754.06 rows=183884 width=354) (actual time=0.223..0.223 rows=6 loops=1)
        Sort Key: t0.block_number DESC, t0.index DESC, t0.hash
        Sort Method: quicksort  Memory: 28kB
        ->  Nested Loop  (cost=992.44..3185.85 rows=183884 width=354) (actual time=0.129..0.192 rows=6 loops=1)
              ->  HashAggregate  (cost=992.01..994.65 rows=264 width=33) (actual time=0.106..0.110 rows=6 loops=1)
                    Group Key: t0_1.hash
                    ->  Append  (cost=19.40..991.35 rows=264 width=33) (actual time=0.062..0.091 rows=6 loops=1)
                          ->  Bitmap Heap Scan on transactions t0_1  (cost=19.40..959.25 rows=258 width=33) (actual time=0.062..0.074 rows=6 loops=1)
                                Recheck Cond: ((to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (created_contract_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea))
                                Heap Blocks: exact=6
                                ->  BitmapOr  (cost=19.40..19.40 rows=258 width=0) (actual time=0.052..0.052 rows=0 loops=1)
                                      ->  Bitmap Index Scan on transactions_to_address_hash_index  (cost=0.00..4.71 rows=38 width=0) (actual time=0.031..0.031 rows=3 loops=1)
                                            Index Cond: (to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on transactions_from_address_hash_index  (cost=0.00..10.07 rows=220 width=0) (actual time=0.012..0.012 rows=3 loops=1)
                                            Index Cond: (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on transactions_created_contract_address_hash_index  (cost=0.00..4.43 rows=1 width=0) (actual time=0.008..0.008 rows=0 loops=1)
                                            Index Cond: (created_contract_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                          ->  Bitmap Heap Scan on token_transfers tt  (cost=8.62..29.46 rows=6 width=33) (actual time=0.014..0.014 rows=0 loops=1)
                                Recheck Cond: ((to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea) OR (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea))
                                ->  BitmapOr  (cost=8.62..8.62 rows=6 width=0) (actual time=0.013..0.013 rows=0 loops=1)
                                      ->  Bitmap Index Scan on token_transfers_to_address_hash_index  (cost=0.00..4.30 rows=3 width=0) (actual time=0.006..0.006 rows=0 loops=1)
                                            Index Cond: (to_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
                                      ->  Bitmap Index Scan on token_transfers_from_address_hash_index  (cost=0.00..4.31 rows=4 width=0) (actual time=0.005..0.005 rows=0 loops=1)
                                            Index Cond: (from_address_hash = '\x5c86d4c0b136bc2072e311fc95a6dc695679c53e'::bytea)
              ->  Index Scan using transactions_pkey on transactions t0  (cost=0.42..8.28 rows=1 width=354) (actual time=0.009..0.010 rows=1 loops=6)
                    Index Cond: (hash = t0_1.hash)
Planning time: 0.804 ms
Execution time: 0.390 ms
```